### PR TITLE
Add ModeUnknown to ParameterMode enum

### DIFF
--- a/core/src/main/scala/doobie/enum/parametermode.scala
+++ b/core/src/main/scala/doobie/enum/parametermode.scala
@@ -12,18 +12,20 @@ object parametermode {
   /** @group Implementation */
   sealed abstract class ParameterMode(val toInt: Int)
 
-  /** @group Values */ case object ModeIn    extends ParameterMode(parameterModeIn)
-  /** @group Values */ case object ModeOut   extends ParameterMode(parameterModeOut)
-  /** @group Values */ case object ModeInOut extends ParameterMode(parameterModeInOut)
+  /** @group Values */ case object ModeIn      extends ParameterMode(parameterModeIn)
+  /** @group Values */ case object ModeOut     extends ParameterMode(parameterModeOut)
+  /** @group Values */ case object ModeInOut   extends ParameterMode(parameterModeInOut)
+  /** @group Values */ case object ModeUnknown extends ParameterMode(parameterModeUnknown)
 
   /** @group Implementation */
   object ParameterMode {
 
     def fromInt(n:Int): Option[ParameterMode] =
       Some(n) collect {
-        case ModeIn.toInt    => ModeIn
-        case ModeOut.toInt   => ModeOut
-        case ModeInOut.toInt => ModeInOut
+        case ModeIn.toInt      => ModeIn
+        case ModeOut.toInt     => ModeOut
+        case ModeInOut.toInt   => ModeInOut
+        case ModeUnknown.toInt => ModeUnknown
       }
 
     def unsafeFromInt(n: Int): ParameterMode =


### PR DESCRIPTION
**Disclaimer: I have no idea what I'm doing**

Currently on 0.2.1, running Analysis on a database that doesn't return proper metadata for prepared statements (SQL Server 2008r2 via jTDS 1.3.1 for anyone interested) throws an `InvalidOrdinal: 0`

```
[info] Query0[(Option[Int], Option[String], Option[Timestamp], Option[Timestamp])] defined at Alpha.scala:14
[info]   
[info]   SELECT ProjectId, Cycle, DateStart, DateFinish FROM tblCycle
[info]   WHERE DateStart > ? AND DateFinish < ?
[info]   
[error]   x SQL Compiles and Typechecks
[error]    x doobie.enum.parametermode$ParameterMode: invalid ordinal: 0 (specs2.scala:61)
```

This is because the parametermode enum doesn't have a representation for `parameterModeUnknown` from `java.sql.ParameterMetaData`. This PR adds one.

```
[info] Query0[(Option[Int], Option[String], Option[Timestamp], Option[Timestamp])] defined at Alpha.scala:14
[info]   
[info]   SELECT ProjectId, Cycle, DateStart, DateFinish FROM tblCycle
[info]   WHERE DateStart > ? AND DateFinish < ?
[info]   
[info]   + SQL Compiles and Typechecks
[error]   x P01 Timestamp  →  NULL (null)
[error]    x Timestamp is not coercible to NULL (null) according to the JDBC specification.
[error]      Fix this by changing the schema type to TIMESTAMP, or the Scala type to . (Alpha.scala:14)
[info] 
[error]   x P02 Timestamp  →  NULL (null)
[error]    x Timestamp is not coercible to NULL (null) according to the JDBC specification.
[error]      Fix this by changing the schema type to TIMESTAMP, or the Scala type to . (Alpha.scala:14)
[info] 
[info]   + C01 ProjectId  INTEGER   (int)           NULL  →  Option[Int]
[info]   + C02 Cycle      VARCHAR   (varchar)       NULL  →  Option[String]
[info]   + C03 DateStart  TIMESTAMP (smalldatetime) NULL  →  Option[Timestamp]
[info]   + C04 DateFinish TIMESTAMP (smalldatetime) NULL  →  Option[Timestamp]
```
It still fails, but at least there's return type checking on the way out the door. I'm not sure if adding the `ModeUnknown` case class breaks any other assumptions or has any subtle implications I can't spot. Maybe something related to #164 could acknowledge and ignore this case as well. 