### PR TITLE
clean up transactor a bit

### DIFF
--- a/core/src/main/scala/doobie/syntax/connectionio.scala
+++ b/core/src/main/scala/doobie/syntax/connectionio.scala
@@ -7,7 +7,7 @@ object connectionio {
 
   implicit class MoreConnectionIOOps[A](ma: ConnectionIO[A]) {
     def transact[M[_]](xa: Transactor[M]): M[A] =
-      xa.transact(ma)
+      xa.trans(ma)
   }
 
 }

--- a/core/src/main/scala/doobie/syntax/process.scala
+++ b/core/src/main/scala/doobie/syntax/process.scala
@@ -24,7 +24,7 @@ object process {
       fa.to(doobie.util.process.sink(f)).run
 
     def transact[M[_]](xa: Transactor[M])(implicit ev: Process[F, A] =:= Process[ConnectionIO, A]): Process[M, A] =
-      xa.transact(fa)
+      xa.transP(fa)
 
   }
 


### PR DESCRIPTION
This PR restructures `Transactor` as a pair of natural transformations, which is a nicer representation with better compositional properties. It also makes the ancillary operations (preparation, cleanup, etc.) overridable by implementations.