### PR TITLE
PG tests

### DIFF
--- a/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgtypes.scala
+++ b/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgtypes.scala
@@ -1,15 +1,12 @@
 package doobie.contrib.postgresql
 
-import doobie.hi.connection.prepareStatement
-import doobie.hi.preparedstatement.executeQuery
-import doobie.hi.resultset.getUnique
-import doobie.util.transactor.DriverManagerTransactor
-import doobie.util.composite.Composite
-import doobie.syntax.connectionio._
+import doobie.imports._
 import doobie.contrib.postgresql.pgtypes._
+import doobie.util.update._
 
 import java.net.InetAddress
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
 
 import org.postgresql.util._
 import org.postgresql.geometric._
@@ -17,7 +14,7 @@ import org.specs2.mutable.Specification
 
 import scalaz.concurrent.Task
 
-// Establish that we can read various types. It's not very comprehensive as a test, bit it's a start.
+// Establish that we can write and read various types.
 object pgtypesspec extends Specification {
 
   val xa = DriverManagerTransactor[Task](
@@ -26,53 +23,61 @@ object pgtypesspec extends Specification {
     "postgres", ""
   )
 
-  implicit class CrazyStringOps(e: String) {
-    def as[A: Composite]: A =
-      prepareStatement(s"SELECT $e")(executeQuery(getUnique[A])).transact(xa).run
+  val next: ConnectionIO[Int] = {
+    val cell = new AtomicInteger(0)
+    HC.delay(cell.getAndIncrement)
   }
 
+  def inOut[A: Meta](col: String, a: A) =
+    for {
+      n <- next.map("TEMP" + _)
+      _ <- Update0(s"CREATE TEMPORARY TABLE $n (value $col)", None).run
+      a <- Update[A](s"INSERT INTO $n VALUES (?)", None).withUniqueGeneratedKeys[A]("value")(a)
+    } yield (a)
+
+  def testInOut[A](col: String, a: A, f: (A => A) = ((a: A) => a))(implicit m: Meta[A]) =
+    s"$col ~ ${m.scalaType}" in { 
+      inOut(col, a).transact(xa).run must_== f(a) 
+    }
+
   "8.1 Numeric Types" >> {
-    "smallint         → Short"      in { "123::smallint".as[Short] must_== 123 }
-    "integer          → Int"        in { "123::integer".as[Int] must_== 123 }
-    "bigint           → Long"       in { "123::bigint".as[Long] must_== 123 }
-    "decimal          → BigDecimal" in { "123.45::decimal".as[BigDecimal] must_== BigDecimal(123.45) }
-    "numeric          → BigDecimal" in { "123.456::numeric".as[BigDecimal] must_== BigDecimal(123.456) }
-    "real             → Float"      in { "123.456::real".as[Float] must_== 123.456f }
-    "double precision → Double"     in { "123.456::double precision".as[Double] must_== 123.456 }
+    testInOut[Short]     ("smallint        ", 123)
+    testInOut[Int]       ("integer         ", 123)
+    testInOut[Long]      ("bigint          ", 123) 
+    testInOut[BigDecimal]("decimal         ", 123)      
+    testInOut[BigDecimal]("numeric         ", 123)      
+    testInOut[Float]     ("real            ", 123.45f)
+    testInOut[Double]    ("double precision", 123.45)
   }
 
   "8.2 Monetary Types" >> {
-    "money             → PGmoney" in { 
-      skipped("* seems not to work; comes back a DOUBLE ")
-    }
-  }
+    "money ~ PGmoney"     in skipped("SKIPPED: seems not to work; comes back a DOUBLE ")
+  }  
 
   "8.3 Character Types" >> {
-    "character varying → String" in { "'abcdef'::character varying".as[String] must_== "abcdef"}
-    "varchar           → String" in { "'abcdef'::varchar".as[String] must_== "abcdef"}
-    "character         → String" in { "'abcdef'::character(6)".as[String] must_== "abcdef"}
-    "char              → String" in { "'abcdef'::char(6)".as[String] must_== "abcdef"}
-    "text              → String" in { "'abcdef'::text".as[String] must_== "abcdef"}
-  }
+    testInOut("character varying", "abcdef")
+    testInOut("varchar          ", "abcdef")
+    testInOut("character(6)     ", "abcdef")
+    testInOut("char(6)          ", "abcdef")
+    testInOut("text             ", "abcdef")
+  }     
 
   "8.4 Binary Types" >> {
-    "bytea             → Array[Byte]" in { 
-      """E'\\xDEADBEEF'::bytea""".as[List[Byte]] must_== 
-        BigInt("DEADBEEF",16).toByteArray.dropWhile(_ == 0).toList 
-    }
+    testInOut[List[Byte]]  ("bytea", BigInt("DEADBEEF",16).toByteArray.toList) 
+    testInOut[Vector[Byte]]("bytea", BigInt("DEADBEEF",16).toByteArray.toVector) 
   }
 
   "8.5 Date/Time Types" >> {
-    "timestamp               " in pending
-    "timestamp with time zone" in pending
-    "date                    " in pending
-    "time                    " in pending
-    "time with time zone     " in pending
-    "interval                " in pending
+    "timestamp                " in pending
+    "timestamp with time zone " in pending
+    "date                     " in pending
+    "time                     " in pending
+    "time with time zone      " in pending
+    "interval                 " in pending
   }
 
   "8.6 Boolean Type" >> {
-    "boolean" in pending
+    testInOut("boolean", true)
   }
 
   "8.7 Enumerated Types" >> {
@@ -80,36 +85,20 @@ object pgtypesspec extends Specification {
   }
 
   "8.8 Geometric Types" >> {
-    "box     → PGbox" in { 
-      "'((1,2),(3,4))'::box".as[PGbox] must_== new PGbox(new PGpoint(1, 2), new PGpoint(3, 4)) 
-    }
-    "circle  → PGcircle" in { 
-      "'<(1,2),3>'::circle".as[PGcircle] must_== new PGcircle(new PGpoint(1, 2), 3) 
-    }
-    "lseg    → PGlseg" in { 
-      "'((1,2),(3,4))'::lseg".as[PGlseg] must_== new PGlseg(new PGpoint(1, 2), new PGpoint(3, 4)) 
-    }
-    "path    → PGpath (c)" in { 
-      "'((1,2),(3,4))'::path".as[PGpath] must_== new PGpath(Array(new PGpoint(1, 2), new PGpoint(3, 4)), false) 
-    }
-    "path    → PGpath (o)" in { 
-      "'[(1,2),(3,4)]'::path".as[PGpath] must_== new PGpath(Array(new PGpoint(1, 2), new PGpoint(3, 4)), true) 
-    }
-    "point   → PGpoint" in { 
-      "'(1,2)'::point".as[PGpoint] must_== new PGpoint(1, 2) 
-    }
-    "polygon → PGpolygon" in { 
-      "'((1,2),(3,4))'::polygon".as[PGpolygon] must_==  new PGpolygon(Array(new PGpoint(1, 2), new PGpoint(3, 4))) 
-    }
-    "line    → PGline" in skipped("* doc says: \"not fully implemented\"")
+    testInOut("box    ", new PGbox(new PGpoint(1, 2), new PGpoint(3, 4)))
+    testInOut("circle ", new PGcircle(new PGpoint(1, 2), 3))
+    testInOut("lseg   ", new PGlseg(new PGpoint(1, 2), new PGpoint(3, 4)))
+    testInOut("path   ", new PGpath(Array(new PGpoint(1, 2), new PGpoint(3, 4)), false))
+    testInOut("path   ", new PGpath(Array(new PGpoint(1, 2), new PGpoint(3, 4)), true))
+    testInOut("point  ", new PGpoint(1, 2))
+    testInOut("polygon", new PGpolygon(Array(new PGpoint(1, 2), new PGpoint(3, 4))))
+              "line    ~ PGline" in skipped("SKIPPED: doc says: \"not fully implemented\"")
   }
 
   "8.9 Network Address Types" >> {
-    "inet    → InetAddress" in {
-      "'123.45.67.8'::inet".as[InetAddress] must_== InetAddress.getByName("123.45.67.8")
-    }
-    "inet    → ???" in skipped("* No suitable JDK Type")
-    "macaddr → ???" in skipped("* No suitable JDK Type")
+    testInOut("inet   ", InetAddress.getByName("123.45.67.8"))
+              "inet    ~" in skipped("SKIPPED: No suitable JDK Type")
+              "macaddr ~" in skipped("SKIPPED: No suitable JDK Type")
   }
 
   "8.10 Bit String Types" >> {
@@ -123,40 +112,26 @@ object pgtypesspec extends Specification {
   }
 
   "8.12 UUID Type" >> {
-    "uuid    → UUID" in {
-      "'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'::uuid".as[UUID] must_== UUID.fromString("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")
-    }
+    testInOut("uuid", UUID.randomUUID)
   }
 
   "8.13 XML Type" >> {
-    "xml" in pending
+    "xml ~" in pending
   }
 
   "8.14 JSON Type" >> {
-    "json" in pending
+    "json ~" in pending
   }
 
   "8.15 Arrays" >> {
-    "bit[]              → Array[Boolean]" in {
-      "'{1, 0}'::bit[]".as[List[Boolean]] must_== List[Boolean](true, false)
-    }
-    "???                → Array[Byte]  " in skipped("* No byte type; bytea.")
-    "smallint[]         → Array[Short] " in skipped("* Oops always comes back as Array[Int]")
-    "integer[]          → Array[Int]" in {
-      "'{1,2}'::integer[]".as[List[Int]] must_== List[Int](1,2)
-    }
-    "bigint[]           → Array[Long]" in {
-      "'{1,2}'::bigint[]".as[List[Long]] must_== List[Long](1,2)
-    } 
-    "real[]             → Array[Float]" in {
-      "'{1.2,3.4}'::real[]".as[List[Float]] must_== List[Float](1.2f, 3.4f)
-    }
-    "double precision[] → Array[Double]" in {
-      "'{1.2,3.4}'::double precision[]".as[List[Double]] must_== List[Double](1.2, 3.4)
-    }
-    "varchar[]          → Array[String]" in {
-      "ARRAY['foo', 'bar']::varchar[]".as[List[String]] must_== List[String]("foo", "bar")
-    } 
+              "bit[]              ~ scala.List[Boolean]" in skipped("SKIPPED: Requires a cast")
+              "???                ~ scala.List[Byte]   " in skipped("SKIPPED: No byte type; use bytea.")
+              "smallint[]         ~ scala.List[Short]  " in skipped("SKIPPED: Oops always comes back as Array[Int]")
+    testInOut("integer[]         ", List[Int](1,2))
+    testInOut("bigint[]          ", List[Long](1,2))
+    testInOut("real[]            ", List[Float](1.2f, 3.4f))
+    testInOut("double precision[]", List[Double](1.2, 3.4))
+    testInOut("varchar[]         ", List[String]("foo", "bar"))
   }
 
   "8.16 Composite Types" >> {

--- a/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgtypes.scala
+++ b/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgtypes.scala
@@ -51,6 +51,11 @@ object pgtypesspec extends Specification {
       }
     }
 
+  def skip(col: String, msg: String = "not yet implemented") =
+    s"Mapping for $col" >> {
+      "PENDING:" in pending(msg)
+    }
+
   // 8.1 Numeric Types
   testInOut[Short]("smallint", 123)
   testInOut[Int]("integer", 123)
@@ -60,9 +65,8 @@ object pgtypesspec extends Specification {
   testInOut[Float]("real", 123.45f)
   testInOut[Double]("double precision", 123.45)
 
-  // "8.2 Monetary Types" >> {
-  //   "money ~ PGmoney"     in skipped("SKIPPED: seems not to work; comes back a DOUBLE ")
-  // }  
+  // 8.2 Monetary Types
+  skip("pgmoney", "getObject returns Double")
 
   // 8.3 Character Types"
   testInOut("character varying", "abcdef")
@@ -75,21 +79,19 @@ object pgtypesspec extends Specification {
   testInOut[List[Byte]]  ("bytea", BigInt("DEADBEEF",16).toByteArray.toList) 
   testInOut[Vector[Byte]]("bytea", BigInt("DEADBEEF",16).toByteArray.toVector) 
 
-  // "8.5 Date/Time Types" >> {
-  //   "timestamp                " in pending
-  //   "timestamp with time zone " in pending
-  //   "date                     " in pending
-  //   "time                     " in pending
-  //   "time with time zone      " in pending
-  //   "interval                 " in pending
-  // }
-
+  // 8.5 Date/Time Types"
+  skip("timestamp")
+  skip("timestamp with time zone")
+  skip("date")
+  skip("time")
+  skip("time with time zone")
+  skip("interval")
+  
   // 8.6 Boolean Type
   testInOut("boolean", true)
 
-  // "8.7 Enumerated Types" >> {
-  //   "«example»" in pending
-  // }
+  // 8.7 Enumerated Types
+  skip("enum")
 
   // 8.8 Geometric Types
   testInOut("box", new PGbox(new PGpoint(1, 2), new PGpoint(3, 4)))
@@ -99,68 +101,50 @@ object pgtypesspec extends Specification {
   testInOut("path", new PGpath(Array(new PGpoint(1, 2), new PGpoint(3, 4)), true))
   testInOut("point", new PGpoint(1, 2))
   testInOut("polygon", new PGpolygon(Array(new PGpoint(1, 2), new PGpoint(3, 4))))
-  //             "line    ~ PGline" in skipped("SKIPPED: doc says: \"not fully implemented\"")
-  // }
+  skip("line", "doc says \"not fully implemented\"")
 
   // 8.9 Network Address Types
   testInOut("inet", InetAddress.getByName("123.45.67.8"))
-  //             "inet    ~" in skipped("SKIPPED: No suitable JDK Type")
-  //             "macaddr ~" in skipped("SKIPPED: No suitable JDK Type")
-  // }
+  skip("inet", "no suitable JDK type")
+  skip("macaddr", "no suitable JDK type")
 
-  // "8.10 Bit String Types" >> {
-  //   "bit        " in pending
-  //   "bit varying" in pending
-  // }
+  // 8.10 Bit String Types
+  skip("bit")
+  skip("bit varying")
 
-  // "8.11 Text Search Types" >> {
-  //   "tsvector" in pending
-  //   "tsquery " in pending
-  // }
+  // 8.11 Text Search Types
+  skip("tsvector")
+  skip("tsquery")
 
   // 8.12 UUID Type
   testInOut("uuid", UUID.randomUUID)
-  // }
 
-  // "8.13 XML Type" >> {
-  //   "xml ~" in pending
-  // }
+  // 8.13 XML Type
+  skip("xml")
 
-  // "8.14 JSON Type" >> {
-  //   "json ~" in pending
-  // }
+  // 8.14 JSON Type
+  skip("json")
 
   // 8.15 Arrays
-  //             "bit[]              ~ scala.List[Boolean]" in skipped("SKIPPED: Requires a cast")
-  //             "???                ~ scala.List[Byte]   " in skipped("SKIPPED: No byte type; use bytea.")
-  //             "smallint[]         ~ scala.List[Short]  " in skipped("SKIPPED: Oops always comes back as Array[Int]")
+
+  skip("bit[]", "Requires a cast")
+  skip("smallint[]", "always comes back as Array[Int]")
   testInOut("integer[]", List[Int](1,2))
   testInOut("bigint[]", List[Long](1,2))
   testInOut("real[]", List[Float](1.2f, 3.4f))
   testInOut("double precision[]", List[Double](1.2, 3.4))
   testInOut("varchar[]", List[String]("foo", "bar"))
-  // }
 
-  // "8.16 Composite Types" >> {
-  //   "composite" in pending
-  // }
+  // 8.16 Composite Types
+  skip("composite")
 
-  // "8.17 Range Types" >> {
-  //   "int4range" in pending
-  //   "int8range" in pending
-  //   "numrange " in pending
-  //   "tsrange  " in pending
-  //   "tstzrange" in pending
-  //   "daterange" in pending
-  //   "custom   " in pending
-  // }
-
-  // "8.18 Object Identifier Types" >> {
-  //   "n/a" in skipped
-  // }
-
-  // "8.19 Pseudo-Types" >> {
-  //   "n/a" in skipped
-  // }
+  // 8.17 Range Types
+  skip("int4range")
+  skip("int8range")
+  skip("numrange")
+  skip("tsrange")
+  skip("tstzrange")
+  skip("daterange")
+  skip("custom")
 
 }

--- a/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgtypes.scala
+++ b/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgtypes.scala
@@ -3,6 +3,7 @@ package doobie.contrib.postgresql
 import doobie.imports._
 import doobie.contrib.postgresql.pgtypes._
 import doobie.util.update._
+import doobie.util.query._
 
 import java.net.InetAddress
 import java.util.UUID
@@ -13,6 +14,7 @@ import org.postgresql.geometric._
 import org.specs2.mutable.Specification
 
 import scalaz.concurrent.Task
+import scalaz.\/-
 
 // Establish that we can write and read various types.
 object pgtypesspec extends Specification {
@@ -28,132 +30,137 @@ object pgtypesspec extends Specification {
     HC.delay(cell.getAndIncrement)
   }
 
-  def inOut[A: Meta](col: String, a: A) =
+  def inOut[A: Atom](col: String, a: A) =
     for {
-      n <- next.map("TEMP" + _)
-      _ <- Update0(s"CREATE TEMPORARY TABLE $n (value $col)", None).run
-      a <- Update[A](s"INSERT INTO $n VALUES (?)", None).withUniqueGeneratedKeys[A]("value")(a)
-    } yield (a)
+      n  <- next.map("TEMP" + _)
+      _  <- Update0(s"CREATE TEMPORARY TABLE $n (value $col)", None).run
+      _  <- Update[A](s"INSERT INTO $n VALUES (?)", None).run(a)
+      a0 <- Query0[A](s"SELECT value FROM $n", None).unique
+    } yield (a0)
 
-  def testInOut[A](col: String, a: A, f: (A => A) = ((a: A) => a))(implicit m: Meta[A]) =
-    s"$col ~ ${m.scalaType}" in { 
-      inOut(col, a).transact(xa).run must_== f(a) 
+  def testInOut[A](col: String, a: A)(implicit m: Meta[A]) = 
+    s"Mapping for $col as ${m.scalaType}" >> {
+      s"write+read $col as ${m.scalaType}" in { 
+        inOut(col, a).transact(xa).attemptRun must_== \/-(a)
+      }
+      s"write+read $col as Option[${m.scalaType}] (Some)" in { 
+        inOut[Option[A]](col, Some(a)).transact(xa).attemptRun must_== \/-(Some(a))
+      }
+      s"write+read $col as Option[${m.scalaType}] (None)" in { 
+        inOut[Option[A]](col, None).transact(xa).attemptRun must_== \/-(None)
+      }
     }
 
-  "8.1 Numeric Types" >> {
-    testInOut[Short]     ("smallint        ", 123)
-    testInOut[Int]       ("integer         ", 123)
-    testInOut[Long]      ("bigint          ", 123) 
-    testInOut[BigDecimal]("decimal         ", 123)      
-    testInOut[BigDecimal]("numeric         ", 123)      
-    testInOut[Float]     ("real            ", 123.45f)
-    testInOut[Double]    ("double precision", 123.45)
-  }
+  // 8.1 Numeric Types
+  testInOut[Short]("smallint", 123)
+  testInOut[Int]("integer", 123)
+  testInOut[Long]("bigint", 123) 
+  testInOut[BigDecimal]("decimal", 123)      
+  testInOut[BigDecimal]("numeric", 123)      
+  testInOut[Float]("real", 123.45f)
+  testInOut[Double]("double precision", 123.45)
 
-  "8.2 Monetary Types" >> {
-    "money ~ PGmoney"     in skipped("SKIPPED: seems not to work; comes back a DOUBLE ")
-  }  
+  // "8.2 Monetary Types" >> {
+  //   "money ~ PGmoney"     in skipped("SKIPPED: seems not to work; comes back a DOUBLE ")
+  // }  
 
-  "8.3 Character Types" >> {
-    testInOut("character varying", "abcdef")
-    testInOut("varchar          ", "abcdef")
-    testInOut("character(6)     ", "abcdef")
-    testInOut("char(6)          ", "abcdef")
-    testInOut("text             ", "abcdef")
-  }     
+  // 8.3 Character Types"
+  testInOut("character varying", "abcdef")
+  testInOut("varchar", "abcdef")
+  testInOut("character(6)", "abcdef")
+  testInOut("char(6)", "abcdef")
+  testInOut("text", "abcdef")
 
-  "8.4 Binary Types" >> {
-    testInOut[List[Byte]]  ("bytea", BigInt("DEADBEEF",16).toByteArray.toList) 
-    testInOut[Vector[Byte]]("bytea", BigInt("DEADBEEF",16).toByteArray.toVector) 
-  }
+  // 8.4 Binary Types
+  testInOut[List[Byte]]  ("bytea", BigInt("DEADBEEF",16).toByteArray.toList) 
+  testInOut[Vector[Byte]]("bytea", BigInt("DEADBEEF",16).toByteArray.toVector) 
 
-  "8.5 Date/Time Types" >> {
-    "timestamp                " in pending
-    "timestamp with time zone " in pending
-    "date                     " in pending
-    "time                     " in pending
-    "time with time zone      " in pending
-    "interval                 " in pending
-  }
+  // "8.5 Date/Time Types" >> {
+  //   "timestamp                " in pending
+  //   "timestamp with time zone " in pending
+  //   "date                     " in pending
+  //   "time                     " in pending
+  //   "time with time zone      " in pending
+  //   "interval                 " in pending
+  // }
 
-  "8.6 Boolean Type" >> {
-    testInOut("boolean", true)
-  }
+  // 8.6 Boolean Type
+  testInOut("boolean", true)
 
-  "8.7 Enumerated Types" >> {
-    "«example»" in pending
-  }
+  // "8.7 Enumerated Types" >> {
+  //   "«example»" in pending
+  // }
 
-  "8.8 Geometric Types" >> {
-    testInOut("box    ", new PGbox(new PGpoint(1, 2), new PGpoint(3, 4)))
-    testInOut("circle ", new PGcircle(new PGpoint(1, 2), 3))
-    testInOut("lseg   ", new PGlseg(new PGpoint(1, 2), new PGpoint(3, 4)))
-    testInOut("path   ", new PGpath(Array(new PGpoint(1, 2), new PGpoint(3, 4)), false))
-    testInOut("path   ", new PGpath(Array(new PGpoint(1, 2), new PGpoint(3, 4)), true))
-    testInOut("point  ", new PGpoint(1, 2))
-    testInOut("polygon", new PGpolygon(Array(new PGpoint(1, 2), new PGpoint(3, 4))))
-              "line    ~ PGline" in skipped("SKIPPED: doc says: \"not fully implemented\"")
-  }
+  // 8.8 Geometric Types
+  testInOut("box", new PGbox(new PGpoint(1, 2), new PGpoint(3, 4)))
+  testInOut("circle", new PGcircle(new PGpoint(1, 2), 3))
+  testInOut("lseg", new PGlseg(new PGpoint(1, 2), new PGpoint(3, 4)))
+  testInOut("path", new PGpath(Array(new PGpoint(1, 2), new PGpoint(3, 4)), false))
+  testInOut("path", new PGpath(Array(new PGpoint(1, 2), new PGpoint(3, 4)), true))
+  testInOut("point", new PGpoint(1, 2))
+  testInOut("polygon", new PGpolygon(Array(new PGpoint(1, 2), new PGpoint(3, 4))))
+  //             "line    ~ PGline" in skipped("SKIPPED: doc says: \"not fully implemented\"")
+  // }
 
-  "8.9 Network Address Types" >> {
-    testInOut("inet   ", InetAddress.getByName("123.45.67.8"))
-              "inet    ~" in skipped("SKIPPED: No suitable JDK Type")
-              "macaddr ~" in skipped("SKIPPED: No suitable JDK Type")
-  }
+  // 8.9 Network Address Types
+  testInOut("inet", InetAddress.getByName("123.45.67.8"))
+  //             "inet    ~" in skipped("SKIPPED: No suitable JDK Type")
+  //             "macaddr ~" in skipped("SKIPPED: No suitable JDK Type")
+  // }
 
-  "8.10 Bit String Types" >> {
-    "bit        " in pending
-    "bit varying" in pending
-  }
+  // "8.10 Bit String Types" >> {
+  //   "bit        " in pending
+  //   "bit varying" in pending
+  // }
 
-  "8.11 Text Search Types" >> {
-    "tsvector" in pending
-    "tsquery " in pending
-  }
+  // "8.11 Text Search Types" >> {
+  //   "tsvector" in pending
+  //   "tsquery " in pending
+  // }
 
-  "8.12 UUID Type" >> {
-    testInOut("uuid", UUID.randomUUID)
-  }
+  // 8.12 UUID Type
+  testInOut("uuid", UUID.randomUUID)
+  // }
 
-  "8.13 XML Type" >> {
-    "xml ~" in pending
-  }
+  // "8.13 XML Type" >> {
+  //   "xml ~" in pending
+  // }
 
-  "8.14 JSON Type" >> {
-    "json ~" in pending
-  }
+  // "8.14 JSON Type" >> {
+  //   "json ~" in pending
+  // }
 
-  "8.15 Arrays" >> {
-              "bit[]              ~ scala.List[Boolean]" in skipped("SKIPPED: Requires a cast")
-              "???                ~ scala.List[Byte]   " in skipped("SKIPPED: No byte type; use bytea.")
-              "smallint[]         ~ scala.List[Short]  " in skipped("SKIPPED: Oops always comes back as Array[Int]")
-    testInOut("integer[]         ", List[Int](1,2))
-    testInOut("bigint[]          ", List[Long](1,2))
-    testInOut("real[]            ", List[Float](1.2f, 3.4f))
-    testInOut("double precision[]", List[Double](1.2, 3.4))
-    testInOut("varchar[]         ", List[String]("foo", "bar"))
-  }
+  // 8.15 Arrays
+  //             "bit[]              ~ scala.List[Boolean]" in skipped("SKIPPED: Requires a cast")
+  //             "???                ~ scala.List[Byte]   " in skipped("SKIPPED: No byte type; use bytea.")
+  //             "smallint[]         ~ scala.List[Short]  " in skipped("SKIPPED: Oops always comes back as Array[Int]")
+  testInOut("integer[]", List[Int](1,2))
+  testInOut("bigint[]", List[Long](1,2))
+  testInOut("real[]", List[Float](1.2f, 3.4f))
+  testInOut("double precision[]", List[Double](1.2, 3.4))
+  testInOut("varchar[]", List[String]("foo", "bar"))
+  // }
 
-  "8.16 Composite Types" >> {
-    "composite" in pending
-  }
+  // "8.16 Composite Types" >> {
+  //   "composite" in pending
+  // }
 
-  "8.17 Range Types" >> {
-    "int4range" in pending
-    "int8range" in pending
-    "numrange " in pending
-    "tsrange  " in pending
-    "tstzrange" in pending
-    "daterange" in pending
-    "custom   " in pending
-  }
+  // "8.17 Range Types" >> {
+  //   "int4range" in pending
+  //   "int8range" in pending
+  //   "numrange " in pending
+  //   "tsrange  " in pending
+  //   "tstzrange" in pending
+  //   "daterange" in pending
+  //   "custom   " in pending
+  // }
 
-  "8.18 Object Identifier Types" >> {
-    "n/a" in skipped
-  }
+  // "8.18 Object Identifier Types" >> {
+  //   "n/a" in skipped
+  // }
 
-  "8.19 Pseudo-Types" >> {
-    "n/a" in skipped
-  }
+  // "8.19 Pseudo-Types" >> {
+  //   "n/a" in skipped
+  // }
 
 }

--- a/core/src/main/scala/doobie/util/atom.scala
+++ b/core/src/main/scala/doobie/util/atom.scala
@@ -48,7 +48,7 @@ object atom {
     implicit def fromScalaTypeOption[A](implicit A: Meta[A]): Atom[Option[A]] = 
       new Atom[Option[A]] {
         val get = (n: Int) => ^(A.get(n), wasNull)((a, b) => (!b) option a)
-        val set = (n: Int, a: Option[A]) => a.fold(setNull(n, A.jdbcTarget.head.toInt))(A.set(n, _))
+        val set = (n: Int, a: Option[A]) => a.fold(A.setNull(n))(A.set(n, _))
         val update = (n: Int, a: Option[A]) => a.fold(updateNull(n))(A.update(n, _))
         val meta = (A, Nullable)
       }


### PR DESCRIPTION
- Improve quality of tests (write and then read values of each type via a temp table)
- Fixed `xmap` calls that didn't consider `null`.
- Reorder `Other` and `JavaObject` to placate PostgreSQL.