### PR TITLE
PostGIS support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
   postgresql: "9.3"
 
 before_script:
+  - psql -c "create extension postgis" -U postgres
   - psql -c 'create database world;' -U postgres
   - psql -c '\i world.sql' -d world -U postgres
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ addons:
   postgresql: "9.3"
 
 before_script:
-  - psql -c "create extension postgis" -U postgres
   - psql -c 'create database world;' -U postgres
   - psql -c '\i world.sql' -d world -U postgres
+  - psql -d world -c "create extension postgis" -U postgres
 
 notifications:
   webhooks:

--- a/contrib/postgresql/README.md
+++ b/contrib/postgresql/README.md
@@ -3,7 +3,8 @@
 This project provides (currently) a handful of PostgreSQL-specific extensions.
 
 * A module of PostgreSQL SQLSTATE values, and a module of `Catchable` combinators for each type. This allows the user to say `doThis.onUniqueViolation(doThat)` for example.
-* `ScalaType` instances for a number of PostgreSQL-specific types like `point` and `inet`, as well as support for underspecified "advanced" types from the JDBC specification (at this point just `ARRAY`).
+* `Meta` instances for a number of PostgreSQL-specific types like `point` and `inet`, as well as support for underspecified "advanced" types from the JDBC specification (at this point just `ARRAY`).
+* `Meta` instances for PostGIS types.
 
 The intent is to eventually support:
 
@@ -12,4 +13,13 @@ The intent is to eventually support:
 * Fastpath function interface.
 * Native large object interface.
 * Server notifications.
+
+In order to set up to run the tests, do something like the following. The tests expect a `world` database with PostGIS enabled, accessable r/w by a `postgres` user with no password.
+
+```
+$ psql -c 'create user postgres createdb'
+$ psql -c 'create database world;' -U postgres
+$ psql -c '\i world.sql' -d world -U postgres
+$ psql -d world -c "create extension postgis" -U postgres
+```
 

--- a/contrib/postgresql/build.sbt
+++ b/contrib/postgresql/build.sbt
@@ -3,19 +3,22 @@ name := "doobie-contrib-postgresql"
 description := "PostgreSQL support for doobie."
 
 libraryDependencies ++= Seq(
-  "org.postgresql" %  "postgresql" % "9.3-1102-jdbc41",
-  "org.specs2"     %% "specs2"     % "2.4"               % "test"
+  "org.postgresql" %  "postgresql"   % "9.3-1102-jdbc41",
+  "org.postgis"    %  "postgis-jdbc" % "1.3.3",
+  "org.specs2"     %% "specs2"       % "2.4"               % "test"
 )
 
 
 initialCommands := """
   import scalaz._,Scalaz._
   import scalaz.concurrent.Task
-  import doobie.syntax.string._
-  import doobie.util.transactor._
+  import doobie.imports._
   import doobie.contrib.postgresql.pgtypes._
   val xa: Transactor[Task] = DriverManagerTransactor[Task]("org.postgresql.Driver", "jdbc:postgresql:world", "postgres", "")
   import xa.yolo._
+  import org.postgis._
+  import org.postgresql.util._
+  import org.postgresql.geometric._
   """
 
 /// PUBLISH SETTINGS

