### PR TITLE
batch updates

### DIFF
--- a/contrib/h2/src/test/scala/doobie/contrib/h2/h2types.scala
+++ b/contrib/h2/src/test/scala/doobie/contrib/h2/h2types.scala
@@ -2,8 +2,6 @@ package doobie.contrib.h2
 
 import doobie.contrib.h2.h2types._
 import doobie.imports._
-import doobie.util.update._
-import doobie.util.query._
 
 import java.net.InetAddress
 import java.util.UUID

--- a/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgtypes.scala
+++ b/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgtypes.scala
@@ -2,8 +2,6 @@ package doobie.contrib.postgresql
 
 import doobie.imports._
 import doobie.contrib.postgresql.pgtypes._
-import doobie.util.update._
-import doobie.util.query._
 
 import java.net.InetAddress
 import java.util.UUID

--- a/core/src/main/scala/doobie/hi/preparedstatement.scala
+++ b/core/src/main/scala/doobie/hi/preparedstatement.scala
@@ -83,14 +83,14 @@ object preparedstatement {
    * @group Batching
    */
   def addBatchesAndExecute[F[_]: Foldable, A: Composite](fa: F[A]): PreparedStatementIO[Int] =
-    fa.foldRight(PS.executeBatch)((a, b) => set(a) *> PS.addBatch *> b).map(_.sum)
+    fa.foldRight(executeBatch)((a, b) => set(a) *> addBatch *> b).map(_.sum)
 
   /**
    * Add many sets of parameters.
    * @group Batching
    */
   def addBatches[F[_]: Foldable, A: Composite](fa: F[A]): PreparedStatementIO[Unit] =
-    fa.foldRight(().point[PreparedStatementIO])((a, b) => set(a) *> PS.addBatch *> b)
+    fa.foldRight(().point[PreparedStatementIO])((a, b) => set(a) *> addBatch *> b)
 
   /** @group Execution */
   def executeQuery[A](k: ResultSetIO[A]): PreparedStatementIO[A] =

--- a/core/src/main/scala/doobie/hi/preparedstatement.scala
+++ b/core/src/main/scala/doobie/hi/preparedstatement.scala
@@ -36,9 +36,12 @@ import scala.Predef.intArrayOps
 import scalaz.stream.Process
 import scalaz.syntax.id._
 import scalaz.syntax.enum._
+import scalaz.syntax.foldable._
+import scalaz.syntax.monad._
 import scalaz.syntax.align._
 import scalaz.std.anyVal._
 import scalaz.std.list._
+import scalaz.Foldable
 import scalaz.\&/
 
 /**
@@ -66,6 +69,28 @@ object preparedstatement {
    */
   def delay[A](a: => A): PreparedStatementIO[A] =
     PS.delay(a)
+
+  /** @group Batching */
+  val executeBatch: PreparedStatementIO[List[Int]] =
+    PS.executeBatch.map(_.toList)
+
+  /** @group Batching */
+  val addBatch: PreparedStatementIO[Unit] =
+    PS.addBatch
+
+  /**
+   * Add many sets of parameters and execute as a batch update, returning total rows updated.
+   * @group Batching
+   */
+  def addBatchesAndExecute[F[_]: Foldable, A: Composite](fa: F[A]): PreparedStatementIO[Int] =
+    fa.foldRight(PS.executeBatch)((a, b) => set(a) *> PS.addBatch *> b).map(_.sum)
+
+  /**
+   * Add many sets of parameters.
+   * @group Batching
+   */
+  def addBatches[F[_]: Foldable, A: Composite](fa: F[A]): PreparedStatementIO[Unit] =
+    fa.foldRight(().point[PreparedStatementIO])((a, b) => set(a) *> PS.addBatch *> b)
 
   /** @group Execution */
   def executeQuery[A](k: ResultSetIO[A]): PreparedStatementIO[A] =

--- a/core/src/main/scala/doobie/imports.scala
+++ b/core/src/main/scala/doobie/imports.scala
@@ -97,10 +97,13 @@ object imports {
   /** @group Type Aliases */      type Composite[A] = doobie.util.composite.Composite[A]
   /** @group Companion Aliases */ val  Composite    = doobie.util.composite.Composite
 
-  /** @group Type Aliases */ type Query[A,B] = doobie.util.query.Query[A,B]
-  /** @group Type Aliases */ type Query0[A]  = doobie.util.query.Query0[A]
+  /** @group Type Aliases */      type Query[A,B] = doobie.util.query.Query[A,B]
+  /** @group Companion Aliases */ val  Query      = doobie.util.query.Query
 
-  /** @group Type Aliases */ type Update[A] = doobie.util.update.Update[A]
+  /** @group Type Aliases */      type Update[A] = doobie.util.update.Update[A]
+  /** @group Companion Aliases */ val  Update    = doobie.util.update.Update
+
+  /** @group Type Aliases */ type Query0[A]  = doobie.util.query.Query0[A]
   /** @group Type Aliases */ type Update0   = doobie.util.update.Update0
 
   /** @group Type Aliases */ type Transactor[M[_]] = doobie.util.transactor.Transactor[M]

--- a/core/src/main/scala/doobie/imports.scala
+++ b/core/src/main/scala/doobie/imports.scala
@@ -103,8 +103,11 @@ object imports {
   /** @group Type Aliases */      type Update[A] = doobie.util.update.Update[A]
   /** @group Companion Aliases */ val  Update    = doobie.util.update.Update
 
-  /** @group Type Aliases */ type Query0[A]  = doobie.util.query.Query0[A]
-  /** @group Type Aliases */ type Update0   = doobie.util.update.Update0
+  /** @group Type Aliases */      type Query0[A]  = doobie.util.query.Query0[A]
+  /** @group Companion Aliases */ val  Query0     = doobie.util.query.Query0
+
+  /** @group Type Aliases */      type Update0   = doobie.util.update.Update0
+  /** @group Companion Aliases */ val  Update0   = doobie.util.update.Update0
 
   /** @group Type Aliases */ type Transactor[M[_]] = doobie.util.transactor.Transactor[M]
 

--- a/doc/src/main/tut/07-Updating.md
+++ b/doc/src/main/tut/07-Updating.md
@@ -134,8 +134,28 @@ up.quick.run
 up.quick.run // and again!
 ```
 
+### Batch Updates
 
+**doobie** supports batch updating via the `updateMany` operation on the `Update` type, which we haven't seen before. Unlike an `Update0`, whose arguments are fixed on construction, an `Update` must be applied to parameters before it can be "executed" to yield a `ConnectionIO`.
 
+```tut:silent
+def insertMany(ps: List[(String, Option[Short])]) = {
+  val sql = "insert into person (name, age) values (?, ?)"
+  Update[(String, Option[Short])](sql).updateMany(ps)
+}
+
+// Some rows to insert
+val data = List[(String, Option[Short])](
+  ("Banjo",   Some(39)), 
+  ("Skeeter", None), 
+  ("Jim-Bob", Some(12)))
+```
+
+The return value is the total number of rows inserted.
+
+```tut
+insertMany(data).quick.run
+```
 
 
 


### PR DESCRIPTION
This adds high-level support for batch updates.

- Re-exports `FPS.addBatch` and `FPS.executeBatch` from `HPS`.
- Adds `HPS.addBatches` and `HPS.addBatchesAndExecute`.
- Adds `Update.updateMany`.
- Adds initial tut doc.
- Adds `Update`, `Update0`, `Query`, and `Query0` to `imports`.

fixes #79 
