### PR TITLE
Add Jdbc BOOLEAN for Meta[Boolean] mapping

### DIFF
--- a/contrib/h2/src/test/scala/doobie/contrib/h2/h2types.scala
+++ b/contrib/h2/src/test/scala/doobie/contrib/h2/h2types.scala
@@ -72,5 +72,20 @@ object h2typesspec extends Specification {
   testInOut[List[String]]("ARRAY", List("foo", "bar"))
   skip("GEOMETRY")
 
+  "Mapping for Boolean" should {
+    "pass query analysis for unascribed 'true'" in {
+      val a = sql"select true".query[Boolean].analysis.transact(xa).run
+      a.alignmentErrors must_== Nil
+    }
+    "pass query analysis for ascribed BIT" in {
+      val a = sql"select true::BIT".query[Boolean].analysis.transact(xa).run
+      a.alignmentErrors must_== Nil
+    }
+    "pass query analysis for ascribed BOOLEAN" in {
+      val a = sql"select true::BIT".query[Boolean].analysis.transact(xa).run
+      a.alignmentErrors must_== Nil
+    }
+  }
+
 }
 

--- a/core/src/main/scala/doobie/hi/preparedstatement.scala
+++ b/core/src/main/scala/doobie/hi/preparedstatement.scala
@@ -31,7 +31,7 @@ import java.sql.{ ParameterMetaData, ResultSetMetaData, SQLWarning, Time, Timest
 
 import scala.collection.immutable.Map
 import scala.collection.JavaConverters._
-import scala.Predef.intArrayOps
+import scala.Predef.{ intArrayOps, intWrapper }
 
 import scalaz.stream.Process
 import scalaz.syntax.id._
@@ -116,7 +116,7 @@ object preparedstatement {
    */
   def getColumnJdbcMeta: PreparedStatementIO[List[ColumnMeta]] =
     PS.getMetaData.map { md =>
-      (1 |-> md.getColumnCount).map { i =>
+      (1 to md.getColumnCount).toList.map { i =>
         val j = JdbcType.unsafeFromInt(md.getColumnType(i))
         val s = md.getColumnTypeName(i)
         val n = ColumnNullable.unsafeFromInt(md.isNullable(i)).toNullability
@@ -155,7 +155,7 @@ object preparedstatement {
    */
   def getParameterJdbcMeta: PreparedStatementIO[List[ParameterMeta]] =
     PS.getParameterMetaData.map { md =>
-      (1 |-> md.getParameterCount).map { i =>
+      (1 to md.getParameterCount).toList.map { i =>
         val j = JdbcType.unsafeFromInt(md.getParameterType(i))
         val s = md.getParameterTypeName(i)
         val n = ParameterNullable.unsafeFromInt(md.isNullable(i)).toNullability

--- a/core/src/main/scala/doobie/util/meta.scala
+++ b/core/src/main/scala/doobie/util/meta.scala
@@ -1,6 +1,6 @@
 package doobie.util
 
-import doobie.enum.jdbctype.{ Array => JdbcArray, _ }
+import doobie.enum.jdbctype.{ Array => JdbcArray, Boolean => JdbcBoolean, _ }
 import doobie.free.{ connection => C, resultset => RS, preparedstatement => PS, statement => S }
 import doobie.util.invariant._
 
@@ -344,8 +344,9 @@ object meta {
       RS.getBigDecimal, PS.setBigDecimal, RS.updateBigDecimal)
 
     /** @group Instances */
-    implicit val BooleanMeta = Meta.basic1[Boolean](
-      Bit, 
+    implicit val BooleanMeta = Meta.basic[Boolean](
+      NonEmptyList(Bit, JdbcBoolean),
+      NonEmptyList(Bit, JdbcBoolean),
       List(TinyInt, Integer, SmallInt, BigInt, Float, Double, Real, Decimal, Numeric, Char, VarChar, 
         LongVarChar),
       RS.getBoolean, PS.setBoolean, RS.updateBoolean)


### PR DESCRIPTION
This fixes #123 by adding jdbc `BOOLEAN` as an acceptable primary mapping for Scala `Boolean` values and adds a test for H2, where the bug was reported. This mapping doesn't appear in the jdbc spec but that's certainly an oversight.

It also fixes a bug discovered along the way that made analysis fail for zero-param queries constructed with the `sql` interpolator ... the scalaz `|->` operator can go forwards or backwards so `1 |-> 0` is actually `List(1,0)` instead of `Nil`, which made `HNil` appear to have two elements instead of zero. Anyway, fixed.