### PR TITLE
java 1.8, scala 2.10.5, 2.11.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: scala
 
 scala:
-  - 2.11.4
-  - 2.10.4
+  - 2.11.6
+  - 2.10.5
 
 jdk:
   - oraclejdk7
+  - oraclejdk8
 
 script: sbt ++$TRAVIS_SCALA_VERSION compile core/test h2/test postgres/test tut unidoc
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ licenses in ThisBuild ++= Seq(("MIT", url("http://opensource.org/licenses/MIT"))
 
 scalaVersion in ThisBuild := "2.11.6"
 
-crossScalaVersions in ThisBuild := Seq("2.10.4", scalaVersion.value)
+crossScalaVersions in ThisBuild := Seq("2.10.5", scalaVersion.value)
 
 scalacOptions in ThisBuild ++= Seq(
   "-encoding", "UTF-8", // 2 args


### PR DESCRIPTION
This adds Java 1.8 and updates to Scala 2.10.5 and 2.11.6 in the CI build; and moves the main 2.10 cross build to Scala 2.10.5

This resolves #155 