### PR TITLE
Unapply for FreeCoyo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,16 +26,22 @@ scalacOptions in ThisBuild ++= Seq(
   "-Ywarn-value-discard"     
 )
 
-unidocSettings
-
-unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(example)
-
 scalacOptions in (Compile, doc) ++= Seq(
   "-groups",
   "-sourcepath", (baseDirectory in LocalRootProject).value.getAbsolutePath, 
   "-doc-source-url", "https://github.com/tpolecat/doobie/tree/v" + version.value + "€{FILE_PATH}.scala",
   "-skip-packages", "scalaz"
 )
+
+/// UNIDOC
+
+resolvers += "bintray/non" at "http://dl.bintray.com/non/maven"
+
+addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.5.2")
+
+unidocSettings
+
+unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(example)
 
 /// SUBMODULES
 

--- a/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/unapply.scala
+++ b/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/unapply.scala
@@ -1,0 +1,23 @@
+package doobie.util
+
+import shapeless._, shapeless.test._
+import doobie.imports._
+import doobie.contrib.postgresql.syntax._
+import org.specs2.mutable.Specification
+
+import scalaz.{ Free, Coyoneda, Monad }
+import scalaz.syntax.monad._
+
+object unapplyspec extends Specification {
+
+  "Unapply" should { 
+
+    "allow use of sqlstate syntax" in {
+      1.point[ConnectionIO].map(_ + 1).void
+      1.point[ConnectionIO].map(_ + 1).onPrivilegeNotRevoked(2.point[ConnectionIO])
+      true
+    }
+
+  }
+
+}

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -31,6 +31,12 @@ scalacOptions ++= Seq(
   "-Yno-predef"
 )
 
+/// COMPILER PLUGINS
+
+resolvers += "bintray/non" at "http://dl.bintray.com/non/maven"
+
+addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.5.2")
+
 /// PUBLISH SETTINGS
 
 bintrayPublishSettings

--- a/core/src/main/scala/doobie/imports.scala
+++ b/core/src/main/scala/doobie/imports.scala
@@ -1,6 +1,6 @@
 package doobie
 
-import scalaz.{ Monad, Catchable }
+import scalaz.{ Monad, Catchable, Unapply, Leibniz, Free, Functor }
 import scalaz.stream.Process
 
 /** Module of aliases for commonly-used types and syntax; use as `import doobie.imports._` */
@@ -119,5 +119,28 @@ object imports {
 
   /** @group Typeclass Instances */
   implicit val NameCapture   = doobie.util.name.NameCapture
+
+  /**
+   * Free monad derivation with correct shape to derive an instance for `Free[Coyoneda[F, ?], ?]`.
+   * @group Hacks
+   */
+  implicit def freeMonadC[FT[_[_], _], F[_]](implicit ev: Functor[FT[F, ?]]) =
+    Free.freeMonad[FT[F,?]]
+
+  /**
+   * Unapply with correct shape to unpack `Monad[Free[Coyoneda[F, ?], ?]]`.
+   * @group Hacks
+   */
+  implicit def unapplyMMFA[TC[_[_]], M0[_[_], _], M1[_[_], _], F0[_], A0](implicit TC0: TC[M0[M1[F0,?], ?]]):
+    Unapply[TC, M0[M1[F0,?], A0]] {
+      type M[X] = M0[M1[F0,?], X]
+      type A = A0
+    } =
+      new Unapply[TC, M0[M1[F0,?], A0]] {
+        type M[X] = M0[M1[F0,?], X]
+        type A = A0
+        def TC = TC0
+        def leibniz = Leibniz.refl
+      }
 
 }

--- a/core/src/test/scala/doobie/util/unapply.scala
+++ b/core/src/test/scala/doobie/util/unapply.scala
@@ -1,0 +1,21 @@
+package doobie.util
+
+import shapeless._, shapeless.test._
+import doobie.imports._
+import org.specs2.mutable.Specification
+
+import scalaz.{ Free, Coyoneda, Monad }
+
+object unapplyspec extends Specification {
+
+  "Unapply" should { 
+
+    "allow inference of Monad[Free[Coyoneda[F, ?], ?]]" in {
+      trait Foo[A]
+      Monad[Free[Coyoneda[Foo, ?], ?]]
+      true
+    }
+
+  }
+
+}


### PR DESCRIPTION
This adds an unapplied implicit constructor for `Monad[Free[Coyoneda[F, ?], ?]]` and an `Unapply` instance matching this shape. This prevents you from losing the `Monad` instance and associated syntax for things like `ConnectionIO` after the alias has been expanded.

Also adds [Kind Projector](https://github.com/non/kind-projector).

This fixes #124 and fixes #57.

Many thanks to Stephen Compall for helping me figure this out.