--- a/contrib/postgresql/src/main/scala/doobie/contrib/postgresql/pgtypes.scala
+++ b/contrib/postgresql/src/main/scala/doobie/contrib/postgresql/pgtypes.scala
@@ -137,7 +137,6 @@ object pgtypes {
   implicit val MultiLineStringType    = geometryType[MultiLineString]
   implicit val MultiPolygonType       = geometryType[MultiPolygon]
   implicit val PointComposedGeomType  = geometryType[PointComposedGeom]
-  implicit val LinearRingType         = geometryType[LinearRing]
   implicit val LineStringType         = geometryType[LineString]
   implicit val MultiPointType         = geometryType[MultiPoint]
   implicit val PolygonType            = geometryType[Polygon]

--- a/contrib/postgresql/src/main/scala/doobie/contrib/postgresql/pgtypes.scala
+++ b/contrib/postgresql/src/main/scala/doobie/contrib/postgresql/pgtypes.scala
@@ -7,6 +7,7 @@ import doobie.util.invariant._
 import java.util.UUID
 import java.net.InetAddress
 
+import org.postgis._
 import org.postgresql.util._
 import org.postgresql.geometric._
 
@@ -50,14 +51,14 @@ object pgtypes {
     a => Option(a).map(a => new PGobject <| (_.setType("inet")) <| (_.setValue(a.getHostAddress))).orNull)
 
   // java.sql.Array::getArray returns an Object that may be of primitive type or of boxed type,
-  // depending on the driver, so we can't really abstract over it. Also there's no telling what 
-  // happens with multi-dimensional arrays since most databases don't support them. So anyway here 
+  // depending on the driver, so we can't really abstract over it. Also there's no telling what
+  // happens with multi-dimensional arrays since most databases don't support them. So anyway here
   // we go with PostgreSQL support:
   //
   // PostgreSQL arrays show up as Array[AnyRef] with `null` for NULL, so that's mostly sensible;
   // there would be no way to distinguish 0 from NULL otherwise for an int[], for example. So,
   // these arrays can be multi-dimensional and can have NULL cells, but cannot have NULL slices;
-  // i.e., {{1,2,3}, {4,5,NULL}} is ok but {{1,2,3}, NULL} is not. So this means we only have to 
+  // i.e., {{1,2,3}, {4,5,NULL}} is ok but {{1,2,3}, NULL} is not. So this means we only have to
   // worry about Array[Array[...[A]]] and Array[Array[...[Option[A]]]] in our mappings.
 
   // Construct a pair of Meta instances for arrays of lifted (nullable) and unlifted (non-
@@ -78,7 +79,7 @@ object pgtypes {
   // does not seem to support tinyint[] (use a bytea instead) and smallint[] always arrives as Int[]
   // so you can xmap if you need Short[]. The type names provided here are what is reported by JDBC
   // when metadata is requested; there are numerous aliases but these are the ones we need. Nothing
-  // about this is portable, sorry. (╯°□°）╯︵ ┻━┻ 
+  // about this is portable, sorry. (╯°□°）╯︵ ┻━┻
   implicit val (unliftedBooleanArrayType, liftedBooleanArrayType) = boxedPair[java.lang.Boolean]("bit",     "_bit")
   implicit val (unliftedIntegerArrayType, liftedIntegerArrayType) = boxedPair[java.lang.Integer]("int4",    "_int4")
   implicit val (unliftedLongArrayType,    liftedLongArrayType)    = boxedPair[java.lang.Long]   ("int8",    "_int8")
@@ -88,14 +89,14 @@ object pgtypes {
 
   // Unboxed equivalents (actually identical in the lifted case). We require that B is the unboxed
   // equivalent of A, otherwise this will fail in spectacular fashion, and we're using a cast in the
-  // lifted case because the representation is identical, assuming no nulls. In the long run this 
+  // lifted case because the representation is identical, assuming no nulls. In the long run this
   // may need to become something slower but safer. Unclear.
   private def unboxedPair[A >: Null <: AnyRef: ClassTag, B <: AnyVal: ClassTag: TypeTag](f: A => B, g: B => A)(
-    implicit boxed: Meta[Array[A]], boxedLifted: Meta[Array[Option[A]]]): (Meta[Array[B]], Meta[Array[Option[B]]]) = 
-    // TODO: assert, somehow, that A is the boxed version of B so we catch errors on instance 
+    implicit boxed: Meta[Array[A]], boxedLifted: Meta[Array[Option[A]]]): (Meta[Array[B]], Meta[Array[Option[B]]]) =
+    // TODO: assert, somehow, that A is the boxed version of B so we catch errors on instance
     // construction, which is somewhat better than at [logical] execution time.
     (boxed.xmap(a => if (a == null) null else a.map(f), a => if (a == null) null else a.map(g)),
-     boxedLifted.xmap(_.asInstanceOf[Array[Option[B]]], _.asInstanceOf[Array[Option[A]]])) 
+     boxedLifted.xmap(_.asInstanceOf[Array[Option[B]]], _.asInstanceOf[Array[Option[A]]]))
 
   // Arrays of lifted (nullable) and unlifted (non-nullable) AnyVals
   implicit val (unliftedUnboxedBooleanArrayType, liftedUnboxedBooleanArrayType) = unboxedPair[java.lang.Boolean, scala.Boolean](_.booleanValue, java.lang.Boolean.valueOf)
@@ -106,7 +107,7 @@ object pgtypes {
 
   // So, it turns out that arrays of structs don't work because something is missing from the
   // implementation. So this means we will only be able to support primitive types for arrays.
-  // 
+  //
   // java.sql.SQLFeatureNotSupportedException: Method org.postgresql.jdbc4.Jdbc4Array.getArrayImpl(long,int,Map) is not yet implemented.
   //   at org.postgresql.Driver.notImplemented(Driver.java:729)
   //   at org.postgresql.jdbc2.AbstractJdbc2Array.buildArray(AbstractJdbc2Array.java:771)
@@ -115,6 +116,32 @@ object pgtypes {
 
   // TODO: multidimensional arrays; in the worst case it's just copy/paste of everything above but
   // we can certainly do better than that.
+
+  // PostGIS outer types
+  implicit val PGgeometryType = Meta.other[PGgeometry]("geometry")
+  implicit val PGbox3dType    = Meta.other[PGbox3d]("box3d")
+  implicit val PGbox2dType    = Meta.other[PGbox2d]("box2d")
+
+  // Constructor for geometry types via the `Geometry` member of PGgeometry
+  private def geometryType[A >: Null <: Geometry: TypeTag](implicit A: ClassTag[A]): Meta[A] =
+    PGgeometryType.nxmap[A](g =>
+      try A.runtimeClass.cast(g.getGeometry).asInstanceOf[A]
+      catch {
+        case _: ClassCastException => throw InvalidObjectMapping(A.runtimeClass, g.getGeometry.getClass)
+      }, new PGgeometry(_))
+
+  // PostGIS Geometry Types
+  implicit val GeometryType           = geometryType[Geometry]
+  implicit val ComposedGeomType       = geometryType[ComposedGeom]
+  implicit val GeometryCollectionType = geometryType[GeometryCollection]
+  implicit val MultiLineStringType    = geometryType[MultiLineString]
+  implicit val MultiPolygonType       = geometryType[MultiPolygon]
+  implicit val PointComposedGeomType  = geometryType[PointComposedGeom]
+  implicit val LinearRingType         = geometryType[LinearRing]
+  implicit val LineStringType         = geometryType[LineString]
+  implicit val MultiPointType         = geometryType[MultiPoint]
+  implicit val PolygonType            = geometryType[Polygon]
+  implicit val PointType              = geometryType[Point]
 
 }
 

--- a/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgtypes.scala
+++ b/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgtypes.scala
@@ -146,19 +146,25 @@ object pgtypesspec extends Specification {
 
   // PostGIS geometry types
 
+  // Random streams of geometry types. Not as good as scalacheck, sorry.
+  val rnd: Iterator[Double]     = Stream.continually(util.Random.nextDouble).iterator
+  val pts: Iterator[Point]      = Stream.continually(new Point(rnd.next, rnd.next)).iterator
+  val lss: Iterator[LineString] = Stream.continually(new LineString(Array(pts.next, pts.next, pts.next))).iterator
 
-  testInOut[Geometry]("geometry", new Point(12.34, 56.78, 90.12))
-  // implicit val ComposedGeomType       = geometryType[ComposedGeom]
-  // implicit val GeometryCollectionType = geometryType[GeometryCollection]
-  testInOut("geometry", new MultiLineString(Array(new LineString(Array(new Point(1, 2), new Point(3, 4))), new LineString(Array(new Point(5, 6), new Point(7, 8), new Point(0, 0))))))
-  // implicit val MultiPolygonType       = geometryType[MultiPolygon]
-  // implicit val PointComposedGeomType  = geometryType[PointComposedGeom]
-  // implicit val LinearRingType         = geometryType[LinearRing]
-  testInOut("geometry", new LineString(Array(new Point(1, 2), new Point(3, 4))))
-  // implicit val MultiPointType         = geometryType[MultiPoint]
-  testInOut("geometry", new MultiPoint(Array(new Point(1, 2), new Point(3, 4))))
-  // implicit val PolygonType            = geometryType[Polygon]
-  testInOut("geometry", new Point(12.34, 56.78, 90.12))
+  def testInOutGeom[A <: Geometry: Meta](a: A) =
+    testInOut[A]("geometry", a)
+
+  testInOutGeom[Geometry](pts.next)
+  // testInOutGeom[ComposedGeom]()
+  // testInOutGeom[GeometryCollection]()
+  testInOutGeom[MultiLineString](new MultiLineString(Array(lss.next, lss.next, lss.next)))
+  // testInOutGeom[MultiPolygon]()
+  // testInOutGeom[PointComposedGeom]()
+  // testInOutGeom[LinearRing]()
+  testInOutGeom[LineString](lss.next)
+  testInOutGeom[MultiPoint](new MultiPoint(Array(pts.next, pts.next, pts.next)))
+  // testInOutGeom[Polygon]()
+  testInOutGeom[Point](pts.next)
 
 }
 

--- a/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgtypes.scala
+++ b/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgtypes.scala
@@ -146,24 +146,32 @@ object pgtypesspec extends Specification {
 
   // PostGIS geometry types
 
-  // Random streams of geometry types. Not as good as scalacheck, sorry.
-  val rnd: Iterator[Double]     = Stream.continually(util.Random.nextDouble).iterator
-  val pts: Iterator[Point]      = Stream.continually(new Point(rnd.next, rnd.next)).iterator
-  val lss: Iterator[LineString] = Stream.continually(new LineString(Array(pts.next, pts.next, pts.next))).iterator
+  // Random streams of geometry values
+  lazy val rnd: Iterator[Double]     = Stream.continually(util.Random.nextDouble).iterator
+  lazy val pts: Iterator[Point]      = Stream.continually(new Point(rnd.next, rnd.next)).iterator
+  lazy val lss: Iterator[LineString] = Stream.continually(new LineString(Array(pts.next, pts.next, pts.next))).iterator
+  lazy val lrs: Iterator[LinearRing] = Stream.continually(new LinearRing({ lazy val p = pts.next; Array(p, pts.next, pts.next, pts.next, p) })).iterator
+  lazy val pls: Iterator[Polygon]    = Stream.continually(new Polygon(lras.next)).iterator
 
+  // Streams of arrays of random geometry values
+  lazy val ptas: Iterator[Array[Point]]      = Stream.continually(Array(pts.next, pts.next, pts.next)).iterator
+  lazy val plas: Iterator[Array[Polygon]]    = Stream.continually(Array(pls.next, pls.next, pls.next)).iterator
+  lazy val lsas: Iterator[Array[LineString]] = Stream.continually(Array(lss.next, lss.next, lss.next)).iterator
+  lazy val lras: Iterator[Array[LinearRing]] = Stream.continually(Array(lrs.next, lrs.next, lrs.next)).iterator
+
+  // All these types map to `geometry`
   def testInOutGeom[A <: Geometry: Meta](a: A) =
     testInOut[A]("geometry", a)
 
   testInOutGeom[Geometry](pts.next)
-  // testInOutGeom[ComposedGeom]()
-  // testInOutGeom[GeometryCollection]()
-  testInOutGeom[MultiLineString](new MultiLineString(Array(lss.next, lss.next, lss.next)))
-  // testInOutGeom[MultiPolygon]()
-  // testInOutGeom[PointComposedGeom]()
-  // testInOutGeom[LinearRing]()
+  testInOutGeom[ComposedGeom](new MultiLineString(lsas.next))
+  testInOutGeom[GeometryCollection](new GeometryCollection(Array(pts.next, lss.next)))
+  testInOutGeom[MultiLineString](new MultiLineString(lsas.next))
+  testInOutGeom[MultiPolygon](new MultiPolygon(plas.next))
+  testInOutGeom[PointComposedGeom](lss.next)
   testInOutGeom[LineString](lss.next)
-  testInOutGeom[MultiPoint](new MultiPoint(Array(pts.next, pts.next, pts.next)))
-  // testInOutGeom[Polygon]()
+  testInOutGeom[MultiPoint](new MultiPoint(ptas.next))
+  testInOutGeom[Polygon](pls.next)
   testInOutGeom[Point](pts.next)
 
 }

--- a/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgtypes.scala
+++ b/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgtypes.scala
@@ -7,6 +7,7 @@ import java.net.InetAddress
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
 
+import org.postgis._
 import org.postgresql.util._
 import org.postgresql.geometric._
 import org.specs2.mutable.Specification
@@ -143,4 +144,22 @@ object pgtypesspec extends Specification {
   skip("daterange")
   skip("custom")
 
+  // PostGIS geometry types
+
+
+  testInOut[Geometry]("geometry", new Point(12.34, 56.78, 90.12))
+  // implicit val ComposedGeomType       = geometryType[ComposedGeom]
+  // implicit val GeometryCollectionType = geometryType[GeometryCollection]
+  testInOut("geometry", new MultiLineString(Array(new LineString(Array(new Point(1, 2), new Point(3, 4))), new LineString(Array(new Point(5, 6), new Point(7, 8), new Point(0, 0))))))
+  // implicit val MultiPolygonType       = geometryType[MultiPolygon]
+  // implicit val PointComposedGeomType  = geometryType[PointComposedGeom]
+  // implicit val LinearRingType         = geometryType[LinearRing]
+  testInOut("geometry", new LineString(Array(new Point(1, 2), new Point(3, 4))))
+  // implicit val MultiPointType         = geometryType[MultiPoint]
+  testInOut("geometry", new MultiPoint(Array(new Point(1, 2), new Point(3, 4))))
+  // implicit val PolygonType            = geometryType[Polygon]
+  testInOut("geometry", new Point(12.34, 56.78, 90.12))
+
 }
+
+

--- a/doc/src/main/tut/01-Introduction.md
+++ b/doc/src/main/tut/01-Introduction.md
@@ -4,7 +4,7 @@ number: 1
 title: Introduction
 ---
 
-This is a very short book about **doobie**, which is a pure-functional JDBC layer for Scala. 
+This is a very short book about **doobie**, which is a pure-functional JDBC layer for Scala.
 
 **doobie** provides low-level access to everything in `java.sql` (as of JDK 1.6, JDBC 4.0), allowing you to write any JDBC program in a pure functional style. However the focus of this book is the **high-level API**, which is where most users will spend their time.
 
@@ -24,16 +24,17 @@ This book is compiled as part of the build using the [tut](https://github.com/tp
 
 #### Sample Database Setup
 
-The example code assumes a local [PostgreSQL](http://www.postgresql.org/) server with a `postgres` user with no password, and the sample `world` database loaded up. If you're on a Mac you might check out the excellent [Postgres.app](http://postgresapp.com/) if you don't want to install PostgreSQL as a service. You can set up the user and sample database as follows:
+The example code assumes a local [PostgreSQL](http://www.postgresql.org/) server with a `postgres` user with no password, [PostGIS](http://postgis.net/) extensions (optional), and the sample `world` database loaded up. If you're on a Mac you might check out the excellent [Postgres.app](http://postgresapp.com/) if you don't want to install PostgreSQL as a service. You can set up the user and sample database as follows:
 
 ```
 $ curl -O https://raw.githubusercontent.com/tpolecat/doobie/master/world.sql
 $ psql -c 'create user postgres createdb'
 $ psql -c 'create database world;' -U postgres
 $ psql -c '\i world.sql' -d world -U postgres
+$ psql -d world -c "create extension postgis" -U postgres
 ```
 
-Note that the final `ANALYZE` comand will emit a few errors for system tables. This is expected and is fine. Try a query or two to double-check your setup:
+Skip the last statement if you don't have PostGIS installed. Note that the final `ANALYZE` comand in the import will emit a few errors for system tables. This is expected and is fine. Try a query or two to double-check your setup:
 
 ```
 $ psql -d world -U postgres
@@ -41,7 +42,7 @@ psql (9.3.5)
 Type "help" for help.
 
 world=> select name, continent, population from country where name like 'U%';
-                 name                 |   continent   | population 
+                 name                 |   continent   | population
 --------------------------------------+---------------+------------
  United Arab Emirates                 | Asia          |    2441000
  United Kingdom                       | Europe        |   59623400
@@ -54,7 +55,7 @@ world=> select name, continent, population from country where name like 'U%';
 (8 rows)
 
 world=> \q
-$ 
+$
 ```
 
 You can of course change this setup if you like, but you will need to adjust your JDBC connection information accordingly. Most examples will work with any compliant database, but in a few cases (noted in the text) we rely on vendor-specific behavior.


### PR DESCRIPTION
This adds support for the main PostGIS types:
- `PGgeometry`
- `PGbox2d`
- `PGbox3d`

As well as the following abstract and fine-grained types carried by `PGgeometry`:
- `Geometry`
- `ComposedGeom`
- `GeometryCollection`
- `MultiLineString`
- `MultiPolygon`
- `PointComposedGeom`
- `LineString`
- `MultiPoint`
- `Polygon`
- `Point`

fixes #82 

cc @aloiscochard @icassina