### PR TITLE
add driver class to hikari ctor

### DIFF
--- a/contrib/hikari/src/main/scala/doobie/contrib/hikari/HikariTransactor.scala
+++ b/contrib/hikari/src/main/scala/doobie/contrib/hikari/HikariTransactor.scala
@@ -29,6 +29,11 @@ object hikaritransactor {
       Capture[M].apply(new HikariTransactor(new HikariDataSource))
 
     /** Constructs a program that yields a `HikariTransactor` configured with the given info. */
+    @deprecated("doesn't load driver properly; will go away in 0.2.2; use 4-arg version", "0.2.1")
+    def apply[M[_]: Monad : Catchable : Capture](url: String, user: String, pass: String): M[HikariTransactor[M]] =
+      apply("java.lang.String", url, user, pass)
+
+    /** Constructs a program that yields a `HikariTransactor` configured with the given info. */
     def apply[M[_]: Monad : Catchable : Capture](driverClassName: String, url: String, user: String, pass: String): M[HikariTransactor[M]] =
       for {
         _ <- Capture[M].apply(Class.forName(driverClassName))

--- a/contrib/hikari/src/main/scala/doobie/contrib/hikari/HikariTransactor.scala
+++ b/contrib/hikari/src/main/scala/doobie/contrib/hikari/HikariTransactor.scala
@@ -29,8 +29,9 @@ object hikaritransactor {
       Capture[M].apply(new HikariTransactor(new HikariDataSource))
 
     /** Constructs a program that yields a `HikariTransactor` configured with the given info. */
-    def apply[M[_]: Monad : Catchable : Capture](url: String, user: String, pass: String): M[HikariTransactor[M]] =
+    def apply[M[_]: Monad : Catchable : Capture](driverClassName: String, url: String, user: String, pass: String): M[HikariTransactor[M]] =
       for {
+        _ <- Capture[M].apply(Class.forName(driverClassName))
         t <- initial[M]
         _ <- t.configure(ds => Capture[M].apply {
           ds setJdbcUrl  url

--- a/example/src/main/scala/example/HikariExample.scala
+++ b/example/src/main/scala/example/HikariExample.scala
@@ -1,0 +1,20 @@
+package doobie.example
+
+import scalaz._, Scalaz._, scalaz.concurrent.Task
+
+import doobie.imports._
+import doobie.contrib.hikari.hikaritransactor._
+
+object HikariExample {
+
+  def tmain: Task[Unit] = 
+    for {
+      xa <- HikariTransactor[Task]("org.h2.Driver", "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", "sa", "")
+      _  <- FirstExample.examples.transact(xa)
+      _  <- xa.shutdown
+    } yield ()
+
+  def main(args: Array[String]) =
+    tmain.run
+
+}


### PR DESCRIPTION
As reported by @ppurang in the gitter channel, the Hikari transactor doesn't really work unless you load the driver class by hand. So this PR adds it as a ctor parameter and restores the example. This is a **breaking change** and will need doc. Fixes #127 pending doc.