### PR TITLE
update freegen

### DIFF
--- a/core/src/main/scala/doobie/free/blob.scala
+++ b/core/src/main/scala/doobie/free/blob.scala
@@ -162,11 +162,11 @@ object blob {
     case class  SetBinaryStream(a: Long) extends BlobOp[OutputStream] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a))
     }
-    case class  SetBytes(a: Long, b: Array[Byte], c: Int, d: Int) extends BlobOp[Int] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBytes(a, b, c, d))
-    }
-    case class  SetBytes1(a: Long, b: Array[Byte]) extends BlobOp[Int] {
+    case class  SetBytes(a: Long, b: Array[Byte]) extends BlobOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBytes(a, b))
+    }
+    case class  SetBytes1(a: Long, b: Array[Byte], c: Int, d: Int) extends BlobOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBytes(a, b, c, d))
     }
     case class  Truncate(a: Long) extends BlobOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.truncate(a))
@@ -358,14 +358,14 @@ object blob {
   /** 
    * @group Constructors (Primitives)
    */
-  def setBytes(a: Long, b: Array[Byte], c: Int, d: Int): BlobIO[Int] =
-    F.liftFC(SetBytes(a, b, c, d))
+  def setBytes(a: Long, b: Array[Byte]): BlobIO[Int] =
+    F.liftFC(SetBytes(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setBytes(a: Long, b: Array[Byte]): BlobIO[Int] =
-    F.liftFC(SetBytes1(a, b))
+  def setBytes(a: Long, b: Array[Byte], c: Int, d: Int): BlobIO[Int] =
+    F.liftFC(SetBytes1(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)

--- a/core/src/main/scala/doobie/free/callablestatement.scala
+++ b/core/src/main/scala/doobie/free/callablestatement.scala
@@ -29,7 +29,6 @@ import java.sql.RowId
 import java.sql.SQLData
 import java.sql.SQLInput
 import java.sql.SQLOutput
-import java.sql.SQLType
 import java.sql.SQLWarning
 import java.sql.SQLXML
 import java.sql.Statement
@@ -185,35 +184,17 @@ object callablestatement {
     case class  Execute1(a: String) extends CallableStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a))
     }
-    case class  Execute2(a: String, b: Array[String]) extends CallableStatementOp[Boolean] {
+    case class  Execute2(a: String, b: Array[Int]) extends CallableStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
     }
-    case class  Execute3(a: String, b: Array[Int]) extends CallableStatementOp[Boolean] {
+    case class  Execute3(a: String, b: Int) extends CallableStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
     }
-    case class  Execute4(a: String, b: Int) extends CallableStatementOp[Boolean] {
+    case class  Execute4(a: String, b: Array[String]) extends CallableStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
     }
     case object ExecuteBatch extends CallableStatementOp[Array[Int]] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeBatch())
-    }
-    case object ExecuteLargeBatch extends CallableStatementOp[Array[Long]] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeBatch())
-    }
-    case object ExecuteLargeUpdate extends CallableStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate())
-    }
-    case class  ExecuteLargeUpdate1(a: String, b: Array[String]) extends CallableStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
-    }
-    case class  ExecuteLargeUpdate2(a: String, b: Array[Int]) extends CallableStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
-    }
-    case class  ExecuteLargeUpdate3(a: String, b: Int) extends CallableStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
-    }
-    case class  ExecuteLargeUpdate4(a: String) extends CallableStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a))
     }
     case object ExecuteQuery extends CallableStatementOp[ResultSet] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeQuery())
@@ -224,17 +205,17 @@ object callablestatement {
     case object ExecuteUpdate extends CallableStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate())
     }
-    case class  ExecuteUpdate1(a: String) extends CallableStatementOp[Int] {
+    case class  ExecuteUpdate1(a: String, b: Array[String]) extends CallableStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
+    }
+    case class  ExecuteUpdate2(a: String, b: Int) extends CallableStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
+    }
+    case class  ExecuteUpdate3(a: String, b: Array[Int]) extends CallableStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
+    }
+    case class  ExecuteUpdate4(a: String) extends CallableStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a))
-    }
-    case class  ExecuteUpdate2(a: String, b: Array[Int]) extends CallableStatementOp[Int] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
-    }
-    case class  ExecuteUpdate3(a: String, b: Int) extends CallableStatementOp[Int] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
-    }
-    case class  ExecuteUpdate4(a: String, b: Array[String]) extends CallableStatementOp[Int] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
     }
     case class  GetArray(a: String) extends CallableStatementOp[SqlArray] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getArray(a))
@@ -245,11 +226,11 @@ object callablestatement {
     case class  GetBigDecimal(a: Int) extends CallableStatementOp[BigDecimal] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a))
     }
-    case class  GetBigDecimal1(a: String) extends CallableStatementOp[BigDecimal] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a))
-    }
-    case class  GetBigDecimal2(a: Int, b: Int) extends CallableStatementOp[BigDecimal] {
+    case class  GetBigDecimal1(a: Int, b: Int) extends CallableStatementOp[BigDecimal] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a, b))
+    }
+    case class  GetBigDecimal2(a: String) extends CallableStatementOp[BigDecimal] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a))
     }
     case class  GetBlob(a: String) extends CallableStatementOp[Blob] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBlob(a))
@@ -263,16 +244,16 @@ object callablestatement {
     case class  GetBoolean1(a: Int) extends CallableStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBoolean(a))
     }
-    case class  GetByte(a: String) extends CallableStatementOp[Byte] {
+    case class  GetByte(a: Int) extends CallableStatementOp[Byte] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getByte(a))
     }
-    case class  GetByte1(a: Int) extends CallableStatementOp[Byte] {
+    case class  GetByte1(a: String) extends CallableStatementOp[Byte] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getByte(a))
     }
-    case class  GetBytes(a: String) extends CallableStatementOp[Array[Byte]] {
+    case class  GetBytes(a: Int) extends CallableStatementOp[Array[Byte]] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBytes(a))
     }
-    case class  GetBytes1(a: Int) extends CallableStatementOp[Array[Byte]] {
+    case class  GetBytes1(a: String) extends CallableStatementOp[Array[Byte]] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBytes(a))
     }
     case class  GetCharacterStream(a: Int) extends CallableStatementOp[Reader] {
@@ -281,31 +262,31 @@ object callablestatement {
     case class  GetCharacterStream1(a: String) extends CallableStatementOp[Reader] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getCharacterStream(a))
     }
-    case class  GetClob(a: String) extends CallableStatementOp[Clob] {
+    case class  GetClob(a: Int) extends CallableStatementOp[Clob] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getClob(a))
     }
-    case class  GetClob1(a: Int) extends CallableStatementOp[Clob] {
+    case class  GetClob1(a: String) extends CallableStatementOp[Clob] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getClob(a))
     }
     case object GetConnection extends CallableStatementOp[Connection] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getConnection())
     }
-    case class  GetDate(a: Int, b: Calendar) extends CallableStatementOp[Date] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a, b))
+    case class  GetDate(a: Int) extends CallableStatementOp[Date] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a))
     }
     case class  GetDate1(a: String, b: Calendar) extends CallableStatementOp[Date] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a, b))
     }
-    case class  GetDate2(a: Int) extends CallableStatementOp[Date] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a))
+    case class  GetDate2(a: Int, b: Calendar) extends CallableStatementOp[Date] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a, b))
     }
     case class  GetDate3(a: String) extends CallableStatementOp[Date] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a))
     }
-    case class  GetDouble(a: Int) extends CallableStatementOp[Double] {
+    case class  GetDouble(a: String) extends CallableStatementOp[Double] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDouble(a))
     }
-    case class  GetDouble1(a: String) extends CallableStatementOp[Double] {
+    case class  GetDouble1(a: Int) extends CallableStatementOp[Double] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDouble(a))
     }
     case object GetFetchDirection extends CallableStatementOp[Int] {
@@ -323,22 +304,16 @@ object callablestatement {
     case object GetGeneratedKeys extends CallableStatementOp[ResultSet] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getGeneratedKeys())
     }
-    case class  GetInt(a: String) extends CallableStatementOp[Int] {
+    case class  GetInt(a: Int) extends CallableStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getInt(a))
     }
-    case class  GetInt1(a: Int) extends CallableStatementOp[Int] {
+    case class  GetInt1(a: String) extends CallableStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getInt(a))
     }
-    case object GetLargeMaxRows extends CallableStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeMaxRows())
-    }
-    case object GetLargeUpdateCount extends CallableStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeUpdateCount())
-    }
-    case class  GetLong(a: Int) extends CallableStatementOp[Long] {
+    case class  GetLong(a: String) extends CallableStatementOp[Long] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLong(a))
     }
-    case class  GetLong1(a: String) extends CallableStatementOp[Long] {
+    case class  GetLong1(a: Int) extends CallableStatementOp[Long] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLong(a))
     }
     case object GetMaxFieldSize extends CallableStatementOp[Int] {
@@ -350,22 +325,22 @@ object callablestatement {
     case object GetMetaData extends CallableStatementOp[ResultSetMetaData] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMetaData())
     }
-    case class  GetMoreResults(a: Int) extends CallableStatementOp[Boolean] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMoreResults(a))
-    }
-    case object GetMoreResults1 extends CallableStatementOp[Boolean] {
+    case object GetMoreResults extends CallableStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMoreResults())
     }
-    case class  GetNCharacterStream(a: Int) extends CallableStatementOp[Reader] {
+    case class  GetMoreResults1(a: Int) extends CallableStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMoreResults(a))
+    }
+    case class  GetNCharacterStream(a: String) extends CallableStatementOp[Reader] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNCharacterStream(a))
     }
-    case class  GetNCharacterStream1(a: String) extends CallableStatementOp[Reader] {
+    case class  GetNCharacterStream1(a: Int) extends CallableStatementOp[Reader] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNCharacterStream(a))
     }
-    case class  GetNClob(a: String) extends CallableStatementOp[NClob] {
+    case class  GetNClob(a: Int) extends CallableStatementOp[NClob] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNClob(a))
     }
-    case class  GetNClob1(a: Int) extends CallableStatementOp[NClob] {
+    case class  GetNClob1(a: String) extends CallableStatementOp[NClob] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNClob(a))
     }
     case class  GetNString(a: String) extends CallableStatementOp[String] {
@@ -374,23 +349,23 @@ object callablestatement {
     case class  GetNString1(a: Int) extends CallableStatementOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNString(a))
     }
-    case class  GetObject(a: Int) extends CallableStatementOp[Object] {
+    case class  GetObject(a: String) extends CallableStatementOp[Object] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a))
     }
-    case class  GetObject1(a: String, b: Map[String, Class[_]]) extends CallableStatementOp[Object] {
+    case class  GetObject1(a: Int, b: Map[String, Class[_]]) extends CallableStatementOp[Object] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
     }
-    case class  GetObject2[T](a: String, b: Class[T]) extends CallableStatementOp[T] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
-    }
-    case class  GetObject3(a: Int, b: Map[String, Class[_]]) extends CallableStatementOp[Object] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
-    }
-    case class  GetObject4[T](a: Int, b: Class[T]) extends CallableStatementOp[T] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
-    }
-    case class  GetObject5(a: String) extends CallableStatementOp[Object] {
+    case class  GetObject2(a: Int) extends CallableStatementOp[Object] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a))
+    }
+    case class  GetObject3(a: String, b: Map[String, Class[_]]) extends CallableStatementOp[Object] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
+    }
+    case class  GetObject4[T](a: String, b: Class[T]) extends CallableStatementOp[T] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
+    }
+    case class  GetObject5[T](a: Int, b: Class[T]) extends CallableStatementOp[T] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
     }
     case object GetParameterMetaData extends CallableStatementOp[ParameterMetaData] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getParameterMetaData())
@@ -398,10 +373,10 @@ object callablestatement {
     case object GetQueryTimeout extends CallableStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getQueryTimeout())
     }
-    case class  GetRef(a: Int) extends CallableStatementOp[Ref] {
+    case class  GetRef(a: String) extends CallableStatementOp[Ref] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getRef(a))
     }
-    case class  GetRef1(a: String) extends CallableStatementOp[Ref] {
+    case class  GetRef1(a: Int) extends CallableStatementOp[Ref] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getRef(a))
     }
     case object GetResultSet extends CallableStatementOp[ResultSet] {
@@ -416,22 +391,22 @@ object callablestatement {
     case object GetResultSetType extends CallableStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getResultSetType())
     }
-    case class  GetRowId(a: Int) extends CallableStatementOp[RowId] {
+    case class  GetRowId(a: String) extends CallableStatementOp[RowId] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getRowId(a))
     }
-    case class  GetRowId1(a: String) extends CallableStatementOp[RowId] {
+    case class  GetRowId1(a: Int) extends CallableStatementOp[RowId] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getRowId(a))
     }
-    case class  GetSQLXML(a: String) extends CallableStatementOp[SQLXML] {
+    case class  GetSQLXML(a: Int) extends CallableStatementOp[SQLXML] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSQLXML(a))
     }
-    case class  GetSQLXML1(a: Int) extends CallableStatementOp[SQLXML] {
+    case class  GetSQLXML1(a: String) extends CallableStatementOp[SQLXML] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSQLXML(a))
     }
-    case class  GetShort(a: Int) extends CallableStatementOp[Short] {
+    case class  GetShort(a: String) extends CallableStatementOp[Short] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getShort(a))
     }
-    case class  GetShort1(a: String) extends CallableStatementOp[Short] {
+    case class  GetShort1(a: Int) extends CallableStatementOp[Short] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getShort(a))
     }
     case class  GetString(a: String) extends CallableStatementOp[String] {
@@ -440,8 +415,8 @@ object callablestatement {
     case class  GetString1(a: Int) extends CallableStatementOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getString(a))
     }
-    case class  GetTime(a: String) extends CallableStatementOp[Time] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a))
+    case class  GetTime(a: Int, b: Calendar) extends CallableStatementOp[Time] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a, b))
     }
     case class  GetTime1(a: String, b: Calendar) extends CallableStatementOp[Time] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a, b))
@@ -449,25 +424,25 @@ object callablestatement {
     case class  GetTime2(a: Int) extends CallableStatementOp[Time] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a))
     }
-    case class  GetTime3(a: Int, b: Calendar) extends CallableStatementOp[Time] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a, b))
+    case class  GetTime3(a: String) extends CallableStatementOp[Time] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a))
     }
-    case class  GetTimestamp(a: Int, b: Calendar) extends CallableStatementOp[Timestamp] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a, b))
-    }
-    case class  GetTimestamp1(a: String) extends CallableStatementOp[Timestamp] {
+    case class  GetTimestamp(a: Int) extends CallableStatementOp[Timestamp] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a))
+    }
+    case class  GetTimestamp1(a: Int, b: Calendar) extends CallableStatementOp[Timestamp] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a, b))
     }
     case class  GetTimestamp2(a: String, b: Calendar) extends CallableStatementOp[Timestamp] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a, b))
     }
-    case class  GetTimestamp3(a: Int) extends CallableStatementOp[Timestamp] {
+    case class  GetTimestamp3(a: String) extends CallableStatementOp[Timestamp] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a))
     }
-    case class  GetURL(a: Int) extends CallableStatementOp[URL] {
+    case class  GetURL(a: String) extends CallableStatementOp[URL] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getURL(a))
     }
-    case class  GetURL1(a: String) extends CallableStatementOp[URL] {
+    case class  GetURL1(a: Int) extends CallableStatementOp[URL] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getURL(a))
     }
     case object GetUpdateCount extends CallableStatementOp[Int] {
@@ -488,61 +463,43 @@ object callablestatement {
     case class  IsWrapperFor(a: Class[_]) extends CallableStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.isWrapperFor(a))
     }
-    case class  RegisterOutParameter(a: String, b: SQLType) extends CallableStatementOp[Unit] {
+    case class  RegisterOutParameter(a: String, b: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b))
     }
-    case class  RegisterOutParameter1(a: Int, b: SQLType, c: String) extends CallableStatementOp[Unit] {
+    case class  RegisterOutParameter1(a: String, b: Int, c: String) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
     }
-    case class  RegisterOutParameter10(a: Int, b: Int, c: Int) extends CallableStatementOp[Unit] {
+    case class  RegisterOutParameter2(a: Int, b: Int, c: String) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
     }
-    case class  RegisterOutParameter11(a: Int, b: Int, c: String) extends CallableStatementOp[Unit] {
+    case class  RegisterOutParameter3(a: String, b: Int, c: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
     }
-    case class  RegisterOutParameter2(a: String, b: SQLType, c: Int) extends CallableStatementOp[Unit] {
+    case class  RegisterOutParameter4(a: Int, b: Int, c: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
     }
-    case class  RegisterOutParameter3(a: String, b: SQLType, c: String) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
-    }
-    case class  RegisterOutParameter4(a: Int, b: SQLType, c: Int) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
-    }
-    case class  RegisterOutParameter5(a: Int, b: SQLType) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b))
-    }
-    case class  RegisterOutParameter6(a: String, b: Int) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b))
-    }
-    case class  RegisterOutParameter7(a: String, b: Int, c: Int) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
-    }
-    case class  RegisterOutParameter8(a: String, b: Int, c: String) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
-    }
-    case class  RegisterOutParameter9(a: Int, b: Int) extends CallableStatementOp[Unit] {
+    case class  RegisterOutParameter5(a: Int, b: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b))
     }
     case class  SetArray(a: Int, b: SqlArray) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setArray(a, b))
     }
-    case class  SetAsciiStream(a: String, b: InputStream, c: Int) extends CallableStatementOp[Unit] {
+    case class  SetAsciiStream(a: String, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
     }
-    case class  SetAsciiStream1(a: String, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
-    }
-    case class  SetAsciiStream2(a: String, b: InputStream) extends CallableStatementOp[Unit] {
+    case class  SetAsciiStream1(a: String, b: InputStream) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b))
     }
-    case class  SetAsciiStream3(a: Int, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
+    case class  SetAsciiStream2(a: String, b: InputStream, c: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
+    }
+    case class  SetAsciiStream3(a: Int, b: InputStream, c: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
     }
     case class  SetAsciiStream4(a: Int, b: InputStream) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b))
     }
-    case class  SetAsciiStream5(a: Int, b: InputStream, c: Int) extends CallableStatementOp[Unit] {
+    case class  SetAsciiStream5(a: Int, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
     }
     case class  SetBigDecimal(a: String, b: BigDecimal) extends CallableStatementOp[Unit] {
@@ -551,10 +508,10 @@ object callablestatement {
     case class  SetBigDecimal1(a: Int, b: BigDecimal) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBigDecimal(a, b))
     }
-    case class  SetBinaryStream(a: String, b: InputStream, c: Int) extends CallableStatementOp[Unit] {
+    case class  SetBinaryStream(a: String, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b, c))
     }
-    case class  SetBinaryStream1(a: String, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
+    case class  SetBinaryStream1(a: String, b: InputStream, c: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b, c))
     }
     case class  SetBinaryStream2(a: String, b: InputStream) extends CallableStatementOp[Unit] {
@@ -569,19 +526,19 @@ object callablestatement {
     case class  SetBinaryStream5(a: Int, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b, c))
     }
-    case class  SetBlob(a: String, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b, c))
-    }
-    case class  SetBlob1(a: String, b: Blob) extends CallableStatementOp[Unit] {
+    case class  SetBlob(a: String, b: Blob) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b))
+    }
+    case class  SetBlob1(a: String, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b, c))
     }
     case class  SetBlob2(a: String, b: InputStream) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b))
     }
-    case class  SetBlob3(a: Int, b: Blob) extends CallableStatementOp[Unit] {
+    case class  SetBlob3(a: Int, b: InputStream) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b))
     }
-    case class  SetBlob4(a: Int, b: InputStream) extends CallableStatementOp[Unit] {
+    case class  SetBlob4(a: Int, b: Blob) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b))
     }
     case class  SetBlob5(a: Int, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
@@ -623,20 +580,20 @@ object callablestatement {
     case class  SetCharacterStream5(a: Int, b: Reader) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b))
     }
-    case class  SetClob(a: String, b: Reader, c: Long) extends CallableStatementOp[Unit] {
+    case class  SetClob(a: String, b: Reader) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
+    }
+    case class  SetClob1(a: String, b: Clob) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
+    }
+    case class  SetClob2(a: String, b: Reader, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b, c))
     }
-    case class  SetClob1(a: String, b: Reader) extends CallableStatementOp[Unit] {
+    case class  SetClob3(a: Int, b: Reader) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
     }
-    case class  SetClob2(a: String, b: Clob) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
-    }
-    case class  SetClob3(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit] {
+    case class  SetClob4(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b, c))
-    }
-    case class  SetClob4(a: Int, b: Reader) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
     }
     case class  SetClob5(a: Int, b: Clob) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
@@ -650,11 +607,11 @@ object callablestatement {
     case class  SetDate1(a: String, b: Date) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b))
     }
-    case class  SetDate2(a: Int, b: Date, c: Calendar) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b, c))
-    }
-    case class  SetDate3(a: Int, b: Date) extends CallableStatementOp[Unit] {
+    case class  SetDate2(a: Int, b: Date) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b))
+    }
+    case class  SetDate3(a: Int, b: Date, c: Calendar) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b, c))
     }
     case class  SetDouble(a: String, b: Double) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDouble(a, b))
@@ -683,9 +640,6 @@ object callablestatement {
     case class  SetInt1(a: Int, b: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setInt(a, b))
     }
-    case class  SetLargeMaxRows(a: Long) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setLargeMaxRows(a))
-    }
     case class  SetLong(a: String, b: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setLong(a, b))
     }
@@ -710,23 +664,23 @@ object callablestatement {
     case class  SetNCharacterStream3(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNCharacterStream(a, b, c))
     }
-    case class  SetNClob(a: String, b: NClob) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
-    }
-    case class  SetNClob1(a: String, b: Reader, c: Long) extends CallableStatementOp[Unit] {
+    case class  SetNClob(a: String, b: Reader, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b, c))
+    }
+    case class  SetNClob1(a: String, b: NClob) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
     }
     case class  SetNClob2(a: String, b: Reader) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
     }
-    case class  SetNClob3(a: Int, b: NClob) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
-    }
-    case class  SetNClob4(a: Int, b: Reader) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
-    }
-    case class  SetNClob5(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit] {
+    case class  SetNClob3(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b, c))
+    }
+    case class  SetNClob4(a: Int, b: NClob) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
+    }
+    case class  SetNClob5(a: Int, b: Reader) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
     }
     case class  SetNString(a: String, b: String) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNString(a, b))
@@ -746,35 +700,23 @@ object callablestatement {
     case class  SetNull3(a: Int, b: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNull(a, b))
     }
-    case class  SetObject(a: String, b: Object, c: SQLType, d: Int) extends CallableStatementOp[Unit] {
+    case class  SetObject(a: String, b: Object, c: Int, d: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
     }
-    case class  SetObject1(a: String, b: Object, c: SQLType) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
+    case class  SetObject1(a: String, b: Object) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b))
     }
     case class  SetObject2(a: String, b: Object, c: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
     }
-    case class  SetObject3(a: String, b: Object, c: Int, d: Int) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
-    }
-    case class  SetObject4(a: String, b: Object) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b))
-    }
-    case class  SetObject5(a: Int, b: Object, c: SQLType) extends CallableStatementOp[Unit] {
+    case class  SetObject3(a: Int, b: Object, c: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
     }
-    case class  SetObject6(a: Int, b: Object, c: Int) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
-    }
-    case class  SetObject7(a: Int, b: Object, c: Int, d: Int) extends CallableStatementOp[Unit] {
+    case class  SetObject4(a: Int, b: Object, c: Int, d: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
     }
-    case class  SetObject8(a: Int, b: Object) extends CallableStatementOp[Unit] {
+    case class  SetObject5(a: Int, b: Object) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b))
-    }
-    case class  SetObject9(a: Int, b: Object, c: SQLType, d: Int) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
     }
     case class  SetPoolable(a: Boolean) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setPoolable(a))
@@ -827,11 +769,11 @@ object callablestatement {
     case class  SetTimestamp1(a: String, b: Timestamp, c: Calendar) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b, c))
     }
-    case class  SetTimestamp2(a: Int, b: Timestamp, c: Calendar) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b, c))
-    }
-    case class  SetTimestamp3(a: Int, b: Timestamp) extends CallableStatementOp[Unit] {
+    case class  SetTimestamp2(a: Int, b: Timestamp) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b))
+    }
+    case class  SetTimestamp3(a: Int, b: Timestamp, c: Calendar) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b, c))
     }
     case class  SetURL(a: String, b: URL) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setURL(a, b))
@@ -1047,19 +989,19 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def execute(a: String, b: Array[String]): CallableStatementIO[Boolean] =
+  def execute(a: String, b: Array[Int]): CallableStatementIO[Boolean] =
     F.liftFC(Execute2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def execute(a: String, b: Array[Int]): CallableStatementIO[Boolean] =
+  def execute(a: String, b: Int): CallableStatementIO[Boolean] =
     F.liftFC(Execute3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def execute(a: String, b: Int): CallableStatementIO[Boolean] =
+  def execute(a: String, b: Array[String]): CallableStatementIO[Boolean] =
     F.liftFC(Execute4(a, b))
 
   /** 
@@ -1067,42 +1009,6 @@ object callablestatement {
    */
   val executeBatch: CallableStatementIO[Array[Int]] =
     F.liftFC(ExecuteBatch)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val executeLargeBatch: CallableStatementIO[Array[Long]] =
-    F.liftFC(ExecuteLargeBatch)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val executeLargeUpdate: CallableStatementIO[Long] =
-    F.liftFC(ExecuteLargeUpdate)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String, b: Array[String]): CallableStatementIO[Long] =
-    F.liftFC(ExecuteLargeUpdate1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String, b: Array[Int]): CallableStatementIO[Long] =
-    F.liftFC(ExecuteLargeUpdate2(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String, b: Int): CallableStatementIO[Long] =
-    F.liftFC(ExecuteLargeUpdate3(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String): CallableStatementIO[Long] =
-    F.liftFC(ExecuteLargeUpdate4(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -1125,26 +1031,26 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def executeUpdate(a: String): CallableStatementIO[Int] =
-    F.liftFC(ExecuteUpdate1(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeUpdate(a: String, b: Array[Int]): CallableStatementIO[Int] =
-    F.liftFC(ExecuteUpdate2(a, b))
+  def executeUpdate(a: String, b: Array[String]): CallableStatementIO[Int] =
+    F.liftFC(ExecuteUpdate1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def executeUpdate(a: String, b: Int): CallableStatementIO[Int] =
+    F.liftFC(ExecuteUpdate2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeUpdate(a: String, b: Array[Int]): CallableStatementIO[Int] =
     F.liftFC(ExecuteUpdate3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def executeUpdate(a: String, b: Array[String]): CallableStatementIO[Int] =
-    F.liftFC(ExecuteUpdate4(a, b))
+  def executeUpdate(a: String): CallableStatementIO[Int] =
+    F.liftFC(ExecuteUpdate4(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -1167,14 +1073,14 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getBigDecimal(a: String): CallableStatementIO[BigDecimal] =
-    F.liftFC(GetBigDecimal1(a))
+  def getBigDecimal(a: Int, b: Int): CallableStatementIO[BigDecimal] =
+    F.liftFC(GetBigDecimal1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getBigDecimal(a: Int, b: Int): CallableStatementIO[BigDecimal] =
-    F.liftFC(GetBigDecimal2(a, b))
+  def getBigDecimal(a: String): CallableStatementIO[BigDecimal] =
+    F.liftFC(GetBigDecimal2(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -1203,25 +1109,25 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getByte(a: String): CallableStatementIO[Byte] =
+  def getByte(a: Int): CallableStatementIO[Byte] =
     F.liftFC(GetByte(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getByte(a: Int): CallableStatementIO[Byte] =
+  def getByte(a: String): CallableStatementIO[Byte] =
     F.liftFC(GetByte1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getBytes(a: String): CallableStatementIO[Array[Byte]] =
+  def getBytes(a: Int): CallableStatementIO[Array[Byte]] =
     F.liftFC(GetBytes(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getBytes(a: Int): CallableStatementIO[Array[Byte]] =
+  def getBytes(a: String): CallableStatementIO[Array[Byte]] =
     F.liftFC(GetBytes1(a))
 
   /** 
@@ -1239,13 +1145,13 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getClob(a: String): CallableStatementIO[Clob] =
+  def getClob(a: Int): CallableStatementIO[Clob] =
     F.liftFC(GetClob(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getClob(a: Int): CallableStatementIO[Clob] =
+  def getClob(a: String): CallableStatementIO[Clob] =
     F.liftFC(GetClob1(a))
 
   /** 
@@ -1257,8 +1163,8 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getDate(a: Int, b: Calendar): CallableStatementIO[Date] =
-    F.liftFC(GetDate(a, b))
+  def getDate(a: Int): CallableStatementIO[Date] =
+    F.liftFC(GetDate(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -1269,8 +1175,8 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getDate(a: Int): CallableStatementIO[Date] =
-    F.liftFC(GetDate2(a))
+  def getDate(a: Int, b: Calendar): CallableStatementIO[Date] =
+    F.liftFC(GetDate2(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1281,13 +1187,13 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getDouble(a: Int): CallableStatementIO[Double] =
+  def getDouble(a: String): CallableStatementIO[Double] =
     F.liftFC(GetDouble(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getDouble(a: String): CallableStatementIO[Double] =
+  def getDouble(a: Int): CallableStatementIO[Double] =
     F.liftFC(GetDouble1(a))
 
   /** 
@@ -1323,37 +1229,25 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getInt(a: String): CallableStatementIO[Int] =
+  def getInt(a: Int): CallableStatementIO[Int] =
     F.liftFC(GetInt(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getInt(a: Int): CallableStatementIO[Int] =
+  def getInt(a: String): CallableStatementIO[Int] =
     F.liftFC(GetInt1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  val getLargeMaxRows: CallableStatementIO[Long] =
-    F.liftFC(GetLargeMaxRows)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val getLargeUpdateCount: CallableStatementIO[Long] =
-    F.liftFC(GetLargeUpdateCount)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getLong(a: Int): CallableStatementIO[Long] =
+  def getLong(a: String): CallableStatementIO[Long] =
     F.liftFC(GetLong(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getLong(a: String): CallableStatementIO[Long] =
+  def getLong(a: Int): CallableStatementIO[Long] =
     F.liftFC(GetLong1(a))
 
   /** 
@@ -1377,37 +1271,37 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getMoreResults(a: Int): CallableStatementIO[Boolean] =
-    F.liftFC(GetMoreResults(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   val getMoreResults: CallableStatementIO[Boolean] =
-    F.liftFC(GetMoreResults1)
+    F.liftFC(GetMoreResults)
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getNCharacterStream(a: Int): CallableStatementIO[Reader] =
-    F.liftFC(GetNCharacterStream(a))
+  def getMoreResults(a: Int): CallableStatementIO[Boolean] =
+    F.liftFC(GetMoreResults1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getNCharacterStream(a: String): CallableStatementIO[Reader] =
+    F.liftFC(GetNCharacterStream(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getNCharacterStream(a: Int): CallableStatementIO[Reader] =
     F.liftFC(GetNCharacterStream1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getNClob(a: String): CallableStatementIO[NClob] =
+  def getNClob(a: Int): CallableStatementIO[NClob] =
     F.liftFC(GetNClob(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getNClob(a: Int): CallableStatementIO[NClob] =
+  def getNClob(a: String): CallableStatementIO[NClob] =
     F.liftFC(GetNClob1(a))
 
   /** 
@@ -1425,38 +1319,38 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getObject(a: Int): CallableStatementIO[Object] =
+  def getObject(a: String): CallableStatementIO[Object] =
     F.liftFC(GetObject(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getObject(a: String, b: Map[String, Class[_]]): CallableStatementIO[Object] =
+  def getObject(a: Int, b: Map[String, Class[_]]): CallableStatementIO[Object] =
     F.liftFC(GetObject1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getObject[T](a: String, b: Class[T]): CallableStatementIO[T] =
-    F.liftFC(GetObject2(a, b))
+  def getObject(a: Int): CallableStatementIO[Object] =
+    F.liftFC(GetObject2(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getObject(a: Int, b: Map[String, Class[_]]): CallableStatementIO[Object] =
+  def getObject(a: String, b: Map[String, Class[_]]): CallableStatementIO[Object] =
     F.liftFC(GetObject3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getObject[T](a: Int, b: Class[T]): CallableStatementIO[T] =
+  def getObject[T](a: String, b: Class[T]): CallableStatementIO[T] =
     F.liftFC(GetObject4(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getObject(a: String): CallableStatementIO[Object] =
-    F.liftFC(GetObject5(a))
+  def getObject[T](a: Int, b: Class[T]): CallableStatementIO[T] =
+    F.liftFC(GetObject5(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1473,13 +1367,13 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getRef(a: Int): CallableStatementIO[Ref] =
+  def getRef(a: String): CallableStatementIO[Ref] =
     F.liftFC(GetRef(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getRef(a: String): CallableStatementIO[Ref] =
+  def getRef(a: Int): CallableStatementIO[Ref] =
     F.liftFC(GetRef1(a))
 
   /** 
@@ -1509,37 +1403,37 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getRowId(a: Int): CallableStatementIO[RowId] =
+  def getRowId(a: String): CallableStatementIO[RowId] =
     F.liftFC(GetRowId(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getRowId(a: String): CallableStatementIO[RowId] =
+  def getRowId(a: Int): CallableStatementIO[RowId] =
     F.liftFC(GetRowId1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getSQLXML(a: String): CallableStatementIO[SQLXML] =
+  def getSQLXML(a: Int): CallableStatementIO[SQLXML] =
     F.liftFC(GetSQLXML(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getSQLXML(a: Int): CallableStatementIO[SQLXML] =
+  def getSQLXML(a: String): CallableStatementIO[SQLXML] =
     F.liftFC(GetSQLXML1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getShort(a: Int): CallableStatementIO[Short] =
+  def getShort(a: String): CallableStatementIO[Short] =
     F.liftFC(GetShort(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getShort(a: String): CallableStatementIO[Short] =
+  def getShort(a: Int): CallableStatementIO[Short] =
     F.liftFC(GetShort1(a))
 
   /** 
@@ -1557,8 +1451,8 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getTime(a: String): CallableStatementIO[Time] =
-    F.liftFC(GetTime(a))
+  def getTime(a: Int, b: Calendar): CallableStatementIO[Time] =
+    F.liftFC(GetTime(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1575,20 +1469,20 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getTime(a: Int, b: Calendar): CallableStatementIO[Time] =
-    F.liftFC(GetTime3(a, b))
+  def getTime(a: String): CallableStatementIO[Time] =
+    F.liftFC(GetTime3(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getTimestamp(a: Int): CallableStatementIO[Timestamp] =
+    F.liftFC(GetTimestamp(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getTimestamp(a: Int, b: Calendar): CallableStatementIO[Timestamp] =
-    F.liftFC(GetTimestamp(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getTimestamp(a: String): CallableStatementIO[Timestamp] =
-    F.liftFC(GetTimestamp1(a))
+    F.liftFC(GetTimestamp1(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1599,19 +1493,19 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getTimestamp(a: Int): CallableStatementIO[Timestamp] =
+  def getTimestamp(a: String): CallableStatementIO[Timestamp] =
     F.liftFC(GetTimestamp3(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getURL(a: Int): CallableStatementIO[URL] =
+  def getURL(a: String): CallableStatementIO[URL] =
     F.liftFC(GetURL(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getURL(a: String): CallableStatementIO[URL] =
+  def getURL(a: Int): CallableStatementIO[URL] =
     F.liftFC(GetURL1(a))
 
   /** 
@@ -1653,74 +1547,38 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def registerOutParameter(a: String, b: SQLType): CallableStatementIO[Unit] =
+  def registerOutParameter(a: String, b: Int): CallableStatementIO[Unit] =
     F.liftFC(RegisterOutParameter(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def registerOutParameter(a: Int, b: SQLType, c: String): CallableStatementIO[Unit] =
+  def registerOutParameter(a: String, b: Int, c: String): CallableStatementIO[Unit] =
     F.liftFC(RegisterOutParameter1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def registerOutParameter(a: Int, b: Int, c: Int): CallableStatementIO[Unit] =
-    F.liftFC(RegisterOutParameter10(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def registerOutParameter(a: Int, b: Int, c: String): CallableStatementIO[Unit] =
-    F.liftFC(RegisterOutParameter11(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def registerOutParameter(a: String, b: SQLType, c: Int): CallableStatementIO[Unit] =
     F.liftFC(RegisterOutParameter2(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def registerOutParameter(a: String, b: SQLType, c: String): CallableStatementIO[Unit] =
+  def registerOutParameter(a: String, b: Int, c: Int): CallableStatementIO[Unit] =
     F.liftFC(RegisterOutParameter3(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def registerOutParameter(a: Int, b: SQLType, c: Int): CallableStatementIO[Unit] =
+  def registerOutParameter(a: Int, b: Int, c: Int): CallableStatementIO[Unit] =
     F.liftFC(RegisterOutParameter4(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def registerOutParameter(a: Int, b: SQLType): CallableStatementIO[Unit] =
-    F.liftFC(RegisterOutParameter5(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def registerOutParameter(a: String, b: Int): CallableStatementIO[Unit] =
-    F.liftFC(RegisterOutParameter6(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def registerOutParameter(a: String, b: Int, c: Int): CallableStatementIO[Unit] =
-    F.liftFC(RegisterOutParameter7(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def registerOutParameter(a: String, b: Int, c: String): CallableStatementIO[Unit] =
-    F.liftFC(RegisterOutParameter8(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def registerOutParameter(a: Int, b: Int): CallableStatementIO[Unit] =
-    F.liftFC(RegisterOutParameter9(a, b))
+    F.liftFC(RegisterOutParameter5(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1731,25 +1589,25 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setAsciiStream(a: String, b: InputStream, c: Int): CallableStatementIO[Unit] =
+  def setAsciiStream(a: String, b: InputStream, c: Long): CallableStatementIO[Unit] =
     F.liftFC(SetAsciiStream(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setAsciiStream(a: String, b: InputStream, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetAsciiStream1(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def setAsciiStream(a: String, b: InputStream): CallableStatementIO[Unit] =
-    F.liftFC(SetAsciiStream2(a, b))
+    F.liftFC(SetAsciiStream1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setAsciiStream(a: Int, b: InputStream, c: Long): CallableStatementIO[Unit] =
+  def setAsciiStream(a: String, b: InputStream, c: Int): CallableStatementIO[Unit] =
+    F.liftFC(SetAsciiStream2(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setAsciiStream(a: Int, b: InputStream, c: Int): CallableStatementIO[Unit] =
     F.liftFC(SetAsciiStream3(a, b, c))
 
   /** 
@@ -1761,7 +1619,7 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setAsciiStream(a: Int, b: InputStream, c: Int): CallableStatementIO[Unit] =
+  def setAsciiStream(a: Int, b: InputStream, c: Long): CallableStatementIO[Unit] =
     F.liftFC(SetAsciiStream5(a, b, c))
 
   /** 
@@ -1779,13 +1637,13 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setBinaryStream(a: String, b: InputStream, c: Int): CallableStatementIO[Unit] =
+  def setBinaryStream(a: String, b: InputStream, c: Long): CallableStatementIO[Unit] =
     F.liftFC(SetBinaryStream(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setBinaryStream(a: String, b: InputStream, c: Long): CallableStatementIO[Unit] =
+  def setBinaryStream(a: String, b: InputStream, c: Int): CallableStatementIO[Unit] =
     F.liftFC(SetBinaryStream1(a, b, c))
 
   /** 
@@ -1815,14 +1673,14 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setBlob(a: String, b: InputStream, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetBlob(a, b, c))
+  def setBlob(a: String, b: Blob): CallableStatementIO[Unit] =
+    F.liftFC(SetBlob(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setBlob(a: String, b: Blob): CallableStatementIO[Unit] =
-    F.liftFC(SetBlob1(a, b))
+  def setBlob(a: String, b: InputStream, c: Long): CallableStatementIO[Unit] =
+    F.liftFC(SetBlob1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -1833,13 +1691,13 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setBlob(a: Int, b: Blob): CallableStatementIO[Unit] =
+  def setBlob(a: Int, b: InputStream): CallableStatementIO[Unit] =
     F.liftFC(SetBlob3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setBlob(a: Int, b: InputStream): CallableStatementIO[Unit] =
+  def setBlob(a: Int, b: Blob): CallableStatementIO[Unit] =
     F.liftFC(SetBlob4(a, b))
 
   /** 
@@ -1923,32 +1781,32 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setClob(a: String, b: Reader, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetClob(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def setClob(a: String, b: Reader): CallableStatementIO[Unit] =
-    F.liftFC(SetClob1(a, b))
+    F.liftFC(SetClob(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setClob(a: String, b: Clob): CallableStatementIO[Unit] =
-    F.liftFC(SetClob2(a, b))
+    F.liftFC(SetClob1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setClob(a: Int, b: Reader, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetClob3(a, b, c))
+  def setClob(a: String, b: Reader, c: Long): CallableStatementIO[Unit] =
+    F.liftFC(SetClob2(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setClob(a: Int, b: Reader): CallableStatementIO[Unit] =
-    F.liftFC(SetClob4(a, b))
+    F.liftFC(SetClob3(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setClob(a: Int, b: Reader, c: Long): CallableStatementIO[Unit] =
+    F.liftFC(SetClob4(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -1977,14 +1835,14 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setDate(a: Int, b: Date, c: Calendar): CallableStatementIO[Unit] =
-    F.liftFC(SetDate2(a, b, c))
+  def setDate(a: Int, b: Date): CallableStatementIO[Unit] =
+    F.liftFC(SetDate2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setDate(a: Int, b: Date): CallableStatementIO[Unit] =
-    F.liftFC(SetDate3(a, b))
+  def setDate(a: Int, b: Date, c: Calendar): CallableStatementIO[Unit] =
+    F.liftFC(SetDate3(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -2043,12 +1901,6 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setLargeMaxRows(a: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetLargeMaxRows(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def setLong(a: String, b: Long): CallableStatementIO[Unit] =
     F.liftFC(SetLong(a, b))
 
@@ -2097,14 +1949,14 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setNClob(a: String, b: NClob): CallableStatementIO[Unit] =
-    F.liftFC(SetNClob(a, b))
+  def setNClob(a: String, b: Reader, c: Long): CallableStatementIO[Unit] =
+    F.liftFC(SetNClob(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setNClob(a: String, b: Reader, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetNClob1(a, b, c))
+  def setNClob(a: String, b: NClob): CallableStatementIO[Unit] =
+    F.liftFC(SetNClob1(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -2115,20 +1967,20 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setNClob(a: Int, b: NClob): CallableStatementIO[Unit] =
-    F.liftFC(SetNClob3(a, b))
+  def setNClob(a: Int, b: Reader, c: Long): CallableStatementIO[Unit] =
+    F.liftFC(SetNClob3(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setNClob(a: Int, b: Reader): CallableStatementIO[Unit] =
+  def setNClob(a: Int, b: NClob): CallableStatementIO[Unit] =
     F.liftFC(SetNClob4(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setNClob(a: Int, b: Reader, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetNClob5(a, b, c))
+  def setNClob(a: Int, b: Reader): CallableStatementIO[Unit] =
+    F.liftFC(SetNClob5(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -2169,14 +2021,14 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setObject(a: String, b: Object, c: SQLType, d: Int): CallableStatementIO[Unit] =
+  def setObject(a: String, b: Object, c: Int, d: Int): CallableStatementIO[Unit] =
     F.liftFC(SetObject(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setObject(a: String, b: Object, c: SQLType): CallableStatementIO[Unit] =
-    F.liftFC(SetObject1(a, b, c))
+  def setObject(a: String, b: Object): CallableStatementIO[Unit] =
+    F.liftFC(SetObject1(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -2187,44 +2039,20 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setObject(a: String, b: Object, c: Int, d: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetObject3(a, b, c, d))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setObject(a: String, b: Object): CallableStatementIO[Unit] =
-    F.liftFC(SetObject4(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setObject(a: Int, b: Object, c: SQLType): CallableStatementIO[Unit] =
-    F.liftFC(SetObject5(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def setObject(a: Int, b: Object, c: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetObject6(a, b, c))
+    F.liftFC(SetObject3(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setObject(a: Int, b: Object, c: Int, d: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetObject7(a, b, c, d))
+    F.liftFC(SetObject4(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setObject(a: Int, b: Object): CallableStatementIO[Unit] =
-    F.liftFC(SetObject8(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setObject(a: Int, b: Object, c: SQLType, d: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetObject9(a, b, c, d))
+    F.liftFC(SetObject5(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -2331,14 +2159,14 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setTimestamp(a: Int, b: Timestamp, c: Calendar): CallableStatementIO[Unit] =
-    F.liftFC(SetTimestamp2(a, b, c))
+  def setTimestamp(a: Int, b: Timestamp): CallableStatementIO[Unit] =
+    F.liftFC(SetTimestamp2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setTimestamp(a: Int, b: Timestamp): CallableStatementIO[Unit] =
-    F.liftFC(SetTimestamp3(a, b))
+  def setTimestamp(a: Int, b: Timestamp, c: Calendar): CallableStatementIO[Unit] =
+    F.liftFC(SetTimestamp3(a, b, c))
 
   /** 
    * @group Constructors (Primitives)

--- a/core/src/main/scala/doobie/free/callablestatement.scala
+++ b/core/src/main/scala/doobie/free/callablestatement.scala
@@ -29,6 +29,7 @@ import java.sql.RowId
 import java.sql.SQLData
 import java.sql.SQLInput
 import java.sql.SQLOutput
+import java.sql.SQLType
 import java.sql.SQLWarning
 import java.sql.SQLXML
 import java.sql.Statement
@@ -86,7 +87,11 @@ object callablestatement {
    * Sum type of primitive operations over a `java.sql.CallableStatement`.
    * @group Algebra 
    */
-  sealed trait CallableStatementOp[A]
+  sealed trait CallableStatementOp[A] {
+    protected def primitive[M[_]: Monad: Capture](f: CallableStatement => A): Kleisli[M, CallableStatement, A] = 
+      Kleisli((s: CallableStatement) => Capture[M].apply(f(s)))
+    def defaultTransK[M[_]: Monad: Catchable: Capture]: Kleisli[M, CallableStatement, A]
+  }
 
   /** 
    * Module of constructors for `CallableStatementOp`. These are rarely useful outside of the implementation;
@@ -96,233 +101,753 @@ object callablestatement {
   object CallableStatementOp {
     
     // Lifting
-    case class LiftBlobIO[A](s: Blob, action: BlobIO[A]) extends CallableStatementOp[A]
-    case class LiftClobIO[A](s: Clob, action: ClobIO[A]) extends CallableStatementOp[A]
-    case class LiftConnectionIO[A](s: Connection, action: ConnectionIO[A]) extends CallableStatementOp[A]
-    case class LiftDatabaseMetaDataIO[A](s: DatabaseMetaData, action: DatabaseMetaDataIO[A]) extends CallableStatementOp[A]
-    case class LiftDriverIO[A](s: Driver, action: DriverIO[A]) extends CallableStatementOp[A]
-    case class LiftNClobIO[A](s: NClob, action: NClobIO[A]) extends CallableStatementOp[A]
-    case class LiftPreparedStatementIO[A](s: PreparedStatement, action: PreparedStatementIO[A]) extends CallableStatementOp[A]
-    case class LiftRefIO[A](s: Ref, action: RefIO[A]) extends CallableStatementOp[A]
-    case class LiftResultSetIO[A](s: ResultSet, action: ResultSetIO[A]) extends CallableStatementOp[A]
-    case class LiftSQLDataIO[A](s: SQLData, action: SQLDataIO[A]) extends CallableStatementOp[A]
-    case class LiftSQLInputIO[A](s: SQLInput, action: SQLInputIO[A]) extends CallableStatementOp[A]
-    case class LiftSQLOutputIO[A](s: SQLOutput, action: SQLOutputIO[A]) extends CallableStatementOp[A]
-    case class LiftStatementIO[A](s: Statement, action: StatementIO[A]) extends CallableStatementOp[A]
+    case class LiftBlobIO[A](s: Blob, action: BlobIO[A]) extends CallableStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftClobIO[A](s: Clob, action: ClobIO[A]) extends CallableStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftConnectionIO[A](s: Connection, action: ConnectionIO[A]) extends CallableStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftDatabaseMetaDataIO[A](s: DatabaseMetaData, action: DatabaseMetaDataIO[A]) extends CallableStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftDriverIO[A](s: Driver, action: DriverIO[A]) extends CallableStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftNClobIO[A](s: NClob, action: NClobIO[A]) extends CallableStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftPreparedStatementIO[A](s: PreparedStatement, action: PreparedStatementIO[A]) extends CallableStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftRefIO[A](s: Ref, action: RefIO[A]) extends CallableStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftResultSetIO[A](s: ResultSet, action: ResultSetIO[A]) extends CallableStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftSQLDataIO[A](s: SQLData, action: SQLDataIO[A]) extends CallableStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftSQLInputIO[A](s: SQLInput, action: SQLInputIO[A]) extends CallableStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftSQLOutputIO[A](s: SQLOutput, action: SQLOutputIO[A]) extends CallableStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftStatementIO[A](s: Statement, action: StatementIO[A]) extends CallableStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
 
     // Combinators
-    case class Attempt[A](action: CallableStatementIO[A]) extends CallableStatementOp[Throwable \/ A]
-    case class Pure[A](a: () => A) extends CallableStatementOp[A]
+    case class Attempt[A](action: CallableStatementIO[A]) extends CallableStatementOp[Throwable \/ A] {
+      import scalaz._, Scalaz._
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = 
+        Predef.implicitly[Catchable[Kleisli[M, CallableStatement, ?]]].attempt(action.transK[M])
+    }
+    case class Pure[A](a: () => A) extends CallableStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_ => a())
+    }
+    case class Raw[A](f: CallableStatement => A) extends CallableStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(f)
+    }
 
     // Primitive Operations
-    case object AddBatch extends CallableStatementOp[Unit]
-    case class  AddBatch1(a: String) extends CallableStatementOp[Unit]
-    case object Cancel extends CallableStatementOp[Unit]
-    case object ClearBatch extends CallableStatementOp[Unit]
-    case object ClearParameters extends CallableStatementOp[Unit]
-    case object ClearWarnings extends CallableStatementOp[Unit]
-    case object Close extends CallableStatementOp[Unit]
-    case object Execute extends CallableStatementOp[Boolean]
-    case class  Execute1(a: String, b: Int) extends CallableStatementOp[Boolean]
-    case class  Execute2(a: String) extends CallableStatementOp[Boolean]
-    case class  Execute3(a: String, b: Array[Int]) extends CallableStatementOp[Boolean]
-    case class  Execute4(a: String, b: Array[String]) extends CallableStatementOp[Boolean]
-    case object ExecuteBatch extends CallableStatementOp[Array[Int]]
-    case object ExecuteQuery extends CallableStatementOp[ResultSet]
-    case class  ExecuteQuery1(a: String) extends CallableStatementOp[ResultSet]
-    case object ExecuteUpdate extends CallableStatementOp[Int]
-    case class  ExecuteUpdate1(a: String, b: Int) extends CallableStatementOp[Int]
-    case class  ExecuteUpdate2(a: String) extends CallableStatementOp[Int]
-    case class  ExecuteUpdate3(a: String, b: Array[String]) extends CallableStatementOp[Int]
-    case class  ExecuteUpdate4(a: String, b: Array[Int]) extends CallableStatementOp[Int]
-    case class  GetArray(a: String) extends CallableStatementOp[SqlArray]
-    case class  GetArray1(a: Int) extends CallableStatementOp[SqlArray]
-    case class  GetBigDecimal(a: String) extends CallableStatementOp[BigDecimal]
-    case class  GetBigDecimal1(a: Int, b: Int) extends CallableStatementOp[BigDecimal]
-    case class  GetBigDecimal2(a: Int) extends CallableStatementOp[BigDecimal]
-    case class  GetBlob(a: Int) extends CallableStatementOp[Blob]
-    case class  GetBlob1(a: String) extends CallableStatementOp[Blob]
-    case class  GetBoolean(a: String) extends CallableStatementOp[Boolean]
-    case class  GetBoolean1(a: Int) extends CallableStatementOp[Boolean]
-    case class  GetByte(a: String) extends CallableStatementOp[Byte]
-    case class  GetByte1(a: Int) extends CallableStatementOp[Byte]
-    case class  GetBytes(a: Int) extends CallableStatementOp[Array[Byte]]
-    case class  GetBytes1(a: String) extends CallableStatementOp[Array[Byte]]
-    case class  GetCharacterStream(a: Int) extends CallableStatementOp[Reader]
-    case class  GetCharacterStream1(a: String) extends CallableStatementOp[Reader]
-    case class  GetClob(a: Int) extends CallableStatementOp[Clob]
-    case class  GetClob1(a: String) extends CallableStatementOp[Clob]
-    case object GetConnection extends CallableStatementOp[Connection]
-    case class  GetDate(a: String, b: Calendar) extends CallableStatementOp[Date]
-    case class  GetDate1(a: String) extends CallableStatementOp[Date]
-    case class  GetDate2(a: Int) extends CallableStatementOp[Date]
-    case class  GetDate3(a: Int, b: Calendar) extends CallableStatementOp[Date]
-    case class  GetDouble(a: Int) extends CallableStatementOp[Double]
-    case class  GetDouble1(a: String) extends CallableStatementOp[Double]
-    case object GetFetchDirection extends CallableStatementOp[Int]
-    case object GetFetchSize extends CallableStatementOp[Int]
-    case class  GetFloat(a: String) extends CallableStatementOp[Float]
-    case class  GetFloat1(a: Int) extends CallableStatementOp[Float]
-    case object GetGeneratedKeys extends CallableStatementOp[ResultSet]
-    case class  GetInt(a: String) extends CallableStatementOp[Int]
-    case class  GetInt1(a: Int) extends CallableStatementOp[Int]
-    case class  GetLong(a: Int) extends CallableStatementOp[Long]
-    case class  GetLong1(a: String) extends CallableStatementOp[Long]
-    case object GetMaxFieldSize extends CallableStatementOp[Int]
-    case object GetMaxRows extends CallableStatementOp[Int]
-    case object GetMetaData extends CallableStatementOp[ResultSetMetaData]
-    case class  GetMoreResults(a: Int) extends CallableStatementOp[Boolean]
-    case object GetMoreResults1 extends CallableStatementOp[Boolean]
-    case class  GetNCharacterStream(a: Int) extends CallableStatementOp[Reader]
-    case class  GetNCharacterStream1(a: String) extends CallableStatementOp[Reader]
-    case class  GetNClob(a: String) extends CallableStatementOp[NClob]
-    case class  GetNClob1(a: Int) extends CallableStatementOp[NClob]
-    case class  GetNString(a: Int) extends CallableStatementOp[String]
-    case class  GetNString1(a: String) extends CallableStatementOp[String]
-    case class  GetObject(a: String) extends CallableStatementOp[Object]
-    case class  GetObject1(a: Int, b: Map[String, Class[_]]) extends CallableStatementOp[Object]
-    case class  GetObject2(a: String, b: Map[String, Class[_]]) extends CallableStatementOp[Object]
-    case class  GetObject3(a: Int) extends CallableStatementOp[Object]
-    case object GetParameterMetaData extends CallableStatementOp[ParameterMetaData]
-    case object GetQueryTimeout extends CallableStatementOp[Int]
-    case class  GetRef(a: Int) extends CallableStatementOp[Ref]
-    case class  GetRef1(a: String) extends CallableStatementOp[Ref]
-    case object GetResultSet extends CallableStatementOp[ResultSet]
-    case object GetResultSetConcurrency extends CallableStatementOp[Int]
-    case object GetResultSetHoldability extends CallableStatementOp[Int]
-    case object GetResultSetType extends CallableStatementOp[Int]
-    case class  GetRowId(a: String) extends CallableStatementOp[RowId]
-    case class  GetRowId1(a: Int) extends CallableStatementOp[RowId]
-    case class  GetSQLXML(a: Int) extends CallableStatementOp[SQLXML]
-    case class  GetSQLXML1(a: String) extends CallableStatementOp[SQLXML]
-    case class  GetShort(a: Int) extends CallableStatementOp[Short]
-    case class  GetShort1(a: String) extends CallableStatementOp[Short]
-    case class  GetString(a: String) extends CallableStatementOp[String]
-    case class  GetString1(a: Int) extends CallableStatementOp[String]
-    case class  GetTime(a: String) extends CallableStatementOp[Time]
-    case class  GetTime1(a: Int) extends CallableStatementOp[Time]
-    case class  GetTime2(a: Int, b: Calendar) extends CallableStatementOp[Time]
-    case class  GetTime3(a: String, b: Calendar) extends CallableStatementOp[Time]
-    case class  GetTimestamp(a: Int, b: Calendar) extends CallableStatementOp[Timestamp]
-    case class  GetTimestamp1(a: Int) extends CallableStatementOp[Timestamp]
-    case class  GetTimestamp2(a: String) extends CallableStatementOp[Timestamp]
-    case class  GetTimestamp3(a: String, b: Calendar) extends CallableStatementOp[Timestamp]
-    case class  GetURL(a: Int) extends CallableStatementOp[URL]
-    case class  GetURL1(a: String) extends CallableStatementOp[URL]
-    case object GetUpdateCount extends CallableStatementOp[Int]
-    case object GetWarnings extends CallableStatementOp[SQLWarning]
-    case object IsClosed extends CallableStatementOp[Boolean]
-    case object IsPoolable extends CallableStatementOp[Boolean]
-    case class  IsWrapperFor(a: Class[_]) extends CallableStatementOp[Boolean]
-    case class  RegisterOutParameter(a: Int, b: Int) extends CallableStatementOp[Unit]
-    case class  RegisterOutParameter1(a: String, b: Int, c: String) extends CallableStatementOp[Unit]
-    case class  RegisterOutParameter2(a: String, b: Int, c: Int) extends CallableStatementOp[Unit]
-    case class  RegisterOutParameter3(a: String, b: Int) extends CallableStatementOp[Unit]
-    case class  RegisterOutParameter4(a: Int, b: Int, c: String) extends CallableStatementOp[Unit]
-    case class  RegisterOutParameter5(a: Int, b: Int, c: Int) extends CallableStatementOp[Unit]
-    case class  SetArray(a: Int, b: SqlArray) extends CallableStatementOp[Unit]
-    case class  SetAsciiStream(a: String, b: InputStream) extends CallableStatementOp[Unit]
-    case class  SetAsciiStream1(a: String, b: InputStream, c: Long) extends CallableStatementOp[Unit]
-    case class  SetAsciiStream2(a: String, b: InputStream, c: Int) extends CallableStatementOp[Unit]
-    case class  SetAsciiStream3(a: Int, b: InputStream, c: Int) extends CallableStatementOp[Unit]
-    case class  SetAsciiStream4(a: Int, b: InputStream) extends CallableStatementOp[Unit]
-    case class  SetAsciiStream5(a: Int, b: InputStream, c: Long) extends CallableStatementOp[Unit]
-    case class  SetBigDecimal(a: String, b: BigDecimal) extends CallableStatementOp[Unit]
-    case class  SetBigDecimal1(a: Int, b: BigDecimal) extends CallableStatementOp[Unit]
-    case class  SetBinaryStream(a: String, b: InputStream) extends CallableStatementOp[Unit]
-    case class  SetBinaryStream1(a: String, b: InputStream, c: Int) extends CallableStatementOp[Unit]
-    case class  SetBinaryStream2(a: String, b: InputStream, c: Long) extends CallableStatementOp[Unit]
-    case class  SetBinaryStream3(a: Int, b: InputStream) extends CallableStatementOp[Unit]
-    case class  SetBinaryStream4(a: Int, b: InputStream, c: Long) extends CallableStatementOp[Unit]
-    case class  SetBinaryStream5(a: Int, b: InputStream, c: Int) extends CallableStatementOp[Unit]
-    case class  SetBlob(a: String, b: Blob) extends CallableStatementOp[Unit]
-    case class  SetBlob1(a: String, b: InputStream) extends CallableStatementOp[Unit]
-    case class  SetBlob2(a: String, b: InputStream, c: Long) extends CallableStatementOp[Unit]
-    case class  SetBlob3(a: Int, b: Blob) extends CallableStatementOp[Unit]
-    case class  SetBlob4(a: Int, b: InputStream) extends CallableStatementOp[Unit]
-    case class  SetBlob5(a: Int, b: InputStream, c: Long) extends CallableStatementOp[Unit]
-    case class  SetBoolean(a: String, b: Boolean) extends CallableStatementOp[Unit]
-    case class  SetBoolean1(a: Int, b: Boolean) extends CallableStatementOp[Unit]
-    case class  SetByte(a: String, b: Byte) extends CallableStatementOp[Unit]
-    case class  SetByte1(a: Int, b: Byte) extends CallableStatementOp[Unit]
-    case class  SetBytes(a: String, b: Array[Byte]) extends CallableStatementOp[Unit]
-    case class  SetBytes1(a: Int, b: Array[Byte]) extends CallableStatementOp[Unit]
-    case class  SetCharacterStream(a: String, b: Reader, c: Int) extends CallableStatementOp[Unit]
-    case class  SetCharacterStream1(a: String, b: Reader, c: Long) extends CallableStatementOp[Unit]
-    case class  SetCharacterStream2(a: String, b: Reader) extends CallableStatementOp[Unit]
-    case class  SetCharacterStream3(a: Int, b: Reader) extends CallableStatementOp[Unit]
-    case class  SetCharacterStream4(a: Int, b: Reader, c: Int) extends CallableStatementOp[Unit]
-    case class  SetCharacterStream5(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit]
-    case class  SetClob(a: String, b: Reader) extends CallableStatementOp[Unit]
-    case class  SetClob1(a: String, b: Clob) extends CallableStatementOp[Unit]
-    case class  SetClob2(a: String, b: Reader, c: Long) extends CallableStatementOp[Unit]
-    case class  SetClob3(a: Int, b: Clob) extends CallableStatementOp[Unit]
-    case class  SetClob4(a: Int, b: Reader) extends CallableStatementOp[Unit]
-    case class  SetClob5(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit]
-    case class  SetCursorName(a: String) extends CallableStatementOp[Unit]
-    case class  SetDate(a: String, b: Date, c: Calendar) extends CallableStatementOp[Unit]
-    case class  SetDate1(a: String, b: Date) extends CallableStatementOp[Unit]
-    case class  SetDate2(a: Int, b: Date, c: Calendar) extends CallableStatementOp[Unit]
-    case class  SetDate3(a: Int, b: Date) extends CallableStatementOp[Unit]
-    case class  SetDouble(a: String, b: Double) extends CallableStatementOp[Unit]
-    case class  SetDouble1(a: Int, b: Double) extends CallableStatementOp[Unit]
-    case class  SetEscapeProcessing(a: Boolean) extends CallableStatementOp[Unit]
-    case class  SetFetchDirection(a: Int) extends CallableStatementOp[Unit]
-    case class  SetFetchSize(a: Int) extends CallableStatementOp[Unit]
-    case class  SetFloat(a: String, b: Float) extends CallableStatementOp[Unit]
-    case class  SetFloat1(a: Int, b: Float) extends CallableStatementOp[Unit]
-    case class  SetInt(a: String, b: Int) extends CallableStatementOp[Unit]
-    case class  SetInt1(a: Int, b: Int) extends CallableStatementOp[Unit]
-    case class  SetLong(a: String, b: Long) extends CallableStatementOp[Unit]
-    case class  SetLong1(a: Int, b: Long) extends CallableStatementOp[Unit]
-    case class  SetMaxFieldSize(a: Int) extends CallableStatementOp[Unit]
-    case class  SetMaxRows(a: Int) extends CallableStatementOp[Unit]
-    case class  SetNCharacterStream(a: String, b: Reader, c: Long) extends CallableStatementOp[Unit]
-    case class  SetNCharacterStream1(a: String, b: Reader) extends CallableStatementOp[Unit]
-    case class  SetNCharacterStream2(a: Int, b: Reader) extends CallableStatementOp[Unit]
-    case class  SetNCharacterStream3(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit]
-    case class  SetNClob(a: String, b: Reader) extends CallableStatementOp[Unit]
-    case class  SetNClob1(a: String, b: NClob) extends CallableStatementOp[Unit]
-    case class  SetNClob2(a: String, b: Reader, c: Long) extends CallableStatementOp[Unit]
-    case class  SetNClob3(a: Int, b: Reader) extends CallableStatementOp[Unit]
-    case class  SetNClob4(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit]
-    case class  SetNClob5(a: Int, b: NClob) extends CallableStatementOp[Unit]
-    case class  SetNString(a: String, b: String) extends CallableStatementOp[Unit]
-    case class  SetNString1(a: Int, b: String) extends CallableStatementOp[Unit]
-    case class  SetNull(a: String, b: Int) extends CallableStatementOp[Unit]
-    case class  SetNull1(a: String, b: Int, c: String) extends CallableStatementOp[Unit]
-    case class  SetNull2(a: Int, b: Int, c: String) extends CallableStatementOp[Unit]
-    case class  SetNull3(a: Int, b: Int) extends CallableStatementOp[Unit]
-    case class  SetObject(a: String, b: Object, c: Int) extends CallableStatementOp[Unit]
-    case class  SetObject1(a: String, b: Object, c: Int, d: Int) extends CallableStatementOp[Unit]
-    case class  SetObject2(a: String, b: Object) extends CallableStatementOp[Unit]
-    case class  SetObject3(a: Int, b: Object, c: Int) extends CallableStatementOp[Unit]
-    case class  SetObject4(a: Int, b: Object) extends CallableStatementOp[Unit]
-    case class  SetObject5(a: Int, b: Object, c: Int, d: Int) extends CallableStatementOp[Unit]
-    case class  SetPoolable(a: Boolean) extends CallableStatementOp[Unit]
-    case class  SetQueryTimeout(a: Int) extends CallableStatementOp[Unit]
-    case class  SetRef(a: Int, b: Ref) extends CallableStatementOp[Unit]
-    case class  SetRowId(a: String, b: RowId) extends CallableStatementOp[Unit]
-    case class  SetRowId1(a: Int, b: RowId) extends CallableStatementOp[Unit]
-    case class  SetSQLXML(a: String, b: SQLXML) extends CallableStatementOp[Unit]
-    case class  SetSQLXML1(a: Int, b: SQLXML) extends CallableStatementOp[Unit]
-    case class  SetShort(a: String, b: Short) extends CallableStatementOp[Unit]
-    case class  SetShort1(a: Int, b: Short) extends CallableStatementOp[Unit]
-    case class  SetString(a: String, b: String) extends CallableStatementOp[Unit]
-    case class  SetString1(a: Int, b: String) extends CallableStatementOp[Unit]
-    case class  SetTime(a: String, b: Time) extends CallableStatementOp[Unit]
-    case class  SetTime1(a: String, b: Time, c: Calendar) extends CallableStatementOp[Unit]
-    case class  SetTime2(a: Int, b: Time, c: Calendar) extends CallableStatementOp[Unit]
-    case class  SetTime3(a: Int, b: Time) extends CallableStatementOp[Unit]
-    case class  SetTimestamp(a: String, b: Timestamp) extends CallableStatementOp[Unit]
-    case class  SetTimestamp1(a: String, b: Timestamp, c: Calendar) extends CallableStatementOp[Unit]
-    case class  SetTimestamp2(a: Int, b: Timestamp, c: Calendar) extends CallableStatementOp[Unit]
-    case class  SetTimestamp3(a: Int, b: Timestamp) extends CallableStatementOp[Unit]
-    case class  SetURL(a: String, b: URL) extends CallableStatementOp[Unit]
-    case class  SetURL1(a: Int, b: URL) extends CallableStatementOp[Unit]
-    case class  SetUnicodeStream(a: Int, b: InputStream, c: Int) extends CallableStatementOp[Unit]
-    case class  Unwrap[T](a: Class[T]) extends CallableStatementOp[T]
-    case object WasNull extends CallableStatementOp[Boolean]
+    case object AddBatch extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.addBatch())
+    }
+    case class  AddBatch1(a: String) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.addBatch(a))
+    }
+    case object Cancel extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.cancel())
+    }
+    case object ClearBatch extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.clearBatch())
+    }
+    case object ClearParameters extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.clearParameters())
+    }
+    case object ClearWarnings extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.clearWarnings())
+    }
+    case object Close extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.close())
+    }
+    case object CloseOnCompletion extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.closeOnCompletion())
+    }
+    case object Execute extends CallableStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute())
+    }
+    case class  Execute1(a: String) extends CallableStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a))
+    }
+    case class  Execute2(a: String, b: Array[String]) extends CallableStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
+    }
+    case class  Execute3(a: String, b: Array[Int]) extends CallableStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
+    }
+    case class  Execute4(a: String, b: Int) extends CallableStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
+    }
+    case object ExecuteBatch extends CallableStatementOp[Array[Int]] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeBatch())
+    }
+    case object ExecuteLargeBatch extends CallableStatementOp[Array[Long]] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeBatch())
+    }
+    case object ExecuteLargeUpdate extends CallableStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate())
+    }
+    case class  ExecuteLargeUpdate1(a: String, b: Array[String]) extends CallableStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
+    }
+    case class  ExecuteLargeUpdate2(a: String, b: Array[Int]) extends CallableStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
+    }
+    case class  ExecuteLargeUpdate3(a: String, b: Int) extends CallableStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
+    }
+    case class  ExecuteLargeUpdate4(a: String) extends CallableStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a))
+    }
+    case object ExecuteQuery extends CallableStatementOp[ResultSet] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeQuery())
+    }
+    case class  ExecuteQuery1(a: String) extends CallableStatementOp[ResultSet] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeQuery(a))
+    }
+    case object ExecuteUpdate extends CallableStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate())
+    }
+    case class  ExecuteUpdate1(a: String) extends CallableStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a))
+    }
+    case class  ExecuteUpdate2(a: String, b: Array[Int]) extends CallableStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
+    }
+    case class  ExecuteUpdate3(a: String, b: Int) extends CallableStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
+    }
+    case class  ExecuteUpdate4(a: String, b: Array[String]) extends CallableStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
+    }
+    case class  GetArray(a: String) extends CallableStatementOp[SqlArray] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getArray(a))
+    }
+    case class  GetArray1(a: Int) extends CallableStatementOp[SqlArray] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getArray(a))
+    }
+    case class  GetBigDecimal(a: Int) extends CallableStatementOp[BigDecimal] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a))
+    }
+    case class  GetBigDecimal1(a: String) extends CallableStatementOp[BigDecimal] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a))
+    }
+    case class  GetBigDecimal2(a: Int, b: Int) extends CallableStatementOp[BigDecimal] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a, b))
+    }
+    case class  GetBlob(a: String) extends CallableStatementOp[Blob] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBlob(a))
+    }
+    case class  GetBlob1(a: Int) extends CallableStatementOp[Blob] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBlob(a))
+    }
+    case class  GetBoolean(a: String) extends CallableStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBoolean(a))
+    }
+    case class  GetBoolean1(a: Int) extends CallableStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBoolean(a))
+    }
+    case class  GetByte(a: String) extends CallableStatementOp[Byte] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getByte(a))
+    }
+    case class  GetByte1(a: Int) extends CallableStatementOp[Byte] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getByte(a))
+    }
+    case class  GetBytes(a: String) extends CallableStatementOp[Array[Byte]] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBytes(a))
+    }
+    case class  GetBytes1(a: Int) extends CallableStatementOp[Array[Byte]] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBytes(a))
+    }
+    case class  GetCharacterStream(a: Int) extends CallableStatementOp[Reader] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getCharacterStream(a))
+    }
+    case class  GetCharacterStream1(a: String) extends CallableStatementOp[Reader] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getCharacterStream(a))
+    }
+    case class  GetClob(a: String) extends CallableStatementOp[Clob] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getClob(a))
+    }
+    case class  GetClob1(a: Int) extends CallableStatementOp[Clob] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getClob(a))
+    }
+    case object GetConnection extends CallableStatementOp[Connection] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getConnection())
+    }
+    case class  GetDate(a: Int, b: Calendar) extends CallableStatementOp[Date] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a, b))
+    }
+    case class  GetDate1(a: String, b: Calendar) extends CallableStatementOp[Date] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a, b))
+    }
+    case class  GetDate2(a: Int) extends CallableStatementOp[Date] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a))
+    }
+    case class  GetDate3(a: String) extends CallableStatementOp[Date] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a))
+    }
+    case class  GetDouble(a: Int) extends CallableStatementOp[Double] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDouble(a))
+    }
+    case class  GetDouble1(a: String) extends CallableStatementOp[Double] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDouble(a))
+    }
+    case object GetFetchDirection extends CallableStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getFetchDirection())
+    }
+    case object GetFetchSize extends CallableStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getFetchSize())
+    }
+    case class  GetFloat(a: Int) extends CallableStatementOp[Float] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getFloat(a))
+    }
+    case class  GetFloat1(a: String) extends CallableStatementOp[Float] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getFloat(a))
+    }
+    case object GetGeneratedKeys extends CallableStatementOp[ResultSet] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getGeneratedKeys())
+    }
+    case class  GetInt(a: String) extends CallableStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getInt(a))
+    }
+    case class  GetInt1(a: Int) extends CallableStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getInt(a))
+    }
+    case object GetLargeMaxRows extends CallableStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeMaxRows())
+    }
+    case object GetLargeUpdateCount extends CallableStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeUpdateCount())
+    }
+    case class  GetLong(a: Int) extends CallableStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLong(a))
+    }
+    case class  GetLong1(a: String) extends CallableStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLong(a))
+    }
+    case object GetMaxFieldSize extends CallableStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMaxFieldSize())
+    }
+    case object GetMaxRows extends CallableStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMaxRows())
+    }
+    case object GetMetaData extends CallableStatementOp[ResultSetMetaData] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMetaData())
+    }
+    case class  GetMoreResults(a: Int) extends CallableStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMoreResults(a))
+    }
+    case object GetMoreResults1 extends CallableStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMoreResults())
+    }
+    case class  GetNCharacterStream(a: Int) extends CallableStatementOp[Reader] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNCharacterStream(a))
+    }
+    case class  GetNCharacterStream1(a: String) extends CallableStatementOp[Reader] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNCharacterStream(a))
+    }
+    case class  GetNClob(a: String) extends CallableStatementOp[NClob] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNClob(a))
+    }
+    case class  GetNClob1(a: Int) extends CallableStatementOp[NClob] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNClob(a))
+    }
+    case class  GetNString(a: String) extends CallableStatementOp[String] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNString(a))
+    }
+    case class  GetNString1(a: Int) extends CallableStatementOp[String] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNString(a))
+    }
+    case class  GetObject(a: Int) extends CallableStatementOp[Object] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a))
+    }
+    case class  GetObject1(a: String, b: Map[String, Class[_]]) extends CallableStatementOp[Object] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
+    }
+    case class  GetObject2[T](a: String, b: Class[T]) extends CallableStatementOp[T] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
+    }
+    case class  GetObject3(a: Int, b: Map[String, Class[_]]) extends CallableStatementOp[Object] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
+    }
+    case class  GetObject4[T](a: Int, b: Class[T]) extends CallableStatementOp[T] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
+    }
+    case class  GetObject5(a: String) extends CallableStatementOp[Object] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a))
+    }
+    case object GetParameterMetaData extends CallableStatementOp[ParameterMetaData] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getParameterMetaData())
+    }
+    case object GetQueryTimeout extends CallableStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getQueryTimeout())
+    }
+    case class  GetRef(a: Int) extends CallableStatementOp[Ref] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getRef(a))
+    }
+    case class  GetRef1(a: String) extends CallableStatementOp[Ref] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getRef(a))
+    }
+    case object GetResultSet extends CallableStatementOp[ResultSet] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getResultSet())
+    }
+    case object GetResultSetConcurrency extends CallableStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getResultSetConcurrency())
+    }
+    case object GetResultSetHoldability extends CallableStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getResultSetHoldability())
+    }
+    case object GetResultSetType extends CallableStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getResultSetType())
+    }
+    case class  GetRowId(a: Int) extends CallableStatementOp[RowId] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getRowId(a))
+    }
+    case class  GetRowId1(a: String) extends CallableStatementOp[RowId] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getRowId(a))
+    }
+    case class  GetSQLXML(a: String) extends CallableStatementOp[SQLXML] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSQLXML(a))
+    }
+    case class  GetSQLXML1(a: Int) extends CallableStatementOp[SQLXML] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSQLXML(a))
+    }
+    case class  GetShort(a: Int) extends CallableStatementOp[Short] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getShort(a))
+    }
+    case class  GetShort1(a: String) extends CallableStatementOp[Short] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getShort(a))
+    }
+    case class  GetString(a: String) extends CallableStatementOp[String] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getString(a))
+    }
+    case class  GetString1(a: Int) extends CallableStatementOp[String] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getString(a))
+    }
+    case class  GetTime(a: String) extends CallableStatementOp[Time] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a))
+    }
+    case class  GetTime1(a: String, b: Calendar) extends CallableStatementOp[Time] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a, b))
+    }
+    case class  GetTime2(a: Int) extends CallableStatementOp[Time] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a))
+    }
+    case class  GetTime3(a: Int, b: Calendar) extends CallableStatementOp[Time] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a, b))
+    }
+    case class  GetTimestamp(a: Int, b: Calendar) extends CallableStatementOp[Timestamp] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a, b))
+    }
+    case class  GetTimestamp1(a: String) extends CallableStatementOp[Timestamp] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a))
+    }
+    case class  GetTimestamp2(a: String, b: Calendar) extends CallableStatementOp[Timestamp] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a, b))
+    }
+    case class  GetTimestamp3(a: Int) extends CallableStatementOp[Timestamp] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a))
+    }
+    case class  GetURL(a: Int) extends CallableStatementOp[URL] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getURL(a))
+    }
+    case class  GetURL1(a: String) extends CallableStatementOp[URL] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getURL(a))
+    }
+    case object GetUpdateCount extends CallableStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getUpdateCount())
+    }
+    case object GetWarnings extends CallableStatementOp[SQLWarning] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getWarnings())
+    }
+    case object IsCloseOnCompletion extends CallableStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.isCloseOnCompletion())
+    }
+    case object IsClosed extends CallableStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.isClosed())
+    }
+    case object IsPoolable extends CallableStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.isPoolable())
+    }
+    case class  IsWrapperFor(a: Class[_]) extends CallableStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.isWrapperFor(a))
+    }
+    case class  RegisterOutParameter(a: String, b: SQLType) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b))
+    }
+    case class  RegisterOutParameter1(a: Int, b: SQLType, c: String) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
+    }
+    case class  RegisterOutParameter10(a: Int, b: Int, c: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
+    }
+    case class  RegisterOutParameter11(a: Int, b: Int, c: String) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
+    }
+    case class  RegisterOutParameter2(a: String, b: SQLType, c: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
+    }
+    case class  RegisterOutParameter3(a: String, b: SQLType, c: String) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
+    }
+    case class  RegisterOutParameter4(a: Int, b: SQLType, c: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
+    }
+    case class  RegisterOutParameter5(a: Int, b: SQLType) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b))
+    }
+    case class  RegisterOutParameter6(a: String, b: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b))
+    }
+    case class  RegisterOutParameter7(a: String, b: Int, c: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
+    }
+    case class  RegisterOutParameter8(a: String, b: Int, c: String) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
+    }
+    case class  RegisterOutParameter9(a: Int, b: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b))
+    }
+    case class  SetArray(a: Int, b: SqlArray) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setArray(a, b))
+    }
+    case class  SetAsciiStream(a: String, b: InputStream, c: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
+    }
+    case class  SetAsciiStream1(a: String, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
+    }
+    case class  SetAsciiStream2(a: String, b: InputStream) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b))
+    }
+    case class  SetAsciiStream3(a: Int, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
+    }
+    case class  SetAsciiStream4(a: Int, b: InputStream) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b))
+    }
+    case class  SetAsciiStream5(a: Int, b: InputStream, c: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
+    }
+    case class  SetBigDecimal(a: String, b: BigDecimal) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBigDecimal(a, b))
+    }
+    case class  SetBigDecimal1(a: Int, b: BigDecimal) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBigDecimal(a, b))
+    }
+    case class  SetBinaryStream(a: String, b: InputStream, c: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b, c))
+    }
+    case class  SetBinaryStream1(a: String, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b, c))
+    }
+    case class  SetBinaryStream2(a: String, b: InputStream) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b))
+    }
+    case class  SetBinaryStream3(a: Int, b: InputStream) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b))
+    }
+    case class  SetBinaryStream4(a: Int, b: InputStream, c: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b, c))
+    }
+    case class  SetBinaryStream5(a: Int, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b, c))
+    }
+    case class  SetBlob(a: String, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b, c))
+    }
+    case class  SetBlob1(a: String, b: Blob) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b))
+    }
+    case class  SetBlob2(a: String, b: InputStream) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b))
+    }
+    case class  SetBlob3(a: Int, b: Blob) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b))
+    }
+    case class  SetBlob4(a: Int, b: InputStream) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b))
+    }
+    case class  SetBlob5(a: Int, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b, c))
+    }
+    case class  SetBoolean(a: String, b: Boolean) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBoolean(a, b))
+    }
+    case class  SetBoolean1(a: Int, b: Boolean) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBoolean(a, b))
+    }
+    case class  SetByte(a: String, b: Byte) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setByte(a, b))
+    }
+    case class  SetByte1(a: Int, b: Byte) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setByte(a, b))
+    }
+    case class  SetBytes(a: String, b: Array[Byte]) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBytes(a, b))
+    }
+    case class  SetBytes1(a: Int, b: Array[Byte]) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBytes(a, b))
+    }
+    case class  SetCharacterStream(a: String, b: Reader, c: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b, c))
+    }
+    case class  SetCharacterStream1(a: String, b: Reader, c: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b, c))
+    }
+    case class  SetCharacterStream2(a: String, b: Reader) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b))
+    }
+    case class  SetCharacterStream3(a: Int, b: Reader, c: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b, c))
+    }
+    case class  SetCharacterStream4(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b, c))
+    }
+    case class  SetCharacterStream5(a: Int, b: Reader) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b))
+    }
+    case class  SetClob(a: String, b: Reader, c: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b, c))
+    }
+    case class  SetClob1(a: String, b: Reader) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
+    }
+    case class  SetClob2(a: String, b: Clob) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
+    }
+    case class  SetClob3(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b, c))
+    }
+    case class  SetClob4(a: Int, b: Reader) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
+    }
+    case class  SetClob5(a: Int, b: Clob) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
+    }
+    case class  SetCursorName(a: String) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCursorName(a))
+    }
+    case class  SetDate(a: String, b: Date, c: Calendar) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b, c))
+    }
+    case class  SetDate1(a: String, b: Date) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b))
+    }
+    case class  SetDate2(a: Int, b: Date, c: Calendar) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b, c))
+    }
+    case class  SetDate3(a: Int, b: Date) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b))
+    }
+    case class  SetDouble(a: String, b: Double) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDouble(a, b))
+    }
+    case class  SetDouble1(a: Int, b: Double) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDouble(a, b))
+    }
+    case class  SetEscapeProcessing(a: Boolean) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setEscapeProcessing(a))
+    }
+    case class  SetFetchDirection(a: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setFetchDirection(a))
+    }
+    case class  SetFetchSize(a: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setFetchSize(a))
+    }
+    case class  SetFloat(a: String, b: Float) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setFloat(a, b))
+    }
+    case class  SetFloat1(a: Int, b: Float) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setFloat(a, b))
+    }
+    case class  SetInt(a: String, b: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setInt(a, b))
+    }
+    case class  SetInt1(a: Int, b: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setInt(a, b))
+    }
+    case class  SetLargeMaxRows(a: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setLargeMaxRows(a))
+    }
+    case class  SetLong(a: String, b: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setLong(a, b))
+    }
+    case class  SetLong1(a: Int, b: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setLong(a, b))
+    }
+    case class  SetMaxFieldSize(a: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setMaxFieldSize(a))
+    }
+    case class  SetMaxRows(a: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setMaxRows(a))
+    }
+    case class  SetNCharacterStream(a: String, b: Reader) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNCharacterStream(a, b))
+    }
+    case class  SetNCharacterStream1(a: String, b: Reader, c: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNCharacterStream(a, b, c))
+    }
+    case class  SetNCharacterStream2(a: Int, b: Reader) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNCharacterStream(a, b))
+    }
+    case class  SetNCharacterStream3(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNCharacterStream(a, b, c))
+    }
+    case class  SetNClob(a: String, b: NClob) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
+    }
+    case class  SetNClob1(a: String, b: Reader, c: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b, c))
+    }
+    case class  SetNClob2(a: String, b: Reader) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
+    }
+    case class  SetNClob3(a: Int, b: NClob) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
+    }
+    case class  SetNClob4(a: Int, b: Reader) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
+    }
+    case class  SetNClob5(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b, c))
+    }
+    case class  SetNString(a: String, b: String) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNString(a, b))
+    }
+    case class  SetNString1(a: Int, b: String) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNString(a, b))
+    }
+    case class  SetNull(a: String, b: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNull(a, b))
+    }
+    case class  SetNull1(a: String, b: Int, c: String) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNull(a, b, c))
+    }
+    case class  SetNull2(a: Int, b: Int, c: String) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNull(a, b, c))
+    }
+    case class  SetNull3(a: Int, b: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNull(a, b))
+    }
+    case class  SetObject(a: String, b: Object, c: SQLType, d: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
+    }
+    case class  SetObject1(a: String, b: Object, c: SQLType) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
+    }
+    case class  SetObject2(a: String, b: Object, c: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
+    }
+    case class  SetObject3(a: String, b: Object, c: Int, d: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
+    }
+    case class  SetObject4(a: String, b: Object) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b))
+    }
+    case class  SetObject5(a: Int, b: Object, c: SQLType) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
+    }
+    case class  SetObject6(a: Int, b: Object, c: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
+    }
+    case class  SetObject7(a: Int, b: Object, c: Int, d: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
+    }
+    case class  SetObject8(a: Int, b: Object) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b))
+    }
+    case class  SetObject9(a: Int, b: Object, c: SQLType, d: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
+    }
+    case class  SetPoolable(a: Boolean) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setPoolable(a))
+    }
+    case class  SetQueryTimeout(a: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setQueryTimeout(a))
+    }
+    case class  SetRef(a: Int, b: Ref) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setRef(a, b))
+    }
+    case class  SetRowId(a: String, b: RowId) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setRowId(a, b))
+    }
+    case class  SetRowId1(a: Int, b: RowId) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setRowId(a, b))
+    }
+    case class  SetSQLXML(a: String, b: SQLXML) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setSQLXML(a, b))
+    }
+    case class  SetSQLXML1(a: Int, b: SQLXML) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setSQLXML(a, b))
+    }
+    case class  SetShort(a: String, b: Short) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setShort(a, b))
+    }
+    case class  SetShort1(a: Int, b: Short) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setShort(a, b))
+    }
+    case class  SetString(a: String, b: String) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setString(a, b))
+    }
+    case class  SetString1(a: Int, b: String) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setString(a, b))
+    }
+    case class  SetTime(a: String, b: Time, c: Calendar) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTime(a, b, c))
+    }
+    case class  SetTime1(a: String, b: Time) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTime(a, b))
+    }
+    case class  SetTime2(a: Int, b: Time) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTime(a, b))
+    }
+    case class  SetTime3(a: Int, b: Time, c: Calendar) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTime(a, b, c))
+    }
+    case class  SetTimestamp(a: String, b: Timestamp) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b))
+    }
+    case class  SetTimestamp1(a: String, b: Timestamp, c: Calendar) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b, c))
+    }
+    case class  SetTimestamp2(a: Int, b: Timestamp, c: Calendar) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b, c))
+    }
+    case class  SetTimestamp3(a: Int, b: Timestamp) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b))
+    }
+    case class  SetURL(a: String, b: URL) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setURL(a, b))
+    }
+    case class  SetURL1(a: Int, b: URL) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setURL(a, b))
+    }
+    case class  SetUnicodeStream(a: Int, b: InputStream, c: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setUnicodeStream(a, b, c))
+    }
+    case class  Unwrap[T](a: Class[T]) extends CallableStatementOp[T] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.unwrap(a))
+    }
+    case object WasNull extends CallableStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.wasNull())
+    }
 
   }
   import CallableStatementOp._ // We use these immediately
@@ -452,6 +977,13 @@ object callablestatement {
   def delay[A](a: => A): CallableStatementIO[A] =
     F.liftFC(Pure(a _))
 
+  /**
+   * Backdoor for arbitrary computations on the underlying CallableStatement.
+   * @group Constructors (Lifting)
+   */
+  def raw[A](f: CallableStatement => A): CallableStatementIO[A] =
+    F.liftFC(Raw(f))
+
   /** 
    * @group Constructors (Primitives)
    */
@@ -497,20 +1029,26 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
+  val closeOnCompletion: CallableStatementIO[Unit] =
+    F.liftFC(CloseOnCompletion)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
   val execute: CallableStatementIO[Boolean] =
     F.liftFC(Execute)
 
   /** 
    * @group Constructors (Primitives)
    */
-  def execute(a: String, b: Int): CallableStatementIO[Boolean] =
-    F.liftFC(Execute1(a, b))
+  def execute(a: String): CallableStatementIO[Boolean] =
+    F.liftFC(Execute1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def execute(a: String): CallableStatementIO[Boolean] =
-    F.liftFC(Execute2(a))
+  def execute(a: String, b: Array[String]): CallableStatementIO[Boolean] =
+    F.liftFC(Execute2(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -521,7 +1059,7 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def execute(a: String, b: Array[String]): CallableStatementIO[Boolean] =
+  def execute(a: String, b: Int): CallableStatementIO[Boolean] =
     F.liftFC(Execute4(a, b))
 
   /** 
@@ -529,6 +1067,42 @@ object callablestatement {
    */
   val executeBatch: CallableStatementIO[Array[Int]] =
     F.liftFC(ExecuteBatch)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val executeLargeBatch: CallableStatementIO[Array[Long]] =
+    F.liftFC(ExecuteLargeBatch)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val executeLargeUpdate: CallableStatementIO[Long] =
+    F.liftFC(ExecuteLargeUpdate)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String, b: Array[String]): CallableStatementIO[Long] =
+    F.liftFC(ExecuteLargeUpdate1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String, b: Array[Int]): CallableStatementIO[Long] =
+    F.liftFC(ExecuteLargeUpdate2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String, b: Int): CallableStatementIO[Long] =
+    F.liftFC(ExecuteLargeUpdate3(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String): CallableStatementIO[Long] =
+    F.liftFC(ExecuteLargeUpdate4(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -551,25 +1125,25 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def executeUpdate(a: String, b: Int): CallableStatementIO[Int] =
-    F.liftFC(ExecuteUpdate1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def executeUpdate(a: String): CallableStatementIO[Int] =
-    F.liftFC(ExecuteUpdate2(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeUpdate(a: String, b: Array[String]): CallableStatementIO[Int] =
-    F.liftFC(ExecuteUpdate3(a, b))
+    F.liftFC(ExecuteUpdate1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def executeUpdate(a: String, b: Array[Int]): CallableStatementIO[Int] =
+    F.liftFC(ExecuteUpdate2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeUpdate(a: String, b: Int): CallableStatementIO[Int] =
+    F.liftFC(ExecuteUpdate3(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeUpdate(a: String, b: Array[String]): CallableStatementIO[Int] =
     F.liftFC(ExecuteUpdate4(a, b))
 
   /** 
@@ -587,31 +1161,31 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getBigDecimal(a: String): CallableStatementIO[BigDecimal] =
+  def getBigDecimal(a: Int): CallableStatementIO[BigDecimal] =
     F.liftFC(GetBigDecimal(a))
 
   /** 
    * @group Constructors (Primitives)
    */
+  def getBigDecimal(a: String): CallableStatementIO[BigDecimal] =
+    F.liftFC(GetBigDecimal1(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
   def getBigDecimal(a: Int, b: Int): CallableStatementIO[BigDecimal] =
-    F.liftFC(GetBigDecimal1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getBigDecimal(a: Int): CallableStatementIO[BigDecimal] =
-    F.liftFC(GetBigDecimal2(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getBlob(a: Int): CallableStatementIO[Blob] =
-    F.liftFC(GetBlob(a))
+    F.liftFC(GetBigDecimal2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getBlob(a: String): CallableStatementIO[Blob] =
+    F.liftFC(GetBlob(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getBlob(a: Int): CallableStatementIO[Blob] =
     F.liftFC(GetBlob1(a))
 
   /** 
@@ -641,13 +1215,13 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getBytes(a: Int): CallableStatementIO[Array[Byte]] =
+  def getBytes(a: String): CallableStatementIO[Array[Byte]] =
     F.liftFC(GetBytes(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getBytes(a: String): CallableStatementIO[Array[Byte]] =
+  def getBytes(a: Int): CallableStatementIO[Array[Byte]] =
     F.liftFC(GetBytes1(a))
 
   /** 
@@ -665,13 +1239,13 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getClob(a: Int): CallableStatementIO[Clob] =
+  def getClob(a: String): CallableStatementIO[Clob] =
     F.liftFC(GetClob(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getClob(a: String): CallableStatementIO[Clob] =
+  def getClob(a: Int): CallableStatementIO[Clob] =
     F.liftFC(GetClob1(a))
 
   /** 
@@ -683,14 +1257,14 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getDate(a: String, b: Calendar): CallableStatementIO[Date] =
+  def getDate(a: Int, b: Calendar): CallableStatementIO[Date] =
     F.liftFC(GetDate(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getDate(a: String): CallableStatementIO[Date] =
-    F.liftFC(GetDate1(a))
+  def getDate(a: String, b: Calendar): CallableStatementIO[Date] =
+    F.liftFC(GetDate1(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -701,8 +1275,8 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getDate(a: Int, b: Calendar): CallableStatementIO[Date] =
-    F.liftFC(GetDate3(a, b))
+  def getDate(a: String): CallableStatementIO[Date] =
+    F.liftFC(GetDate3(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -731,13 +1305,13 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getFloat(a: String): CallableStatementIO[Float] =
+  def getFloat(a: Int): CallableStatementIO[Float] =
     F.liftFC(GetFloat(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getFloat(a: Int): CallableStatementIO[Float] =
+  def getFloat(a: String): CallableStatementIO[Float] =
     F.liftFC(GetFloat1(a))
 
   /** 
@@ -757,6 +1331,18 @@ object callablestatement {
    */
   def getInt(a: Int): CallableStatementIO[Int] =
     F.liftFC(GetInt1(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val getLargeMaxRows: CallableStatementIO[Long] =
+    F.liftFC(GetLargeMaxRows)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val getLargeUpdateCount: CallableStatementIO[Long] =
+    F.liftFC(GetLargeUpdateCount)
 
   /** 
    * @group Constructors (Primitives)
@@ -827,38 +1413,50 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getNString(a: Int): CallableStatementIO[String] =
+  def getNString(a: String): CallableStatementIO[String] =
     F.liftFC(GetNString(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getNString(a: String): CallableStatementIO[String] =
+  def getNString(a: Int): CallableStatementIO[String] =
     F.liftFC(GetNString1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getObject(a: String): CallableStatementIO[Object] =
+  def getObject(a: Int): CallableStatementIO[Object] =
     F.liftFC(GetObject(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getObject(a: Int, b: Map[String, Class[_]]): CallableStatementIO[Object] =
+  def getObject(a: String, b: Map[String, Class[_]]): CallableStatementIO[Object] =
     F.liftFC(GetObject1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getObject(a: String, b: Map[String, Class[_]]): CallableStatementIO[Object] =
+  def getObject[T](a: String, b: Class[T]): CallableStatementIO[T] =
     F.liftFC(GetObject2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getObject(a: Int): CallableStatementIO[Object] =
-    F.liftFC(GetObject3(a))
+  def getObject(a: Int, b: Map[String, Class[_]]): CallableStatementIO[Object] =
+    F.liftFC(GetObject3(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getObject[T](a: Int, b: Class[T]): CallableStatementIO[T] =
+    F.liftFC(GetObject4(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getObject(a: String): CallableStatementIO[Object] =
+    F.liftFC(GetObject5(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -911,25 +1509,25 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getRowId(a: String): CallableStatementIO[RowId] =
+  def getRowId(a: Int): CallableStatementIO[RowId] =
     F.liftFC(GetRowId(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getRowId(a: Int): CallableStatementIO[RowId] =
+  def getRowId(a: String): CallableStatementIO[RowId] =
     F.liftFC(GetRowId1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getSQLXML(a: Int): CallableStatementIO[SQLXML] =
+  def getSQLXML(a: String): CallableStatementIO[SQLXML] =
     F.liftFC(GetSQLXML(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getSQLXML(a: String): CallableStatementIO[SQLXML] =
+  def getSQLXML(a: Int): CallableStatementIO[SQLXML] =
     F.liftFC(GetSQLXML1(a))
 
   /** 
@@ -965,19 +1563,19 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
+  def getTime(a: String, b: Calendar): CallableStatementIO[Time] =
+    F.liftFC(GetTime1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
   def getTime(a: Int): CallableStatementIO[Time] =
-    F.liftFC(GetTime1(a))
+    F.liftFC(GetTime2(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getTime(a: Int, b: Calendar): CallableStatementIO[Time] =
-    F.liftFC(GetTime2(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getTime(a: String, b: Calendar): CallableStatementIO[Time] =
     F.liftFC(GetTime3(a, b))
 
   /** 
@@ -989,20 +1587,20 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getTimestamp(a: Int): CallableStatementIO[Timestamp] =
+  def getTimestamp(a: String): CallableStatementIO[Timestamp] =
     F.liftFC(GetTimestamp1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getTimestamp(a: String): CallableStatementIO[Timestamp] =
-    F.liftFC(GetTimestamp2(a))
+  def getTimestamp(a: String, b: Calendar): CallableStatementIO[Timestamp] =
+    F.liftFC(GetTimestamp2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getTimestamp(a: String, b: Calendar): CallableStatementIO[Timestamp] =
-    F.liftFC(GetTimestamp3(a, b))
+  def getTimestamp(a: Int): CallableStatementIO[Timestamp] =
+    F.liftFC(GetTimestamp3(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -1031,6 +1629,12 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
+  val isCloseOnCompletion: CallableStatementIO[Boolean] =
+    F.liftFC(IsCloseOnCompletion)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
   val isClosed: CallableStatementIO[Boolean] =
     F.liftFC(IsClosed)
 
@@ -1049,38 +1653,74 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def registerOutParameter(a: Int, b: Int): CallableStatementIO[Unit] =
+  def registerOutParameter(a: String, b: SQLType): CallableStatementIO[Unit] =
     F.liftFC(RegisterOutParameter(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def registerOutParameter(a: String, b: Int, c: String): CallableStatementIO[Unit] =
+  def registerOutParameter(a: Int, b: SQLType, c: String): CallableStatementIO[Unit] =
     F.liftFC(RegisterOutParameter1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def registerOutParameter(a: String, b: Int, c: Int): CallableStatementIO[Unit] =
-    F.liftFC(RegisterOutParameter2(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def registerOutParameter(a: String, b: Int): CallableStatementIO[Unit] =
-    F.liftFC(RegisterOutParameter3(a, b))
+  def registerOutParameter(a: Int, b: Int, c: Int): CallableStatementIO[Unit] =
+    F.liftFC(RegisterOutParameter10(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def registerOutParameter(a: Int, b: Int, c: String): CallableStatementIO[Unit] =
+    F.liftFC(RegisterOutParameter11(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def registerOutParameter(a: String, b: SQLType, c: Int): CallableStatementIO[Unit] =
+    F.liftFC(RegisterOutParameter2(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def registerOutParameter(a: String, b: SQLType, c: String): CallableStatementIO[Unit] =
+    F.liftFC(RegisterOutParameter3(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def registerOutParameter(a: Int, b: SQLType, c: Int): CallableStatementIO[Unit] =
     F.liftFC(RegisterOutParameter4(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def registerOutParameter(a: Int, b: Int, c: Int): CallableStatementIO[Unit] =
-    F.liftFC(RegisterOutParameter5(a, b, c))
+  def registerOutParameter(a: Int, b: SQLType): CallableStatementIO[Unit] =
+    F.liftFC(RegisterOutParameter5(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def registerOutParameter(a: String, b: Int): CallableStatementIO[Unit] =
+    F.liftFC(RegisterOutParameter6(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def registerOutParameter(a: String, b: Int, c: Int): CallableStatementIO[Unit] =
+    F.liftFC(RegisterOutParameter7(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def registerOutParameter(a: String, b: Int, c: String): CallableStatementIO[Unit] =
+    F.liftFC(RegisterOutParameter8(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def registerOutParameter(a: Int, b: Int): CallableStatementIO[Unit] =
+    F.liftFC(RegisterOutParameter9(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1091,8 +1731,8 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setAsciiStream(a: String, b: InputStream): CallableStatementIO[Unit] =
-    F.liftFC(SetAsciiStream(a, b))
+  def setAsciiStream(a: String, b: InputStream, c: Int): CallableStatementIO[Unit] =
+    F.liftFC(SetAsciiStream(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -1103,13 +1743,13 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setAsciiStream(a: String, b: InputStream, c: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetAsciiStream2(a, b, c))
+  def setAsciiStream(a: String, b: InputStream): CallableStatementIO[Unit] =
+    F.liftFC(SetAsciiStream2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setAsciiStream(a: Int, b: InputStream, c: Int): CallableStatementIO[Unit] =
+  def setAsciiStream(a: Int, b: InputStream, c: Long): CallableStatementIO[Unit] =
     F.liftFC(SetAsciiStream3(a, b, c))
 
   /** 
@@ -1121,7 +1761,7 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setAsciiStream(a: Int, b: InputStream, c: Long): CallableStatementIO[Unit] =
+  def setAsciiStream(a: Int, b: InputStream, c: Int): CallableStatementIO[Unit] =
     F.liftFC(SetAsciiStream5(a, b, c))
 
   /** 
@@ -1139,20 +1779,20 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setBinaryStream(a: String, b: InputStream): CallableStatementIO[Unit] =
-    F.liftFC(SetBinaryStream(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def setBinaryStream(a: String, b: InputStream, c: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetBinaryStream1(a, b, c))
+    F.liftFC(SetBinaryStream(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBinaryStream(a: String, b: InputStream, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetBinaryStream2(a, b, c))
+    F.liftFC(SetBinaryStream1(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setBinaryStream(a: String, b: InputStream): CallableStatementIO[Unit] =
+    F.liftFC(SetBinaryStream2(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1163,32 +1803,32 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setBinaryStream(a: Int, b: InputStream, c: Long): CallableStatementIO[Unit] =
+  def setBinaryStream(a: Int, b: InputStream, c: Int): CallableStatementIO[Unit] =
     F.liftFC(SetBinaryStream4(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setBinaryStream(a: Int, b: InputStream, c: Int): CallableStatementIO[Unit] =
+  def setBinaryStream(a: Int, b: InputStream, c: Long): CallableStatementIO[Unit] =
     F.liftFC(SetBinaryStream5(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setBlob(a: String, b: Blob): CallableStatementIO[Unit] =
-    F.liftFC(SetBlob(a, b))
+  def setBlob(a: String, b: InputStream, c: Long): CallableStatementIO[Unit] =
+    F.liftFC(SetBlob(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setBlob(a: String, b: InputStream): CallableStatementIO[Unit] =
+  def setBlob(a: String, b: Blob): CallableStatementIO[Unit] =
     F.liftFC(SetBlob1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setBlob(a: String, b: InputStream, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetBlob2(a, b, c))
+  def setBlob(a: String, b: InputStream): CallableStatementIO[Unit] =
+    F.liftFC(SetBlob2(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1247,13 +1887,13 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setCharacterStream(a: String, b: Reader, c: Int): CallableStatementIO[Unit] =
+  def setCharacterStream(a: String, b: Reader, c: Long): CallableStatementIO[Unit] =
     F.liftFC(SetCharacterStream(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setCharacterStream(a: String, b: Reader, c: Long): CallableStatementIO[Unit] =
+  def setCharacterStream(a: String, b: Reader, c: Int): CallableStatementIO[Unit] =
     F.liftFC(SetCharacterStream1(a, b, c))
 
   /** 
@@ -1265,44 +1905,44 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setCharacterStream(a: Int, b: Reader): CallableStatementIO[Unit] =
-    F.liftFC(SetCharacterStream3(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def setCharacterStream(a: Int, b: Reader, c: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetCharacterStream4(a, b, c))
+    F.liftFC(SetCharacterStream3(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setCharacterStream(a: Int, b: Reader, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetCharacterStream5(a, b, c))
+    F.liftFC(SetCharacterStream4(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setClob(a: String, b: Reader): CallableStatementIO[Unit] =
-    F.liftFC(SetClob(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setClob(a: String, b: Clob): CallableStatementIO[Unit] =
-    F.liftFC(SetClob1(a, b))
+  def setCharacterStream(a: Int, b: Reader): CallableStatementIO[Unit] =
+    F.liftFC(SetCharacterStream5(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setClob(a: String, b: Reader, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetClob2(a, b, c))
+    F.liftFC(SetClob(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setClob(a: Int, b: Clob): CallableStatementIO[Unit] =
-    F.liftFC(SetClob3(a, b))
+  def setClob(a: String, b: Reader): CallableStatementIO[Unit] =
+    F.liftFC(SetClob1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setClob(a: String, b: Clob): CallableStatementIO[Unit] =
+    F.liftFC(SetClob2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setClob(a: Int, b: Reader, c: Long): CallableStatementIO[Unit] =
+    F.liftFC(SetClob3(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -1313,8 +1953,8 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setClob(a: Int, b: Reader, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetClob5(a, b, c))
+  def setClob(a: Int, b: Clob): CallableStatementIO[Unit] =
+    F.liftFC(SetClob5(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1403,6 +2043,12 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
+  def setLargeMaxRows(a: Long): CallableStatementIO[Unit] =
+    F.liftFC(SetLargeMaxRows(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
   def setLong(a: String, b: Long): CallableStatementIO[Unit] =
     F.liftFC(SetLong(a, b))
 
@@ -1427,14 +2073,14 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setNCharacterStream(a: String, b: Reader, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetNCharacterStream(a, b, c))
+  def setNCharacterStream(a: String, b: Reader): CallableStatementIO[Unit] =
+    F.liftFC(SetNCharacterStream(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setNCharacterStream(a: String, b: Reader): CallableStatementIO[Unit] =
-    F.liftFC(SetNCharacterStream1(a, b))
+  def setNCharacterStream(a: String, b: Reader, c: Long): CallableStatementIO[Unit] =
+    F.liftFC(SetNCharacterStream1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -1451,38 +2097,38 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setNClob(a: String, b: Reader): CallableStatementIO[Unit] =
+  def setNClob(a: String, b: NClob): CallableStatementIO[Unit] =
     F.liftFC(SetNClob(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setNClob(a: String, b: NClob): CallableStatementIO[Unit] =
-    F.liftFC(SetNClob1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def setNClob(a: String, b: Reader, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetNClob2(a, b, c))
+    F.liftFC(SetNClob1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setNClob(a: Int, b: Reader): CallableStatementIO[Unit] =
-    F.liftFC(SetNClob3(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setNClob(a: Int, b: Reader, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetNClob4(a, b, c))
+  def setNClob(a: String, b: Reader): CallableStatementIO[Unit] =
+    F.liftFC(SetNClob2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNClob(a: Int, b: NClob): CallableStatementIO[Unit] =
-    F.liftFC(SetNClob5(a, b))
+    F.liftFC(SetNClob3(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setNClob(a: Int, b: Reader): CallableStatementIO[Unit] =
+    F.liftFC(SetNClob4(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setNClob(a: Int, b: Reader, c: Long): CallableStatementIO[Unit] =
+    F.liftFC(SetNClob5(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -1523,38 +2169,62 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
+  def setObject(a: String, b: Object, c: SQLType, d: Int): CallableStatementIO[Unit] =
+    F.liftFC(SetObject(a, b, c, d))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setObject(a: String, b: Object, c: SQLType): CallableStatementIO[Unit] =
+    F.liftFC(SetObject1(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
   def setObject(a: String, b: Object, c: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetObject(a, b, c))
+    F.liftFC(SetObject2(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setObject(a: String, b: Object, c: Int, d: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetObject1(a, b, c, d))
+    F.liftFC(SetObject3(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setObject(a: String, b: Object): CallableStatementIO[Unit] =
-    F.liftFC(SetObject2(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setObject(a: Int, b: Object, c: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetObject3(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setObject(a: Int, b: Object): CallableStatementIO[Unit] =
     F.liftFC(SetObject4(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
+  def setObject(a: Int, b: Object, c: SQLType): CallableStatementIO[Unit] =
+    F.liftFC(SetObject5(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setObject(a: Int, b: Object, c: Int): CallableStatementIO[Unit] =
+    F.liftFC(SetObject6(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
   def setObject(a: Int, b: Object, c: Int, d: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetObject5(a, b, c, d))
+    F.liftFC(SetObject7(a, b, c, d))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setObject(a: Int, b: Object): CallableStatementIO[Unit] =
+    F.liftFC(SetObject8(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setObject(a: Int, b: Object, c: SQLType, d: Int): CallableStatementIO[Unit] =
+    F.liftFC(SetObject9(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
@@ -1625,26 +2295,26 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setTime(a: String, b: Time): CallableStatementIO[Unit] =
-    F.liftFC(SetTime(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def setTime(a: String, b: Time, c: Calendar): CallableStatementIO[Unit] =
-    F.liftFC(SetTime1(a, b, c))
+    F.liftFC(SetTime(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setTime(a: Int, b: Time, c: Calendar): CallableStatementIO[Unit] =
-    F.liftFC(SetTime2(a, b, c))
+  def setTime(a: String, b: Time): CallableStatementIO[Unit] =
+    F.liftFC(SetTime1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setTime(a: Int, b: Time): CallableStatementIO[Unit] =
-    F.liftFC(SetTime3(a, b))
+    F.liftFC(SetTime2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setTime(a: Int, b: Time, c: Calendar): CallableStatementIO[Unit] =
+    F.liftFC(SetTime3(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -1704,249 +2374,10 @@ object callablestatement {
   * Natural transformation from `CallableStatementOp` to `Kleisli` for the given `M`, consuming a `java.sql.CallableStatement`. 
   * @group Algebra
   */
- def kleisliTrans[M[_]: Monad: Catchable: Capture]: CallableStatementOp ~> ({type l[a] = Kleisli[M, CallableStatement, a]})#l =
-   new (CallableStatementOp ~> ({type l[a] = Kleisli[M, CallableStatement, a]})#l) {
-     import scalaz.syntax.catchable._
-
-     val L = Predef.implicitly[Capture[M]]
-
-     def primitive[A](f: CallableStatement => A): Kleisli[M, CallableStatement, A] =
-       Kleisli(s => L.apply(f(s)))
-
-     def apply[A](op: CallableStatementOp[A]): Kleisli[M, CallableStatement, A] = 
-       op match {
-
-        // Lifting
-        case LiftBlobIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftClobIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftConnectionIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftDatabaseMetaDataIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftDriverIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftNClobIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftPreparedStatementIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftRefIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftResultSetIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftSQLDataIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftSQLInputIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftSQLOutputIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftStatementIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-  
-        // Combinators
-        case Pure(a) => primitive(_ => a())
-        case Attempt(a) => a.transK[M].attempt
-  
-        // Primitive Operations
-        case AddBatch => primitive(_.addBatch)
-        case AddBatch1(a) => primitive(_.addBatch(a))
-        case Cancel => primitive(_.cancel)
-        case ClearBatch => primitive(_.clearBatch)
-        case ClearParameters => primitive(_.clearParameters)
-        case ClearWarnings => primitive(_.clearWarnings)
-        case Close => primitive(_.close)
-        case Execute => primitive(_.execute)
-        case Execute1(a, b) => primitive(_.execute(a, b))
-        case Execute2(a) => primitive(_.execute(a))
-        case Execute3(a, b) => primitive(_.execute(a, b))
-        case Execute4(a, b) => primitive(_.execute(a, b))
-        case ExecuteBatch => primitive(_.executeBatch)
-        case ExecuteQuery => primitive(_.executeQuery)
-        case ExecuteQuery1(a) => primitive(_.executeQuery(a))
-        case ExecuteUpdate => primitive(_.executeUpdate)
-        case ExecuteUpdate1(a, b) => primitive(_.executeUpdate(a, b))
-        case ExecuteUpdate2(a) => primitive(_.executeUpdate(a))
-        case ExecuteUpdate3(a, b) => primitive(_.executeUpdate(a, b))
-        case ExecuteUpdate4(a, b) => primitive(_.executeUpdate(a, b))
-        case GetArray(a) => primitive(_.getArray(a))
-        case GetArray1(a) => primitive(_.getArray(a))
-        case GetBigDecimal(a) => primitive(_.getBigDecimal(a))
-        case GetBigDecimal1(a, b) => primitive(_.getBigDecimal(a, b))
-        case GetBigDecimal2(a) => primitive(_.getBigDecimal(a))
-        case GetBlob(a) => primitive(_.getBlob(a))
-        case GetBlob1(a) => primitive(_.getBlob(a))
-        case GetBoolean(a) => primitive(_.getBoolean(a))
-        case GetBoolean1(a) => primitive(_.getBoolean(a))
-        case GetByte(a) => primitive(_.getByte(a))
-        case GetByte1(a) => primitive(_.getByte(a))
-        case GetBytes(a) => primitive(_.getBytes(a))
-        case GetBytes1(a) => primitive(_.getBytes(a))
-        case GetCharacterStream(a) => primitive(_.getCharacterStream(a))
-        case GetCharacterStream1(a) => primitive(_.getCharacterStream(a))
-        case GetClob(a) => primitive(_.getClob(a))
-        case GetClob1(a) => primitive(_.getClob(a))
-        case GetConnection => primitive(_.getConnection)
-        case GetDate(a, b) => primitive(_.getDate(a, b))
-        case GetDate1(a) => primitive(_.getDate(a))
-        case GetDate2(a) => primitive(_.getDate(a))
-        case GetDate3(a, b) => primitive(_.getDate(a, b))
-        case GetDouble(a) => primitive(_.getDouble(a))
-        case GetDouble1(a) => primitive(_.getDouble(a))
-        case GetFetchDirection => primitive(_.getFetchDirection)
-        case GetFetchSize => primitive(_.getFetchSize)
-        case GetFloat(a) => primitive(_.getFloat(a))
-        case GetFloat1(a) => primitive(_.getFloat(a))
-        case GetGeneratedKeys => primitive(_.getGeneratedKeys)
-        case GetInt(a) => primitive(_.getInt(a))
-        case GetInt1(a) => primitive(_.getInt(a))
-        case GetLong(a) => primitive(_.getLong(a))
-        case GetLong1(a) => primitive(_.getLong(a))
-        case GetMaxFieldSize => primitive(_.getMaxFieldSize)
-        case GetMaxRows => primitive(_.getMaxRows)
-        case GetMetaData => primitive(_.getMetaData)
-        case GetMoreResults(a) => primitive(_.getMoreResults(a))
-        case GetMoreResults1 => primitive(_.getMoreResults)
-        case GetNCharacterStream(a) => primitive(_.getNCharacterStream(a))
-        case GetNCharacterStream1(a) => primitive(_.getNCharacterStream(a))
-        case GetNClob(a) => primitive(_.getNClob(a))
-        case GetNClob1(a) => primitive(_.getNClob(a))
-        case GetNString(a) => primitive(_.getNString(a))
-        case GetNString1(a) => primitive(_.getNString(a))
-        case GetObject(a) => primitive(_.getObject(a))
-        case GetObject1(a, b) => primitive(_.getObject(a, b))
-        case GetObject2(a, b) => primitive(_.getObject(a, b))
-        case GetObject3(a) => primitive(_.getObject(a))
-        case GetParameterMetaData => primitive(_.getParameterMetaData)
-        case GetQueryTimeout => primitive(_.getQueryTimeout)
-        case GetRef(a) => primitive(_.getRef(a))
-        case GetRef1(a) => primitive(_.getRef(a))
-        case GetResultSet => primitive(_.getResultSet)
-        case GetResultSetConcurrency => primitive(_.getResultSetConcurrency)
-        case GetResultSetHoldability => primitive(_.getResultSetHoldability)
-        case GetResultSetType => primitive(_.getResultSetType)
-        case GetRowId(a) => primitive(_.getRowId(a))
-        case GetRowId1(a) => primitive(_.getRowId(a))
-        case GetSQLXML(a) => primitive(_.getSQLXML(a))
-        case GetSQLXML1(a) => primitive(_.getSQLXML(a))
-        case GetShort(a) => primitive(_.getShort(a))
-        case GetShort1(a) => primitive(_.getShort(a))
-        case GetString(a) => primitive(_.getString(a))
-        case GetString1(a) => primitive(_.getString(a))
-        case GetTime(a) => primitive(_.getTime(a))
-        case GetTime1(a) => primitive(_.getTime(a))
-        case GetTime2(a, b) => primitive(_.getTime(a, b))
-        case GetTime3(a, b) => primitive(_.getTime(a, b))
-        case GetTimestamp(a, b) => primitive(_.getTimestamp(a, b))
-        case GetTimestamp1(a) => primitive(_.getTimestamp(a))
-        case GetTimestamp2(a) => primitive(_.getTimestamp(a))
-        case GetTimestamp3(a, b) => primitive(_.getTimestamp(a, b))
-        case GetURL(a) => primitive(_.getURL(a))
-        case GetURL1(a) => primitive(_.getURL(a))
-        case GetUpdateCount => primitive(_.getUpdateCount)
-        case GetWarnings => primitive(_.getWarnings)
-        case IsClosed => primitive(_.isClosed)
-        case IsPoolable => primitive(_.isPoolable)
-        case IsWrapperFor(a) => primitive(_.isWrapperFor(a))
-        case RegisterOutParameter(a, b) => primitive(_.registerOutParameter(a, b))
-        case RegisterOutParameter1(a, b, c) => primitive(_.registerOutParameter(a, b, c))
-        case RegisterOutParameter2(a, b, c) => primitive(_.registerOutParameter(a, b, c))
-        case RegisterOutParameter3(a, b) => primitive(_.registerOutParameter(a, b))
-        case RegisterOutParameter4(a, b, c) => primitive(_.registerOutParameter(a, b, c))
-        case RegisterOutParameter5(a, b, c) => primitive(_.registerOutParameter(a, b, c))
-        case SetArray(a, b) => primitive(_.setArray(a, b))
-        case SetAsciiStream(a, b) => primitive(_.setAsciiStream(a, b))
-        case SetAsciiStream1(a, b, c) => primitive(_.setAsciiStream(a, b, c))
-        case SetAsciiStream2(a, b, c) => primitive(_.setAsciiStream(a, b, c))
-        case SetAsciiStream3(a, b, c) => primitive(_.setAsciiStream(a, b, c))
-        case SetAsciiStream4(a, b) => primitive(_.setAsciiStream(a, b))
-        case SetAsciiStream5(a, b, c) => primitive(_.setAsciiStream(a, b, c))
-        case SetBigDecimal(a, b) => primitive(_.setBigDecimal(a, b))
-        case SetBigDecimal1(a, b) => primitive(_.setBigDecimal(a, b))
-        case SetBinaryStream(a, b) => primitive(_.setBinaryStream(a, b))
-        case SetBinaryStream1(a, b, c) => primitive(_.setBinaryStream(a, b, c))
-        case SetBinaryStream2(a, b, c) => primitive(_.setBinaryStream(a, b, c))
-        case SetBinaryStream3(a, b) => primitive(_.setBinaryStream(a, b))
-        case SetBinaryStream4(a, b, c) => primitive(_.setBinaryStream(a, b, c))
-        case SetBinaryStream5(a, b, c) => primitive(_.setBinaryStream(a, b, c))
-        case SetBlob(a, b) => primitive(_.setBlob(a, b))
-        case SetBlob1(a, b) => primitive(_.setBlob(a, b))
-        case SetBlob2(a, b, c) => primitive(_.setBlob(a, b, c))
-        case SetBlob3(a, b) => primitive(_.setBlob(a, b))
-        case SetBlob4(a, b) => primitive(_.setBlob(a, b))
-        case SetBlob5(a, b, c) => primitive(_.setBlob(a, b, c))
-        case SetBoolean(a, b) => primitive(_.setBoolean(a, b))
-        case SetBoolean1(a, b) => primitive(_.setBoolean(a, b))
-        case SetByte(a, b) => primitive(_.setByte(a, b))
-        case SetByte1(a, b) => primitive(_.setByte(a, b))
-        case SetBytes(a, b) => primitive(_.setBytes(a, b))
-        case SetBytes1(a, b) => primitive(_.setBytes(a, b))
-        case SetCharacterStream(a, b, c) => primitive(_.setCharacterStream(a, b, c))
-        case SetCharacterStream1(a, b, c) => primitive(_.setCharacterStream(a, b, c))
-        case SetCharacterStream2(a, b) => primitive(_.setCharacterStream(a, b))
-        case SetCharacterStream3(a, b) => primitive(_.setCharacterStream(a, b))
-        case SetCharacterStream4(a, b, c) => primitive(_.setCharacterStream(a, b, c))
-        case SetCharacterStream5(a, b, c) => primitive(_.setCharacterStream(a, b, c))
-        case SetClob(a, b) => primitive(_.setClob(a, b))
-        case SetClob1(a, b) => primitive(_.setClob(a, b))
-        case SetClob2(a, b, c) => primitive(_.setClob(a, b, c))
-        case SetClob3(a, b) => primitive(_.setClob(a, b))
-        case SetClob4(a, b) => primitive(_.setClob(a, b))
-        case SetClob5(a, b, c) => primitive(_.setClob(a, b, c))
-        case SetCursorName(a) => primitive(_.setCursorName(a))
-        case SetDate(a, b, c) => primitive(_.setDate(a, b, c))
-        case SetDate1(a, b) => primitive(_.setDate(a, b))
-        case SetDate2(a, b, c) => primitive(_.setDate(a, b, c))
-        case SetDate3(a, b) => primitive(_.setDate(a, b))
-        case SetDouble(a, b) => primitive(_.setDouble(a, b))
-        case SetDouble1(a, b) => primitive(_.setDouble(a, b))
-        case SetEscapeProcessing(a) => primitive(_.setEscapeProcessing(a))
-        case SetFetchDirection(a) => primitive(_.setFetchDirection(a))
-        case SetFetchSize(a) => primitive(_.setFetchSize(a))
-        case SetFloat(a, b) => primitive(_.setFloat(a, b))
-        case SetFloat1(a, b) => primitive(_.setFloat(a, b))
-        case SetInt(a, b) => primitive(_.setInt(a, b))
-        case SetInt1(a, b) => primitive(_.setInt(a, b))
-        case SetLong(a, b) => primitive(_.setLong(a, b))
-        case SetLong1(a, b) => primitive(_.setLong(a, b))
-        case SetMaxFieldSize(a) => primitive(_.setMaxFieldSize(a))
-        case SetMaxRows(a) => primitive(_.setMaxRows(a))
-        case SetNCharacterStream(a, b, c) => primitive(_.setNCharacterStream(a, b, c))
-        case SetNCharacterStream1(a, b) => primitive(_.setNCharacterStream(a, b))
-        case SetNCharacterStream2(a, b) => primitive(_.setNCharacterStream(a, b))
-        case SetNCharacterStream3(a, b, c) => primitive(_.setNCharacterStream(a, b, c))
-        case SetNClob(a, b) => primitive(_.setNClob(a, b))
-        case SetNClob1(a, b) => primitive(_.setNClob(a, b))
-        case SetNClob2(a, b, c) => primitive(_.setNClob(a, b, c))
-        case SetNClob3(a, b) => primitive(_.setNClob(a, b))
-        case SetNClob4(a, b, c) => primitive(_.setNClob(a, b, c))
-        case SetNClob5(a, b) => primitive(_.setNClob(a, b))
-        case SetNString(a, b) => primitive(_.setNString(a, b))
-        case SetNString1(a, b) => primitive(_.setNString(a, b))
-        case SetNull(a, b) => primitive(_.setNull(a, b))
-        case SetNull1(a, b, c) => primitive(_.setNull(a, b, c))
-        case SetNull2(a, b, c) => primitive(_.setNull(a, b, c))
-        case SetNull3(a, b) => primitive(_.setNull(a, b))
-        case SetObject(a, b, c) => primitive(_.setObject(a, b, c))
-        case SetObject1(a, b, c, d) => primitive(_.setObject(a, b, c, d))
-        case SetObject2(a, b) => primitive(_.setObject(a, b))
-        case SetObject3(a, b, c) => primitive(_.setObject(a, b, c))
-        case SetObject4(a, b) => primitive(_.setObject(a, b))
-        case SetObject5(a, b, c, d) => primitive(_.setObject(a, b, c, d))
-        case SetPoolable(a) => primitive(_.setPoolable(a))
-        case SetQueryTimeout(a) => primitive(_.setQueryTimeout(a))
-        case SetRef(a, b) => primitive(_.setRef(a, b))
-        case SetRowId(a, b) => primitive(_.setRowId(a, b))
-        case SetRowId1(a, b) => primitive(_.setRowId(a, b))
-        case SetSQLXML(a, b) => primitive(_.setSQLXML(a, b))
-        case SetSQLXML1(a, b) => primitive(_.setSQLXML(a, b))
-        case SetShort(a, b) => primitive(_.setShort(a, b))
-        case SetShort1(a, b) => primitive(_.setShort(a, b))
-        case SetString(a, b) => primitive(_.setString(a, b))
-        case SetString1(a, b) => primitive(_.setString(a, b))
-        case SetTime(a, b) => primitive(_.setTime(a, b))
-        case SetTime1(a, b, c) => primitive(_.setTime(a, b, c))
-        case SetTime2(a, b, c) => primitive(_.setTime(a, b, c))
-        case SetTime3(a, b) => primitive(_.setTime(a, b))
-        case SetTimestamp(a, b) => primitive(_.setTimestamp(a, b))
-        case SetTimestamp1(a, b, c) => primitive(_.setTimestamp(a, b, c))
-        case SetTimestamp2(a, b, c) => primitive(_.setTimestamp(a, b, c))
-        case SetTimestamp3(a, b) => primitive(_.setTimestamp(a, b))
-        case SetURL(a, b) => primitive(_.setURL(a, b))
-        case SetURL1(a, b) => primitive(_.setURL(a, b))
-        case SetUnicodeStream(a, b, c) => primitive(_.setUnicodeStream(a, b, c))
-        case Unwrap(a) => primitive(_.unwrap(a))
-        case WasNull => primitive(_.wasNull)
-  
-      }
-  
+  def kleisliTrans[M[_]: Monad: Catchable: Capture]: CallableStatementOp ~> Kleisli[M, CallableStatement, ?] =
+    new (CallableStatementOp ~> Kleisli[M, CallableStatement, ?]) {
+      def apply[A](op: CallableStatementOp[A]): Kleisli[M, CallableStatement, A] =
+        op.defaultTransK[M]
     }
 
   /**
@@ -1955,7 +2386,7 @@ object callablestatement {
    */
   implicit class CallableStatementIOOps[A](ma: CallableStatementIO[A]) {
     def transK[M[_]: Monad: Catchable: Capture]: Kleisli[M, CallableStatement, A] =
-      F.runFC[CallableStatementOp,({type l[a]=Kleisli[M,CallableStatement,a]})#l,A](ma)(kleisliTrans[M])
+      F.runFC[CallableStatementOp, Kleisli[M, CallableStatement, ?], A](ma)(kleisliTrans[M])
   }
 
 }

--- a/core/src/main/scala/doobie/free/connection.scala
+++ b/core/src/main/scala/doobie/free/connection.scala
@@ -174,11 +174,11 @@ object connection {
     case object CreateSQLXML extends ConnectionOp[SQLXML] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.createSQLXML())
     }
-    case class  CreateStatement(a: Int, b: Int) extends ConnectionOp[Statement] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.createStatement(a, b))
-    }
-    case object CreateStatement1 extends ConnectionOp[Statement] {
+    case object CreateStatement extends ConnectionOp[Statement] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.createStatement())
+    }
+    case class  CreateStatement1(a: Int, b: Int) extends ConnectionOp[Statement] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.createStatement(a, b))
     }
     case class  CreateStatement2(a: Int, b: Int, c: Int) extends ConnectionOp[Statement] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.createStatement(a, b, c))
@@ -237,11 +237,11 @@ object connection {
     case class  PrepareCall(a: String, b: Int, c: Int) extends ConnectionOp[CallableStatement] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareCall(a, b, c))
     }
-    case class  PrepareCall1(a: String, b: Int, c: Int, d: Int) extends ConnectionOp[CallableStatement] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareCall(a, b, c, d))
-    }
-    case class  PrepareCall2(a: String) extends ConnectionOp[CallableStatement] {
+    case class  PrepareCall1(a: String) extends ConnectionOp[CallableStatement] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareCall(a))
+    }
+    case class  PrepareCall2(a: String, b: Int, c: Int, d: Int) extends ConnectionOp[CallableStatement] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareCall(a, b, c, d))
     }
     case class  PrepareStatement(a: String, b: Array[Int]) extends ConnectionOp[PreparedStatement] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a, b))
@@ -249,11 +249,11 @@ object connection {
     case class  PrepareStatement1(a: String, b: Int) extends ConnectionOp[PreparedStatement] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a, b))
     }
-    case class  PrepareStatement2(a: String, b: Array[String]) extends ConnectionOp[PreparedStatement] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a, b))
-    }
-    case class  PrepareStatement3(a: String, b: Int, c: Int, d: Int) extends ConnectionOp[PreparedStatement] {
+    case class  PrepareStatement2(a: String, b: Int, c: Int, d: Int) extends ConnectionOp[PreparedStatement] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a, b, c, d))
+    }
+    case class  PrepareStatement3(a: String, b: Array[String]) extends ConnectionOp[PreparedStatement] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a, b))
     }
     case class  PrepareStatement4(a: String, b: Int, c: Int) extends ConnectionOp[PreparedStatement] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a, b, c))
@@ -291,11 +291,11 @@ object connection {
     case class  SetReadOnly(a: Boolean) extends ConnectionOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setReadOnly(a))
     }
-    case object SetSavepoint extends ConnectionOp[Savepoint] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setSavepoint())
-    }
-    case class  SetSavepoint1(a: String) extends ConnectionOp[Savepoint] {
+    case class  SetSavepoint(a: String) extends ConnectionOp[Savepoint] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setSavepoint(a))
+    }
+    case object SetSavepoint1 extends ConnectionOp[Savepoint] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setSavepoint())
     }
     case class  SetSchema(a: String) extends ConnectionOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setSchema(a))
@@ -502,14 +502,14 @@ object connection {
   /** 
    * @group Constructors (Primitives)
    */
-  def createStatement(a: Int, b: Int): ConnectionIO[Statement] =
-    F.liftFC(CreateStatement(a, b))
+  val createStatement: ConnectionIO[Statement] =
+    F.liftFC(CreateStatement)
 
   /** 
    * @group Constructors (Primitives)
    */
-  val createStatement: ConnectionIO[Statement] =
-    F.liftFC(CreateStatement1)
+  def createStatement(a: Int, b: Int): ConnectionIO[Statement] =
+    F.liftFC(CreateStatement1(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -628,14 +628,14 @@ object connection {
   /** 
    * @group Constructors (Primitives)
    */
-  def prepareCall(a: String, b: Int, c: Int, d: Int): ConnectionIO[CallableStatement] =
-    F.liftFC(PrepareCall1(a, b, c, d))
+  def prepareCall(a: String): ConnectionIO[CallableStatement] =
+    F.liftFC(PrepareCall1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def prepareCall(a: String): ConnectionIO[CallableStatement] =
-    F.liftFC(PrepareCall2(a))
+  def prepareCall(a: String, b: Int, c: Int, d: Int): ConnectionIO[CallableStatement] =
+    F.liftFC(PrepareCall2(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
@@ -652,14 +652,14 @@ object connection {
   /** 
    * @group Constructors (Primitives)
    */
-  def prepareStatement(a: String, b: Array[String]): ConnectionIO[PreparedStatement] =
-    F.liftFC(PrepareStatement2(a, b))
+  def prepareStatement(a: String, b: Int, c: Int, d: Int): ConnectionIO[PreparedStatement] =
+    F.liftFC(PrepareStatement2(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def prepareStatement(a: String, b: Int, c: Int, d: Int): ConnectionIO[PreparedStatement] =
-    F.liftFC(PrepareStatement3(a, b, c, d))
+  def prepareStatement(a: String, b: Array[String]): ConnectionIO[PreparedStatement] =
+    F.liftFC(PrepareStatement3(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -736,14 +736,14 @@ object connection {
   /** 
    * @group Constructors (Primitives)
    */
-  val setSavepoint: ConnectionIO[Savepoint] =
-    F.liftFC(SetSavepoint)
+  def setSavepoint(a: String): ConnectionIO[Savepoint] =
+    F.liftFC(SetSavepoint(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setSavepoint(a: String): ConnectionIO[Savepoint] =
-    F.liftFC(SetSavepoint1(a))
+  val setSavepoint: ConnectionIO[Savepoint] =
+    F.liftFC(SetSavepoint1)
 
   /** 
    * @group Constructors (Primitives)

--- a/core/src/main/scala/doobie/free/databasemetadata.scala
+++ b/core/src/main/scala/doobie/free/databasemetadata.scala
@@ -284,9 +284,6 @@ object databasemetadata {
     case object GetMaxIndexLength extends DatabaseMetaDataOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMaxIndexLength())
     }
-    case object GetMaxLogicalLobSize extends DatabaseMetaDataOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMaxLogicalLobSize())
-    }
     case object GetMaxProcedureNameLength extends DatabaseMetaDataOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMaxProcedureNameLength())
     }
@@ -344,11 +341,11 @@ object databasemetadata {
     case object GetSchemaTerm extends DatabaseMetaDataOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSchemaTerm())
     }
-    case class  GetSchemas(a: String, b: String) extends DatabaseMetaDataOp[ResultSet] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSchemas(a, b))
-    }
-    case object GetSchemas1 extends DatabaseMetaDataOp[ResultSet] {
+    case object GetSchemas extends DatabaseMetaDataOp[ResultSet] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSchemas())
+    }
+    case class  GetSchemas1(a: String, b: String) extends DatabaseMetaDataOp[ResultSet] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSchemas(a, b))
     }
     case object GetSearchStringEscape extends DatabaseMetaDataOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSearchStringEscape())
@@ -592,9 +589,6 @@ object databasemetadata {
     }
     case object SupportsPositionedUpdate extends DatabaseMetaDataOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.supportsPositionedUpdate())
-    }
-    case object SupportsRefCursors extends DatabaseMetaDataOp[Boolean] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.supportsRefCursors())
     }
     case class  SupportsResultSetConcurrency(a: Int, b: Int) extends DatabaseMetaDataOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.supportsResultSetConcurrency(a, b))
@@ -1101,12 +1095,6 @@ object databasemetadata {
   /** 
    * @group Constructors (Primitives)
    */
-  val getMaxLogicalLobSize: DatabaseMetaDataIO[Long] =
-    F.liftFC(GetMaxLogicalLobSize)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   val getMaxProcedureNameLength: DatabaseMetaDataIO[Int] =
     F.liftFC(GetMaxProcedureNameLength)
 
@@ -1221,14 +1209,14 @@ object databasemetadata {
   /** 
    * @group Constructors (Primitives)
    */
-  def getSchemas(a: String, b: String): DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetSchemas(a, b))
+  val getSchemas: DatabaseMetaDataIO[ResultSet] =
+    F.liftFC(GetSchemas)
 
   /** 
    * @group Constructors (Primitives)
    */
-  val getSchemas: DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetSchemas1)
+  def getSchemas(a: String, b: String): DatabaseMetaDataIO[ResultSet] =
+    F.liftFC(GetSchemas1(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1715,12 +1703,6 @@ object databasemetadata {
    */
   val supportsPositionedUpdate: DatabaseMetaDataIO[Boolean] =
     F.liftFC(SupportsPositionedUpdate)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val supportsRefCursors: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsRefCursors)
 
   /** 
    * @group Constructors (Primitives)

--- a/core/src/main/scala/doobie/free/preparedstatement.scala
+++ b/core/src/main/scala/doobie/free/preparedstatement.scala
@@ -29,7 +29,6 @@ import java.sql.RowId
 import java.sql.SQLData
 import java.sql.SQLInput
 import java.sql.SQLOutput
-import java.sql.SQLType
 import java.sql.SQLWarning
 import java.sql.SQLXML
 import java.sql.Statement
@@ -184,35 +183,17 @@ object preparedstatement {
     case class  Execute1(a: String) extends PreparedStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a))
     }
-    case class  Execute2(a: String, b: Array[String]) extends PreparedStatementOp[Boolean] {
+    case class  Execute2(a: String, b: Array[Int]) extends PreparedStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
     }
-    case class  Execute3(a: String, b: Array[Int]) extends PreparedStatementOp[Boolean] {
+    case class  Execute3(a: String, b: Int) extends PreparedStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
     }
-    case class  Execute4(a: String, b: Int) extends PreparedStatementOp[Boolean] {
+    case class  Execute4(a: String, b: Array[String]) extends PreparedStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
     }
     case object ExecuteBatch extends PreparedStatementOp[Array[Int]] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeBatch())
-    }
-    case object ExecuteLargeBatch extends PreparedStatementOp[Array[Long]] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeBatch())
-    }
-    case object ExecuteLargeUpdate extends PreparedStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate())
-    }
-    case class  ExecuteLargeUpdate1(a: String, b: Array[String]) extends PreparedStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
-    }
-    case class  ExecuteLargeUpdate2(a: String, b: Array[Int]) extends PreparedStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
-    }
-    case class  ExecuteLargeUpdate3(a: String, b: Int) extends PreparedStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
-    }
-    case class  ExecuteLargeUpdate4(a: String) extends PreparedStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a))
     }
     case object ExecuteQuery extends PreparedStatementOp[ResultSet] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeQuery())
@@ -223,17 +204,17 @@ object preparedstatement {
     case object ExecuteUpdate extends PreparedStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate())
     }
-    case class  ExecuteUpdate1(a: String) extends PreparedStatementOp[Int] {
+    case class  ExecuteUpdate1(a: String, b: Array[String]) extends PreparedStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
+    }
+    case class  ExecuteUpdate2(a: String, b: Int) extends PreparedStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
+    }
+    case class  ExecuteUpdate3(a: String, b: Array[Int]) extends PreparedStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
+    }
+    case class  ExecuteUpdate4(a: String) extends PreparedStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a))
-    }
-    case class  ExecuteUpdate2(a: String, b: Array[Int]) extends PreparedStatementOp[Int] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
-    }
-    case class  ExecuteUpdate3(a: String, b: Int) extends PreparedStatementOp[Int] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
-    }
-    case class  ExecuteUpdate4(a: String, b: Array[String]) extends PreparedStatementOp[Int] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
     }
     case object GetConnection extends PreparedStatementOp[Connection] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getConnection())
@@ -247,12 +228,6 @@ object preparedstatement {
     case object GetGeneratedKeys extends PreparedStatementOp[ResultSet] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getGeneratedKeys())
     }
-    case object GetLargeMaxRows extends PreparedStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeMaxRows())
-    }
-    case object GetLargeUpdateCount extends PreparedStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeUpdateCount())
-    }
     case object GetMaxFieldSize extends PreparedStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMaxFieldSize())
     }
@@ -262,11 +237,11 @@ object preparedstatement {
     case object GetMetaData extends PreparedStatementOp[ResultSetMetaData] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMetaData())
     }
-    case class  GetMoreResults(a: Int) extends PreparedStatementOp[Boolean] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMoreResults(a))
-    }
-    case object GetMoreResults1 extends PreparedStatementOp[Boolean] {
+    case object GetMoreResults extends PreparedStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMoreResults())
+    }
+    case class  GetMoreResults1(a: Int) extends PreparedStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMoreResults(a))
     }
     case object GetParameterMetaData extends PreparedStatementOp[ParameterMetaData] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getParameterMetaData())
@@ -307,13 +282,13 @@ object preparedstatement {
     case class  SetArray(a: Int, b: SqlArray) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setArray(a, b))
     }
-    case class  SetAsciiStream(a: Int, b: InputStream, c: Long) extends PreparedStatementOp[Unit] {
+    case class  SetAsciiStream(a: Int, b: InputStream, c: Int) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
     }
     case class  SetAsciiStream1(a: Int, b: InputStream) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b))
     }
-    case class  SetAsciiStream2(a: Int, b: InputStream, c: Int) extends PreparedStatementOp[Unit] {
+    case class  SetAsciiStream2(a: Int, b: InputStream, c: Long) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
     }
     case class  SetBigDecimal(a: Int, b: BigDecimal) extends PreparedStatementOp[Unit] {
@@ -328,10 +303,10 @@ object preparedstatement {
     case class  SetBinaryStream2(a: Int, b: InputStream, c: Long) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b, c))
     }
-    case class  SetBlob(a: Int, b: Blob) extends PreparedStatementOp[Unit] {
+    case class  SetBlob(a: Int, b: InputStream) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b))
     }
-    case class  SetBlob1(a: Int, b: InputStream) extends PreparedStatementOp[Unit] {
+    case class  SetBlob1(a: Int, b: Blob) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b))
     }
     case class  SetBlob2(a: Int, b: InputStream, c: Long) extends PreparedStatementOp[Unit] {
@@ -355,11 +330,11 @@ object preparedstatement {
     case class  SetCharacterStream2(a: Int, b: Reader) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b))
     }
-    case class  SetClob(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b, c))
-    }
-    case class  SetClob1(a: Int, b: Reader) extends PreparedStatementOp[Unit] {
+    case class  SetClob(a: Int, b: Reader) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
+    }
+    case class  SetClob1(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b, c))
     }
     case class  SetClob2(a: Int, b: Clob) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
@@ -367,11 +342,11 @@ object preparedstatement {
     case class  SetCursorName(a: String) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCursorName(a))
     }
-    case class  SetDate(a: Int, b: Date, c: Calendar) extends PreparedStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b, c))
-    }
-    case class  SetDate1(a: Int, b: Date) extends PreparedStatementOp[Unit] {
+    case class  SetDate(a: Int, b: Date) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b))
+    }
+    case class  SetDate1(a: Int, b: Date, c: Calendar) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b, c))
     }
     case class  SetDouble(a: Int, b: Double) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDouble(a, b))
@@ -391,9 +366,6 @@ object preparedstatement {
     case class  SetInt(a: Int, b: Int) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setInt(a, b))
     }
-    case class  SetLargeMaxRows(a: Long) extends PreparedStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setLargeMaxRows(a))
-    }
     case class  SetLong(a: Int, b: Long) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setLong(a, b))
     }
@@ -409,14 +381,14 @@ object preparedstatement {
     case class  SetNCharacterStream1(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNCharacterStream(a, b, c))
     }
-    case class  SetNClob(a: Int, b: NClob) extends PreparedStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
-    }
-    case class  SetNClob1(a: Int, b: Reader) extends PreparedStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
-    }
-    case class  SetNClob2(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit] {
+    case class  SetNClob(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b, c))
+    }
+    case class  SetNClob1(a: Int, b: NClob) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
+    }
+    case class  SetNClob2(a: Int, b: Reader) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
     }
     case class  SetNString(a: Int, b: String) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNString(a, b))
@@ -427,20 +399,14 @@ object preparedstatement {
     case class  SetNull1(a: Int, b: Int) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNull(a, b))
     }
-    case class  SetObject(a: Int, b: Object, c: SQLType) extends PreparedStatementOp[Unit] {
+    case class  SetObject(a: Int, b: Object, c: Int) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
     }
-    case class  SetObject1(a: Int, b: Object, c: Int) extends PreparedStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
-    }
-    case class  SetObject2(a: Int, b: Object, c: Int, d: Int) extends PreparedStatementOp[Unit] {
+    case class  SetObject1(a: Int, b: Object, c: Int, d: Int) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
     }
-    case class  SetObject3(a: Int, b: Object) extends PreparedStatementOp[Unit] {
+    case class  SetObject2(a: Int, b: Object) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b))
-    }
-    case class  SetObject4(a: Int, b: Object, c: SQLType, d: Int) extends PreparedStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
     }
     case class  SetPoolable(a: Boolean) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setPoolable(a))
@@ -469,11 +435,11 @@ object preparedstatement {
     case class  SetTime1(a: Int, b: Time, c: Calendar) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTime(a, b, c))
     }
-    case class  SetTimestamp(a: Int, b: Timestamp, c: Calendar) extends PreparedStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b, c))
-    }
-    case class  SetTimestamp1(a: Int, b: Timestamp) extends PreparedStatementOp[Unit] {
+    case class  SetTimestamp(a: Int, b: Timestamp) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b))
+    }
+    case class  SetTimestamp1(a: Int, b: Timestamp, c: Calendar) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b, c))
     }
     case class  SetURL(a: Int, b: URL) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setURL(a, b))
@@ -683,19 +649,19 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def execute(a: String, b: Array[String]): PreparedStatementIO[Boolean] =
+  def execute(a: String, b: Array[Int]): PreparedStatementIO[Boolean] =
     F.liftFC(Execute2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def execute(a: String, b: Array[Int]): PreparedStatementIO[Boolean] =
+  def execute(a: String, b: Int): PreparedStatementIO[Boolean] =
     F.liftFC(Execute3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def execute(a: String, b: Int): PreparedStatementIO[Boolean] =
+  def execute(a: String, b: Array[String]): PreparedStatementIO[Boolean] =
     F.liftFC(Execute4(a, b))
 
   /** 
@@ -703,42 +669,6 @@ object preparedstatement {
    */
   val executeBatch: PreparedStatementIO[Array[Int]] =
     F.liftFC(ExecuteBatch)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val executeLargeBatch: PreparedStatementIO[Array[Long]] =
-    F.liftFC(ExecuteLargeBatch)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val executeLargeUpdate: PreparedStatementIO[Long] =
-    F.liftFC(ExecuteLargeUpdate)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String, b: Array[String]): PreparedStatementIO[Long] =
-    F.liftFC(ExecuteLargeUpdate1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String, b: Array[Int]): PreparedStatementIO[Long] =
-    F.liftFC(ExecuteLargeUpdate2(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String, b: Int): PreparedStatementIO[Long] =
-    F.liftFC(ExecuteLargeUpdate3(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String): PreparedStatementIO[Long] =
-    F.liftFC(ExecuteLargeUpdate4(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -761,26 +691,26 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def executeUpdate(a: String): PreparedStatementIO[Int] =
-    F.liftFC(ExecuteUpdate1(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeUpdate(a: String, b: Array[Int]): PreparedStatementIO[Int] =
-    F.liftFC(ExecuteUpdate2(a, b))
+  def executeUpdate(a: String, b: Array[String]): PreparedStatementIO[Int] =
+    F.liftFC(ExecuteUpdate1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def executeUpdate(a: String, b: Int): PreparedStatementIO[Int] =
+    F.liftFC(ExecuteUpdate2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeUpdate(a: String, b: Array[Int]): PreparedStatementIO[Int] =
     F.liftFC(ExecuteUpdate3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def executeUpdate(a: String, b: Array[String]): PreparedStatementIO[Int] =
-    F.liftFC(ExecuteUpdate4(a, b))
+  def executeUpdate(a: String): PreparedStatementIO[Int] =
+    F.liftFC(ExecuteUpdate4(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -809,18 +739,6 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  val getLargeMaxRows: PreparedStatementIO[Long] =
-    F.liftFC(GetLargeMaxRows)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val getLargeUpdateCount: PreparedStatementIO[Long] =
-    F.liftFC(GetLargeUpdateCount)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   val getMaxFieldSize: PreparedStatementIO[Int] =
     F.liftFC(GetMaxFieldSize)
 
@@ -839,14 +757,14 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getMoreResults(a: Int): PreparedStatementIO[Boolean] =
-    F.liftFC(GetMoreResults(a))
+  val getMoreResults: PreparedStatementIO[Boolean] =
+    F.liftFC(GetMoreResults)
 
   /** 
    * @group Constructors (Primitives)
    */
-  val getMoreResults: PreparedStatementIO[Boolean] =
-    F.liftFC(GetMoreResults1)
+  def getMoreResults(a: Int): PreparedStatementIO[Boolean] =
+    F.liftFC(GetMoreResults1(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -929,7 +847,7 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setAsciiStream(a: Int, b: InputStream, c: Long): PreparedStatementIO[Unit] =
+  def setAsciiStream(a: Int, b: InputStream, c: Int): PreparedStatementIO[Unit] =
     F.liftFC(SetAsciiStream(a, b, c))
 
   /** 
@@ -941,7 +859,7 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setAsciiStream(a: Int, b: InputStream, c: Int): PreparedStatementIO[Unit] =
+  def setAsciiStream(a: Int, b: InputStream, c: Long): PreparedStatementIO[Unit] =
     F.liftFC(SetAsciiStream2(a, b, c))
 
   /** 
@@ -971,13 +889,13 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setBlob(a: Int, b: Blob): PreparedStatementIO[Unit] =
+  def setBlob(a: Int, b: InputStream): PreparedStatementIO[Unit] =
     F.liftFC(SetBlob(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setBlob(a: Int, b: InputStream): PreparedStatementIO[Unit] =
+  def setBlob(a: Int, b: Blob): PreparedStatementIO[Unit] =
     F.liftFC(SetBlob1(a, b))
 
   /** 
@@ -1025,14 +943,14 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setClob(a: Int, b: Reader, c: Long): PreparedStatementIO[Unit] =
-    F.liftFC(SetClob(a, b, c))
+  def setClob(a: Int, b: Reader): PreparedStatementIO[Unit] =
+    F.liftFC(SetClob(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setClob(a: Int, b: Reader): PreparedStatementIO[Unit] =
-    F.liftFC(SetClob1(a, b))
+  def setClob(a: Int, b: Reader, c: Long): PreparedStatementIO[Unit] =
+    F.liftFC(SetClob1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -1049,14 +967,14 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setDate(a: Int, b: Date, c: Calendar): PreparedStatementIO[Unit] =
-    F.liftFC(SetDate(a, b, c))
+  def setDate(a: Int, b: Date): PreparedStatementIO[Unit] =
+    F.liftFC(SetDate(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setDate(a: Int, b: Date): PreparedStatementIO[Unit] =
-    F.liftFC(SetDate1(a, b))
+  def setDate(a: Int, b: Date, c: Calendar): PreparedStatementIO[Unit] =
+    F.liftFC(SetDate1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -1097,12 +1015,6 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setLargeMaxRows(a: Long): PreparedStatementIO[Unit] =
-    F.liftFC(SetLargeMaxRows(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def setLong(a: Int, b: Long): PreparedStatementIO[Unit] =
     F.liftFC(SetLong(a, b))
 
@@ -1133,20 +1045,20 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setNClob(a: Int, b: NClob): PreparedStatementIO[Unit] =
-    F.liftFC(SetNClob(a, b))
+  def setNClob(a: Int, b: Reader, c: Long): PreparedStatementIO[Unit] =
+    F.liftFC(SetNClob(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setNClob(a: Int, b: Reader): PreparedStatementIO[Unit] =
+  def setNClob(a: Int, b: NClob): PreparedStatementIO[Unit] =
     F.liftFC(SetNClob1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setNClob(a: Int, b: Reader, c: Long): PreparedStatementIO[Unit] =
-    F.liftFC(SetNClob2(a, b, c))
+  def setNClob(a: Int, b: Reader): PreparedStatementIO[Unit] =
+    F.liftFC(SetNClob2(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1169,32 +1081,20 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setObject(a: Int, b: Object, c: SQLType): PreparedStatementIO[Unit] =
+  def setObject(a: Int, b: Object, c: Int): PreparedStatementIO[Unit] =
     F.liftFC(SetObject(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setObject(a: Int, b: Object, c: Int): PreparedStatementIO[Unit] =
-    F.liftFC(SetObject1(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def setObject(a: Int, b: Object, c: Int, d: Int): PreparedStatementIO[Unit] =
-    F.liftFC(SetObject2(a, b, c, d))
+    F.liftFC(SetObject1(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setObject(a: Int, b: Object): PreparedStatementIO[Unit] =
-    F.liftFC(SetObject3(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setObject(a: Int, b: Object, c: SQLType, d: Int): PreparedStatementIO[Unit] =
-    F.liftFC(SetObject4(a, b, c, d))
+    F.liftFC(SetObject2(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1253,14 +1153,14 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setTimestamp(a: Int, b: Timestamp, c: Calendar): PreparedStatementIO[Unit] =
-    F.liftFC(SetTimestamp(a, b, c))
+  def setTimestamp(a: Int, b: Timestamp): PreparedStatementIO[Unit] =
+    F.liftFC(SetTimestamp(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setTimestamp(a: Int, b: Timestamp): PreparedStatementIO[Unit] =
-    F.liftFC(SetTimestamp1(a, b))
+  def setTimestamp(a: Int, b: Timestamp, c: Calendar): PreparedStatementIO[Unit] =
+    F.liftFC(SetTimestamp1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)

--- a/core/src/main/scala/doobie/free/preparedstatement.scala
+++ b/core/src/main/scala/doobie/free/preparedstatement.scala
@@ -29,6 +29,7 @@ import java.sql.RowId
 import java.sql.SQLData
 import java.sql.SQLInput
 import java.sql.SQLOutput
+import java.sql.SQLType
 import java.sql.SQLWarning
 import java.sql.SQLXML
 import java.sql.Statement
@@ -85,7 +86,11 @@ object preparedstatement {
    * Sum type of primitive operations over a `java.sql.PreparedStatement`.
    * @group Algebra 
    */
-  sealed trait PreparedStatementOp[A]
+  sealed trait PreparedStatementOp[A] {
+    protected def primitive[M[_]: Monad: Capture](f: PreparedStatement => A): Kleisli[M, PreparedStatement, A] = 
+      Kleisli((s: PreparedStatement) => Capture[M].apply(f(s)))
+    def defaultTransK[M[_]: Monad: Catchable: Capture]: Kleisli[M, PreparedStatement, A]
+  }
 
   /** 
    * Module of constructors for `PreparedStatementOp`. These are rarely useful outside of the implementation;
@@ -95,122 +100,390 @@ object preparedstatement {
   object PreparedStatementOp {
     
     // Lifting
-    case class LiftBlobIO[A](s: Blob, action: BlobIO[A]) extends PreparedStatementOp[A]
-    case class LiftCallableStatementIO[A](s: CallableStatement, action: CallableStatementIO[A]) extends PreparedStatementOp[A]
-    case class LiftClobIO[A](s: Clob, action: ClobIO[A]) extends PreparedStatementOp[A]
-    case class LiftConnectionIO[A](s: Connection, action: ConnectionIO[A]) extends PreparedStatementOp[A]
-    case class LiftDatabaseMetaDataIO[A](s: DatabaseMetaData, action: DatabaseMetaDataIO[A]) extends PreparedStatementOp[A]
-    case class LiftDriverIO[A](s: Driver, action: DriverIO[A]) extends PreparedStatementOp[A]
-    case class LiftNClobIO[A](s: NClob, action: NClobIO[A]) extends PreparedStatementOp[A]
-    case class LiftRefIO[A](s: Ref, action: RefIO[A]) extends PreparedStatementOp[A]
-    case class LiftResultSetIO[A](s: ResultSet, action: ResultSetIO[A]) extends PreparedStatementOp[A]
-    case class LiftSQLDataIO[A](s: SQLData, action: SQLDataIO[A]) extends PreparedStatementOp[A]
-    case class LiftSQLInputIO[A](s: SQLInput, action: SQLInputIO[A]) extends PreparedStatementOp[A]
-    case class LiftSQLOutputIO[A](s: SQLOutput, action: SQLOutputIO[A]) extends PreparedStatementOp[A]
-    case class LiftStatementIO[A](s: Statement, action: StatementIO[A]) extends PreparedStatementOp[A]
+    case class LiftBlobIO[A](s: Blob, action: BlobIO[A]) extends PreparedStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftCallableStatementIO[A](s: CallableStatement, action: CallableStatementIO[A]) extends PreparedStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftClobIO[A](s: Clob, action: ClobIO[A]) extends PreparedStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftConnectionIO[A](s: Connection, action: ConnectionIO[A]) extends PreparedStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftDatabaseMetaDataIO[A](s: DatabaseMetaData, action: DatabaseMetaDataIO[A]) extends PreparedStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftDriverIO[A](s: Driver, action: DriverIO[A]) extends PreparedStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftNClobIO[A](s: NClob, action: NClobIO[A]) extends PreparedStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftRefIO[A](s: Ref, action: RefIO[A]) extends PreparedStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftResultSetIO[A](s: ResultSet, action: ResultSetIO[A]) extends PreparedStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftSQLDataIO[A](s: SQLData, action: SQLDataIO[A]) extends PreparedStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftSQLInputIO[A](s: SQLInput, action: SQLInputIO[A]) extends PreparedStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftSQLOutputIO[A](s: SQLOutput, action: SQLOutputIO[A]) extends PreparedStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftStatementIO[A](s: Statement, action: StatementIO[A]) extends PreparedStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
 
     // Combinators
-    case class Attempt[A](action: PreparedStatementIO[A]) extends PreparedStatementOp[Throwable \/ A]
-    case class Pure[A](a: () => A) extends PreparedStatementOp[A]
+    case class Attempt[A](action: PreparedStatementIO[A]) extends PreparedStatementOp[Throwable \/ A] {
+      import scalaz._, Scalaz._
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = 
+        Predef.implicitly[Catchable[Kleisli[M, PreparedStatement, ?]]].attempt(action.transK[M])
+    }
+    case class Pure[A](a: () => A) extends PreparedStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_ => a())
+    }
+    case class Raw[A](f: PreparedStatement => A) extends PreparedStatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(f)
+    }
 
     // Primitive Operations
-    case object AddBatch extends PreparedStatementOp[Unit]
-    case class  AddBatch1(a: String) extends PreparedStatementOp[Unit]
-    case object Cancel extends PreparedStatementOp[Unit]
-    case object ClearBatch extends PreparedStatementOp[Unit]
-    case object ClearParameters extends PreparedStatementOp[Unit]
-    case object ClearWarnings extends PreparedStatementOp[Unit]
-    case object Close extends PreparedStatementOp[Unit]
-    case object Execute extends PreparedStatementOp[Boolean]
-    case class  Execute1(a: String, b: Int) extends PreparedStatementOp[Boolean]
-    case class  Execute2(a: String) extends PreparedStatementOp[Boolean]
-    case class  Execute3(a: String, b: Array[Int]) extends PreparedStatementOp[Boolean]
-    case class  Execute4(a: String, b: Array[String]) extends PreparedStatementOp[Boolean]
-    case object ExecuteBatch extends PreparedStatementOp[Array[Int]]
-    case object ExecuteQuery extends PreparedStatementOp[ResultSet]
-    case class  ExecuteQuery1(a: String) extends PreparedStatementOp[ResultSet]
-    case object ExecuteUpdate extends PreparedStatementOp[Int]
-    case class  ExecuteUpdate1(a: String, b: Int) extends PreparedStatementOp[Int]
-    case class  ExecuteUpdate2(a: String) extends PreparedStatementOp[Int]
-    case class  ExecuteUpdate3(a: String, b: Array[String]) extends PreparedStatementOp[Int]
-    case class  ExecuteUpdate4(a: String, b: Array[Int]) extends PreparedStatementOp[Int]
-    case object GetConnection extends PreparedStatementOp[Connection]
-    case object GetFetchDirection extends PreparedStatementOp[Int]
-    case object GetFetchSize extends PreparedStatementOp[Int]
-    case object GetGeneratedKeys extends PreparedStatementOp[ResultSet]
-    case object GetMaxFieldSize extends PreparedStatementOp[Int]
-    case object GetMaxRows extends PreparedStatementOp[Int]
-    case object GetMetaData extends PreparedStatementOp[ResultSetMetaData]
-    case class  GetMoreResults(a: Int) extends PreparedStatementOp[Boolean]
-    case object GetMoreResults1 extends PreparedStatementOp[Boolean]
-    case object GetParameterMetaData extends PreparedStatementOp[ParameterMetaData]
-    case object GetQueryTimeout extends PreparedStatementOp[Int]
-    case object GetResultSet extends PreparedStatementOp[ResultSet]
-    case object GetResultSetConcurrency extends PreparedStatementOp[Int]
-    case object GetResultSetHoldability extends PreparedStatementOp[Int]
-    case object GetResultSetType extends PreparedStatementOp[Int]
-    case object GetUpdateCount extends PreparedStatementOp[Int]
-    case object GetWarnings extends PreparedStatementOp[SQLWarning]
-    case object IsClosed extends PreparedStatementOp[Boolean]
-    case object IsPoolable extends PreparedStatementOp[Boolean]
-    case class  IsWrapperFor(a: Class[_]) extends PreparedStatementOp[Boolean]
-    case class  SetArray(a: Int, b: SqlArray) extends PreparedStatementOp[Unit]
-    case class  SetAsciiStream(a: Int, b: InputStream, c: Int) extends PreparedStatementOp[Unit]
-    case class  SetAsciiStream1(a: Int, b: InputStream) extends PreparedStatementOp[Unit]
-    case class  SetAsciiStream2(a: Int, b: InputStream, c: Long) extends PreparedStatementOp[Unit]
-    case class  SetBigDecimal(a: Int, b: BigDecimal) extends PreparedStatementOp[Unit]
-    case class  SetBinaryStream(a: Int, b: InputStream) extends PreparedStatementOp[Unit]
-    case class  SetBinaryStream1(a: Int, b: InputStream, c: Long) extends PreparedStatementOp[Unit]
-    case class  SetBinaryStream2(a: Int, b: InputStream, c: Int) extends PreparedStatementOp[Unit]
-    case class  SetBlob(a: Int, b: Blob) extends PreparedStatementOp[Unit]
-    case class  SetBlob1(a: Int, b: InputStream) extends PreparedStatementOp[Unit]
-    case class  SetBlob2(a: Int, b: InputStream, c: Long) extends PreparedStatementOp[Unit]
-    case class  SetBoolean(a: Int, b: Boolean) extends PreparedStatementOp[Unit]
-    case class  SetByte(a: Int, b: Byte) extends PreparedStatementOp[Unit]
-    case class  SetBytes(a: Int, b: Array[Byte]) extends PreparedStatementOp[Unit]
-    case class  SetCharacterStream(a: Int, b: Reader) extends PreparedStatementOp[Unit]
-    case class  SetCharacterStream1(a: Int, b: Reader, c: Int) extends PreparedStatementOp[Unit]
-    case class  SetCharacterStream2(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit]
-    case class  SetClob(a: Int, b: Clob) extends PreparedStatementOp[Unit]
-    case class  SetClob1(a: Int, b: Reader) extends PreparedStatementOp[Unit]
-    case class  SetClob2(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit]
-    case class  SetCursorName(a: String) extends PreparedStatementOp[Unit]
-    case class  SetDate(a: Int, b: Date, c: Calendar) extends PreparedStatementOp[Unit]
-    case class  SetDate1(a: Int, b: Date) extends PreparedStatementOp[Unit]
-    case class  SetDouble(a: Int, b: Double) extends PreparedStatementOp[Unit]
-    case class  SetEscapeProcessing(a: Boolean) extends PreparedStatementOp[Unit]
-    case class  SetFetchDirection(a: Int) extends PreparedStatementOp[Unit]
-    case class  SetFetchSize(a: Int) extends PreparedStatementOp[Unit]
-    case class  SetFloat(a: Int, b: Float) extends PreparedStatementOp[Unit]
-    case class  SetInt(a: Int, b: Int) extends PreparedStatementOp[Unit]
-    case class  SetLong(a: Int, b: Long) extends PreparedStatementOp[Unit]
-    case class  SetMaxFieldSize(a: Int) extends PreparedStatementOp[Unit]
-    case class  SetMaxRows(a: Int) extends PreparedStatementOp[Unit]
-    case class  SetNCharacterStream(a: Int, b: Reader) extends PreparedStatementOp[Unit]
-    case class  SetNCharacterStream1(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit]
-    case class  SetNClob(a: Int, b: Reader) extends PreparedStatementOp[Unit]
-    case class  SetNClob1(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit]
-    case class  SetNClob2(a: Int, b: NClob) extends PreparedStatementOp[Unit]
-    case class  SetNString(a: Int, b: String) extends PreparedStatementOp[Unit]
-    case class  SetNull(a: Int, b: Int, c: String) extends PreparedStatementOp[Unit]
-    case class  SetNull1(a: Int, b: Int) extends PreparedStatementOp[Unit]
-    case class  SetObject(a: Int, b: Object, c: Int) extends PreparedStatementOp[Unit]
-    case class  SetObject1(a: Int, b: Object) extends PreparedStatementOp[Unit]
-    case class  SetObject2(a: Int, b: Object, c: Int, d: Int) extends PreparedStatementOp[Unit]
-    case class  SetPoolable(a: Boolean) extends PreparedStatementOp[Unit]
-    case class  SetQueryTimeout(a: Int) extends PreparedStatementOp[Unit]
-    case class  SetRef(a: Int, b: Ref) extends PreparedStatementOp[Unit]
-    case class  SetRowId(a: Int, b: RowId) extends PreparedStatementOp[Unit]
-    case class  SetSQLXML(a: Int, b: SQLXML) extends PreparedStatementOp[Unit]
-    case class  SetShort(a: Int, b: Short) extends PreparedStatementOp[Unit]
-    case class  SetString(a: Int, b: String) extends PreparedStatementOp[Unit]
-    case class  SetTime(a: Int, b: Time, c: Calendar) extends PreparedStatementOp[Unit]
-    case class  SetTime1(a: Int, b: Time) extends PreparedStatementOp[Unit]
-    case class  SetTimestamp(a: Int, b: Timestamp, c: Calendar) extends PreparedStatementOp[Unit]
-    case class  SetTimestamp1(a: Int, b: Timestamp) extends PreparedStatementOp[Unit]
-    case class  SetURL(a: Int, b: URL) extends PreparedStatementOp[Unit]
-    case class  SetUnicodeStream(a: Int, b: InputStream, c: Int) extends PreparedStatementOp[Unit]
-    case class  Unwrap[T](a: Class[T]) extends PreparedStatementOp[T]
+    case object AddBatch extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.addBatch())
+    }
+    case class  AddBatch1(a: String) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.addBatch(a))
+    }
+    case object Cancel extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.cancel())
+    }
+    case object ClearBatch extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.clearBatch())
+    }
+    case object ClearParameters extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.clearParameters())
+    }
+    case object ClearWarnings extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.clearWarnings())
+    }
+    case object Close extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.close())
+    }
+    case object CloseOnCompletion extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.closeOnCompletion())
+    }
+    case object Execute extends PreparedStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute())
+    }
+    case class  Execute1(a: String) extends PreparedStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a))
+    }
+    case class  Execute2(a: String, b: Array[String]) extends PreparedStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
+    }
+    case class  Execute3(a: String, b: Array[Int]) extends PreparedStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
+    }
+    case class  Execute4(a: String, b: Int) extends PreparedStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
+    }
+    case object ExecuteBatch extends PreparedStatementOp[Array[Int]] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeBatch())
+    }
+    case object ExecuteLargeBatch extends PreparedStatementOp[Array[Long]] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeBatch())
+    }
+    case object ExecuteLargeUpdate extends PreparedStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate())
+    }
+    case class  ExecuteLargeUpdate1(a: String, b: Array[String]) extends PreparedStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
+    }
+    case class  ExecuteLargeUpdate2(a: String, b: Array[Int]) extends PreparedStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
+    }
+    case class  ExecuteLargeUpdate3(a: String, b: Int) extends PreparedStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
+    }
+    case class  ExecuteLargeUpdate4(a: String) extends PreparedStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a))
+    }
+    case object ExecuteQuery extends PreparedStatementOp[ResultSet] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeQuery())
+    }
+    case class  ExecuteQuery1(a: String) extends PreparedStatementOp[ResultSet] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeQuery(a))
+    }
+    case object ExecuteUpdate extends PreparedStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate())
+    }
+    case class  ExecuteUpdate1(a: String) extends PreparedStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a))
+    }
+    case class  ExecuteUpdate2(a: String, b: Array[Int]) extends PreparedStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
+    }
+    case class  ExecuteUpdate3(a: String, b: Int) extends PreparedStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
+    }
+    case class  ExecuteUpdate4(a: String, b: Array[String]) extends PreparedStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
+    }
+    case object GetConnection extends PreparedStatementOp[Connection] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getConnection())
+    }
+    case object GetFetchDirection extends PreparedStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getFetchDirection())
+    }
+    case object GetFetchSize extends PreparedStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getFetchSize())
+    }
+    case object GetGeneratedKeys extends PreparedStatementOp[ResultSet] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getGeneratedKeys())
+    }
+    case object GetLargeMaxRows extends PreparedStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeMaxRows())
+    }
+    case object GetLargeUpdateCount extends PreparedStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeUpdateCount())
+    }
+    case object GetMaxFieldSize extends PreparedStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMaxFieldSize())
+    }
+    case object GetMaxRows extends PreparedStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMaxRows())
+    }
+    case object GetMetaData extends PreparedStatementOp[ResultSetMetaData] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMetaData())
+    }
+    case class  GetMoreResults(a: Int) extends PreparedStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMoreResults(a))
+    }
+    case object GetMoreResults1 extends PreparedStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMoreResults())
+    }
+    case object GetParameterMetaData extends PreparedStatementOp[ParameterMetaData] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getParameterMetaData())
+    }
+    case object GetQueryTimeout extends PreparedStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getQueryTimeout())
+    }
+    case object GetResultSet extends PreparedStatementOp[ResultSet] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getResultSet())
+    }
+    case object GetResultSetConcurrency extends PreparedStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getResultSetConcurrency())
+    }
+    case object GetResultSetHoldability extends PreparedStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getResultSetHoldability())
+    }
+    case object GetResultSetType extends PreparedStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getResultSetType())
+    }
+    case object GetUpdateCount extends PreparedStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getUpdateCount())
+    }
+    case object GetWarnings extends PreparedStatementOp[SQLWarning] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getWarnings())
+    }
+    case object IsCloseOnCompletion extends PreparedStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.isCloseOnCompletion())
+    }
+    case object IsClosed extends PreparedStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.isClosed())
+    }
+    case object IsPoolable extends PreparedStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.isPoolable())
+    }
+    case class  IsWrapperFor(a: Class[_]) extends PreparedStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.isWrapperFor(a))
+    }
+    case class  SetArray(a: Int, b: SqlArray) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setArray(a, b))
+    }
+    case class  SetAsciiStream(a: Int, b: InputStream, c: Long) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
+    }
+    case class  SetAsciiStream1(a: Int, b: InputStream) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b))
+    }
+    case class  SetAsciiStream2(a: Int, b: InputStream, c: Int) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
+    }
+    case class  SetBigDecimal(a: Int, b: BigDecimal) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBigDecimal(a, b))
+    }
+    case class  SetBinaryStream(a: Int, b: InputStream) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b))
+    }
+    case class  SetBinaryStream1(a: Int, b: InputStream, c: Int) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b, c))
+    }
+    case class  SetBinaryStream2(a: Int, b: InputStream, c: Long) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b, c))
+    }
+    case class  SetBlob(a: Int, b: Blob) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b))
+    }
+    case class  SetBlob1(a: Int, b: InputStream) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b))
+    }
+    case class  SetBlob2(a: Int, b: InputStream, c: Long) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b, c))
+    }
+    case class  SetBoolean(a: Int, b: Boolean) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBoolean(a, b))
+    }
+    case class  SetByte(a: Int, b: Byte) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setByte(a, b))
+    }
+    case class  SetBytes(a: Int, b: Array[Byte]) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBytes(a, b))
+    }
+    case class  SetCharacterStream(a: Int, b: Reader, c: Int) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b, c))
+    }
+    case class  SetCharacterStream1(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b, c))
+    }
+    case class  SetCharacterStream2(a: Int, b: Reader) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b))
+    }
+    case class  SetClob(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b, c))
+    }
+    case class  SetClob1(a: Int, b: Reader) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
+    }
+    case class  SetClob2(a: Int, b: Clob) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
+    }
+    case class  SetCursorName(a: String) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCursorName(a))
+    }
+    case class  SetDate(a: Int, b: Date, c: Calendar) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b, c))
+    }
+    case class  SetDate1(a: Int, b: Date) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b))
+    }
+    case class  SetDouble(a: Int, b: Double) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDouble(a, b))
+    }
+    case class  SetEscapeProcessing(a: Boolean) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setEscapeProcessing(a))
+    }
+    case class  SetFetchDirection(a: Int) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setFetchDirection(a))
+    }
+    case class  SetFetchSize(a: Int) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setFetchSize(a))
+    }
+    case class  SetFloat(a: Int, b: Float) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setFloat(a, b))
+    }
+    case class  SetInt(a: Int, b: Int) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setInt(a, b))
+    }
+    case class  SetLargeMaxRows(a: Long) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setLargeMaxRows(a))
+    }
+    case class  SetLong(a: Int, b: Long) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setLong(a, b))
+    }
+    case class  SetMaxFieldSize(a: Int) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setMaxFieldSize(a))
+    }
+    case class  SetMaxRows(a: Int) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setMaxRows(a))
+    }
+    case class  SetNCharacterStream(a: Int, b: Reader) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNCharacterStream(a, b))
+    }
+    case class  SetNCharacterStream1(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNCharacterStream(a, b, c))
+    }
+    case class  SetNClob(a: Int, b: NClob) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
+    }
+    case class  SetNClob1(a: Int, b: Reader) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
+    }
+    case class  SetNClob2(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b, c))
+    }
+    case class  SetNString(a: Int, b: String) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNString(a, b))
+    }
+    case class  SetNull(a: Int, b: Int, c: String) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNull(a, b, c))
+    }
+    case class  SetNull1(a: Int, b: Int) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNull(a, b))
+    }
+    case class  SetObject(a: Int, b: Object, c: SQLType) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
+    }
+    case class  SetObject1(a: Int, b: Object, c: Int) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
+    }
+    case class  SetObject2(a: Int, b: Object, c: Int, d: Int) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
+    }
+    case class  SetObject3(a: Int, b: Object) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b))
+    }
+    case class  SetObject4(a: Int, b: Object, c: SQLType, d: Int) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
+    }
+    case class  SetPoolable(a: Boolean) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setPoolable(a))
+    }
+    case class  SetQueryTimeout(a: Int) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setQueryTimeout(a))
+    }
+    case class  SetRef(a: Int, b: Ref) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setRef(a, b))
+    }
+    case class  SetRowId(a: Int, b: RowId) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setRowId(a, b))
+    }
+    case class  SetSQLXML(a: Int, b: SQLXML) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setSQLXML(a, b))
+    }
+    case class  SetShort(a: Int, b: Short) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setShort(a, b))
+    }
+    case class  SetString(a: Int, b: String) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setString(a, b))
+    }
+    case class  SetTime(a: Int, b: Time) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTime(a, b))
+    }
+    case class  SetTime1(a: Int, b: Time, c: Calendar) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTime(a, b, c))
+    }
+    case class  SetTimestamp(a: Int, b: Timestamp, c: Calendar) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b, c))
+    }
+    case class  SetTimestamp1(a: Int, b: Timestamp) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b))
+    }
+    case class  SetURL(a: Int, b: URL) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setURL(a, b))
+    }
+    case class  SetUnicodeStream(a: Int, b: InputStream, c: Int) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setUnicodeStream(a, b, c))
+    }
+    case class  Unwrap[T](a: Class[T]) extends PreparedStatementOp[T] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.unwrap(a))
+    }
 
   }
   import PreparedStatementOp._ // We use these immediately
@@ -340,6 +613,13 @@ object preparedstatement {
   def delay[A](a: => A): PreparedStatementIO[A] =
     F.liftFC(Pure(a _))
 
+  /**
+   * Backdoor for arbitrary computations on the underlying PreparedStatement.
+   * @group Constructors (Lifting)
+   */
+  def raw[A](f: PreparedStatement => A): PreparedStatementIO[A] =
+    F.liftFC(Raw(f))
+
   /** 
    * @group Constructors (Primitives)
    */
@@ -385,20 +665,26 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
+  val closeOnCompletion: PreparedStatementIO[Unit] =
+    F.liftFC(CloseOnCompletion)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
   val execute: PreparedStatementIO[Boolean] =
     F.liftFC(Execute)
 
   /** 
    * @group Constructors (Primitives)
    */
-  def execute(a: String, b: Int): PreparedStatementIO[Boolean] =
-    F.liftFC(Execute1(a, b))
+  def execute(a: String): PreparedStatementIO[Boolean] =
+    F.liftFC(Execute1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def execute(a: String): PreparedStatementIO[Boolean] =
-    F.liftFC(Execute2(a))
+  def execute(a: String, b: Array[String]): PreparedStatementIO[Boolean] =
+    F.liftFC(Execute2(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -409,7 +695,7 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def execute(a: String, b: Array[String]): PreparedStatementIO[Boolean] =
+  def execute(a: String, b: Int): PreparedStatementIO[Boolean] =
     F.liftFC(Execute4(a, b))
 
   /** 
@@ -417,6 +703,42 @@ object preparedstatement {
    */
   val executeBatch: PreparedStatementIO[Array[Int]] =
     F.liftFC(ExecuteBatch)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val executeLargeBatch: PreparedStatementIO[Array[Long]] =
+    F.liftFC(ExecuteLargeBatch)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val executeLargeUpdate: PreparedStatementIO[Long] =
+    F.liftFC(ExecuteLargeUpdate)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String, b: Array[String]): PreparedStatementIO[Long] =
+    F.liftFC(ExecuteLargeUpdate1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String, b: Array[Int]): PreparedStatementIO[Long] =
+    F.liftFC(ExecuteLargeUpdate2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String, b: Int): PreparedStatementIO[Long] =
+    F.liftFC(ExecuteLargeUpdate3(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String): PreparedStatementIO[Long] =
+    F.liftFC(ExecuteLargeUpdate4(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -439,25 +761,25 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def executeUpdate(a: String, b: Int): PreparedStatementIO[Int] =
-    F.liftFC(ExecuteUpdate1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def executeUpdate(a: String): PreparedStatementIO[Int] =
-    F.liftFC(ExecuteUpdate2(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeUpdate(a: String, b: Array[String]): PreparedStatementIO[Int] =
-    F.liftFC(ExecuteUpdate3(a, b))
+    F.liftFC(ExecuteUpdate1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def executeUpdate(a: String, b: Array[Int]): PreparedStatementIO[Int] =
+    F.liftFC(ExecuteUpdate2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeUpdate(a: String, b: Int): PreparedStatementIO[Int] =
+    F.liftFC(ExecuteUpdate3(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeUpdate(a: String, b: Array[String]): PreparedStatementIO[Int] =
     F.liftFC(ExecuteUpdate4(a, b))
 
   /** 
@@ -483,6 +805,18 @@ object preparedstatement {
    */
   val getGeneratedKeys: PreparedStatementIO[ResultSet] =
     F.liftFC(GetGeneratedKeys)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val getLargeMaxRows: PreparedStatementIO[Long] =
+    F.liftFC(GetLargeMaxRows)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val getLargeUpdateCount: PreparedStatementIO[Long] =
+    F.liftFC(GetLargeUpdateCount)
 
   /** 
    * @group Constructors (Primitives)
@@ -565,6 +899,12 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
+  val isCloseOnCompletion: PreparedStatementIO[Boolean] =
+    F.liftFC(IsCloseOnCompletion)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
   val isClosed: PreparedStatementIO[Boolean] =
     F.liftFC(IsClosed)
 
@@ -589,7 +929,7 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setAsciiStream(a: Int, b: InputStream, c: Int): PreparedStatementIO[Unit] =
+  def setAsciiStream(a: Int, b: InputStream, c: Long): PreparedStatementIO[Unit] =
     F.liftFC(SetAsciiStream(a, b, c))
 
   /** 
@@ -601,7 +941,7 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setAsciiStream(a: Int, b: InputStream, c: Long): PreparedStatementIO[Unit] =
+  def setAsciiStream(a: Int, b: InputStream, c: Int): PreparedStatementIO[Unit] =
     F.liftFC(SetAsciiStream2(a, b, c))
 
   /** 
@@ -619,13 +959,13 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setBinaryStream(a: Int, b: InputStream, c: Long): PreparedStatementIO[Unit] =
+  def setBinaryStream(a: Int, b: InputStream, c: Int): PreparedStatementIO[Unit] =
     F.liftFC(SetBinaryStream1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setBinaryStream(a: Int, b: InputStream, c: Int): PreparedStatementIO[Unit] =
+  def setBinaryStream(a: Int, b: InputStream, c: Long): PreparedStatementIO[Unit] =
     F.liftFC(SetBinaryStream2(a, b, c))
 
   /** 
@@ -667,26 +1007,26 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setCharacterStream(a: Int, b: Reader): PreparedStatementIO[Unit] =
-    F.liftFC(SetCharacterStream(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def setCharacterStream(a: Int, b: Reader, c: Int): PreparedStatementIO[Unit] =
-    F.liftFC(SetCharacterStream1(a, b, c))
+    F.liftFC(SetCharacterStream(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setCharacterStream(a: Int, b: Reader, c: Long): PreparedStatementIO[Unit] =
-    F.liftFC(SetCharacterStream2(a, b, c))
+    F.liftFC(SetCharacterStream1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setClob(a: Int, b: Clob): PreparedStatementIO[Unit] =
-    F.liftFC(SetClob(a, b))
+  def setCharacterStream(a: Int, b: Reader): PreparedStatementIO[Unit] =
+    F.liftFC(SetCharacterStream2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setClob(a: Int, b: Reader, c: Long): PreparedStatementIO[Unit] =
+    F.liftFC(SetClob(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -697,8 +1037,8 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setClob(a: Int, b: Reader, c: Long): PreparedStatementIO[Unit] =
-    F.liftFC(SetClob2(a, b, c))
+  def setClob(a: Int, b: Clob): PreparedStatementIO[Unit] =
+    F.liftFC(SetClob2(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -757,6 +1097,12 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
+  def setLargeMaxRows(a: Long): PreparedStatementIO[Unit] =
+    F.liftFC(SetLargeMaxRows(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
   def setLong(a: Int, b: Long): PreparedStatementIO[Unit] =
     F.liftFC(SetLong(a, b))
 
@@ -787,20 +1133,20 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setNClob(a: Int, b: Reader): PreparedStatementIO[Unit] =
+  def setNClob(a: Int, b: NClob): PreparedStatementIO[Unit] =
     F.liftFC(SetNClob(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setNClob(a: Int, b: Reader, c: Long): PreparedStatementIO[Unit] =
-    F.liftFC(SetNClob1(a, b, c))
+  def setNClob(a: Int, b: Reader): PreparedStatementIO[Unit] =
+    F.liftFC(SetNClob1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setNClob(a: Int, b: NClob): PreparedStatementIO[Unit] =
-    F.liftFC(SetNClob2(a, b))
+  def setNClob(a: Int, b: Reader, c: Long): PreparedStatementIO[Unit] =
+    F.liftFC(SetNClob2(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -823,20 +1169,32 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setObject(a: Int, b: Object, c: Int): PreparedStatementIO[Unit] =
+  def setObject(a: Int, b: Object, c: SQLType): PreparedStatementIO[Unit] =
     F.liftFC(SetObject(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setObject(a: Int, b: Object): PreparedStatementIO[Unit] =
-    F.liftFC(SetObject1(a, b))
+  def setObject(a: Int, b: Object, c: Int): PreparedStatementIO[Unit] =
+    F.liftFC(SetObject1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setObject(a: Int, b: Object, c: Int, d: Int): PreparedStatementIO[Unit] =
     F.liftFC(SetObject2(a, b, c, d))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setObject(a: Int, b: Object): PreparedStatementIO[Unit] =
+    F.liftFC(SetObject3(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setObject(a: Int, b: Object, c: SQLType, d: Int): PreparedStatementIO[Unit] =
+    F.liftFC(SetObject4(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
@@ -883,14 +1241,14 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setTime(a: Int, b: Time, c: Calendar): PreparedStatementIO[Unit] =
-    F.liftFC(SetTime(a, b, c))
+  def setTime(a: Int, b: Time): PreparedStatementIO[Unit] =
+    F.liftFC(SetTime(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setTime(a: Int, b: Time): PreparedStatementIO[Unit] =
-    F.liftFC(SetTime1(a, b))
+  def setTime(a: Int, b: Time, c: Calendar): PreparedStatementIO[Unit] =
+    F.liftFC(SetTime1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -926,138 +1284,10 @@ object preparedstatement {
   * Natural transformation from `PreparedStatementOp` to `Kleisli` for the given `M`, consuming a `java.sql.PreparedStatement`. 
   * @group Algebra
   */
- def kleisliTrans[M[_]: Monad: Catchable: Capture]: PreparedStatementOp ~> ({type l[a] = Kleisli[M, PreparedStatement, a]})#l =
-   new (PreparedStatementOp ~> ({type l[a] = Kleisli[M, PreparedStatement, a]})#l) {
-     import scalaz.syntax.catchable._
-
-     val L = Predef.implicitly[Capture[M]]
-
-     def primitive[A](f: PreparedStatement => A): Kleisli[M, PreparedStatement, A] =
-       Kleisli(s => L.apply(f(s)))
-
-     def apply[A](op: PreparedStatementOp[A]): Kleisli[M, PreparedStatement, A] = 
-       op match {
-
-        // Lifting
-        case LiftBlobIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftCallableStatementIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftClobIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftConnectionIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftDatabaseMetaDataIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftDriverIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftNClobIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftRefIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftResultSetIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftSQLDataIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftSQLInputIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftSQLOutputIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftStatementIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-  
-        // Combinators
-        case Pure(a) => primitive(_ => a())
-        case Attempt(a) => a.transK[M].attempt
-  
-        // Primitive Operations
-        case AddBatch => primitive(_.addBatch)
-        case AddBatch1(a) => primitive(_.addBatch(a))
-        case Cancel => primitive(_.cancel)
-        case ClearBatch => primitive(_.clearBatch)
-        case ClearParameters => primitive(_.clearParameters)
-        case ClearWarnings => primitive(_.clearWarnings)
-        case Close => primitive(_.close)
-        case Execute => primitive(_.execute)
-        case Execute1(a, b) => primitive(_.execute(a, b))
-        case Execute2(a) => primitive(_.execute(a))
-        case Execute3(a, b) => primitive(_.execute(a, b))
-        case Execute4(a, b) => primitive(_.execute(a, b))
-        case ExecuteBatch => primitive(_.executeBatch)
-        case ExecuteQuery => primitive(_.executeQuery)
-        case ExecuteQuery1(a) => primitive(_.executeQuery(a))
-        case ExecuteUpdate => primitive(_.executeUpdate)
-        case ExecuteUpdate1(a, b) => primitive(_.executeUpdate(a, b))
-        case ExecuteUpdate2(a) => primitive(_.executeUpdate(a))
-        case ExecuteUpdate3(a, b) => primitive(_.executeUpdate(a, b))
-        case ExecuteUpdate4(a, b) => primitive(_.executeUpdate(a, b))
-        case GetConnection => primitive(_.getConnection)
-        case GetFetchDirection => primitive(_.getFetchDirection)
-        case GetFetchSize => primitive(_.getFetchSize)
-        case GetGeneratedKeys => primitive(_.getGeneratedKeys)
-        case GetMaxFieldSize => primitive(_.getMaxFieldSize)
-        case GetMaxRows => primitive(_.getMaxRows)
-        case GetMetaData => primitive(_.getMetaData)
-        case GetMoreResults(a) => primitive(_.getMoreResults(a))
-        case GetMoreResults1 => primitive(_.getMoreResults)
-        case GetParameterMetaData => primitive(_.getParameterMetaData)
-        case GetQueryTimeout => primitive(_.getQueryTimeout)
-        case GetResultSet => primitive(_.getResultSet)
-        case GetResultSetConcurrency => primitive(_.getResultSetConcurrency)
-        case GetResultSetHoldability => primitive(_.getResultSetHoldability)
-        case GetResultSetType => primitive(_.getResultSetType)
-        case GetUpdateCount => primitive(_.getUpdateCount)
-        case GetWarnings => primitive(_.getWarnings)
-        case IsClosed => primitive(_.isClosed)
-        case IsPoolable => primitive(_.isPoolable)
-        case IsWrapperFor(a) => primitive(_.isWrapperFor(a))
-        case SetArray(a, b) => primitive(_.setArray(a, b))
-        case SetAsciiStream(a, b, c) => primitive(_.setAsciiStream(a, b, c))
-        case SetAsciiStream1(a, b) => primitive(_.setAsciiStream(a, b))
-        case SetAsciiStream2(a, b, c) => primitive(_.setAsciiStream(a, b, c))
-        case SetBigDecimal(a, b) => primitive(_.setBigDecimal(a, b))
-        case SetBinaryStream(a, b) => primitive(_.setBinaryStream(a, b))
-        case SetBinaryStream1(a, b, c) => primitive(_.setBinaryStream(a, b, c))
-        case SetBinaryStream2(a, b, c) => primitive(_.setBinaryStream(a, b, c))
-        case SetBlob(a, b) => primitive(_.setBlob(a, b))
-        case SetBlob1(a, b) => primitive(_.setBlob(a, b))
-        case SetBlob2(a, b, c) => primitive(_.setBlob(a, b, c))
-        case SetBoolean(a, b) => primitive(_.setBoolean(a, b))
-        case SetByte(a, b) => primitive(_.setByte(a, b))
-        case SetBytes(a, b) => primitive(_.setBytes(a, b))
-        case SetCharacterStream(a, b) => primitive(_.setCharacterStream(a, b))
-        case SetCharacterStream1(a, b, c) => primitive(_.setCharacterStream(a, b, c))
-        case SetCharacterStream2(a, b, c) => primitive(_.setCharacterStream(a, b, c))
-        case SetClob(a, b) => primitive(_.setClob(a, b))
-        case SetClob1(a, b) => primitive(_.setClob(a, b))
-        case SetClob2(a, b, c) => primitive(_.setClob(a, b, c))
-        case SetCursorName(a) => primitive(_.setCursorName(a))
-        case SetDate(a, b, c) => primitive(_.setDate(a, b, c))
-        case SetDate1(a, b) => primitive(_.setDate(a, b))
-        case SetDouble(a, b) => primitive(_.setDouble(a, b))
-        case SetEscapeProcessing(a) => primitive(_.setEscapeProcessing(a))
-        case SetFetchDirection(a) => primitive(_.setFetchDirection(a))
-        case SetFetchSize(a) => primitive(_.setFetchSize(a))
-        case SetFloat(a, b) => primitive(_.setFloat(a, b))
-        case SetInt(a, b) => primitive(_.setInt(a, b))
-        case SetLong(a, b) => primitive(_.setLong(a, b))
-        case SetMaxFieldSize(a) => primitive(_.setMaxFieldSize(a))
-        case SetMaxRows(a) => primitive(_.setMaxRows(a))
-        case SetNCharacterStream(a, b) => primitive(_.setNCharacterStream(a, b))
-        case SetNCharacterStream1(a, b, c) => primitive(_.setNCharacterStream(a, b, c))
-        case SetNClob(a, b) => primitive(_.setNClob(a, b))
-        case SetNClob1(a, b, c) => primitive(_.setNClob(a, b, c))
-        case SetNClob2(a, b) => primitive(_.setNClob(a, b))
-        case SetNString(a, b) => primitive(_.setNString(a, b))
-        case SetNull(a, b, c) => primitive(_.setNull(a, b, c))
-        case SetNull1(a, b) => primitive(_.setNull(a, b))
-        case SetObject(a, b, c) => primitive(_.setObject(a, b, c))
-        case SetObject1(a, b) => primitive(_.setObject(a, b))
-        case SetObject2(a, b, c, d) => primitive(_.setObject(a, b, c, d))
-        case SetPoolable(a) => primitive(_.setPoolable(a))
-        case SetQueryTimeout(a) => primitive(_.setQueryTimeout(a))
-        case SetRef(a, b) => primitive(_.setRef(a, b))
-        case SetRowId(a, b) => primitive(_.setRowId(a, b))
-        case SetSQLXML(a, b) => primitive(_.setSQLXML(a, b))
-        case SetShort(a, b) => primitive(_.setShort(a, b))
-        case SetString(a, b) => primitive(_.setString(a, b))
-        case SetTime(a, b, c) => primitive(_.setTime(a, b, c))
-        case SetTime1(a, b) => primitive(_.setTime(a, b))
-        case SetTimestamp(a, b, c) => primitive(_.setTimestamp(a, b, c))
-        case SetTimestamp1(a, b) => primitive(_.setTimestamp(a, b))
-        case SetURL(a, b) => primitive(_.setURL(a, b))
-        case SetUnicodeStream(a, b, c) => primitive(_.setUnicodeStream(a, b, c))
-        case Unwrap(a) => primitive(_.unwrap(a))
-  
-      }
-  
+  def kleisliTrans[M[_]: Monad: Catchable: Capture]: PreparedStatementOp ~> Kleisli[M, PreparedStatement, ?] =
+    new (PreparedStatementOp ~> Kleisli[M, PreparedStatement, ?]) {
+      def apply[A](op: PreparedStatementOp[A]): Kleisli[M, PreparedStatement, A] =
+        op.defaultTransK[M]
     }
 
   /**
@@ -1066,7 +1296,7 @@ object preparedstatement {
    */
   implicit class PreparedStatementIOOps[A](ma: PreparedStatementIO[A]) {
     def transK[M[_]: Monad: Catchable: Capture]: Kleisli[M, PreparedStatement, A] =
-      F.runFC[PreparedStatementOp,({type l[a]=Kleisli[M,PreparedStatement,a]})#l,A](ma)(kleisliTrans[M])
+      F.runFC[PreparedStatementOp, Kleisli[M, PreparedStatement, ?], A](ma)(kleisliTrans[M])
   }
 
 }

--- a/core/src/main/scala/doobie/free/resultset.scala
+++ b/core/src/main/scala/doobie/free/resultset.scala
@@ -28,7 +28,6 @@ import java.sql.RowId
 import java.sql.SQLData
 import java.sql.SQLInput
 import java.sql.SQLOutput
-import java.sql.SQLType
 import java.sql.SQLWarning
 import java.sql.SQLXML
 import java.sql.Statement
@@ -187,23 +186,23 @@ object resultset {
     case class  GetArray1(a: Int) extends ResultSetOp[SqlArray] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getArray(a))
     }
-    case class  GetAsciiStream(a: Int) extends ResultSetOp[InputStream] {
+    case class  GetAsciiStream(a: String) extends ResultSetOp[InputStream] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getAsciiStream(a))
     }
-    case class  GetAsciiStream1(a: String) extends ResultSetOp[InputStream] {
+    case class  GetAsciiStream1(a: Int) extends ResultSetOp[InputStream] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getAsciiStream(a))
     }
     case class  GetBigDecimal(a: String, b: Int) extends ResultSetOp[BigDecimal] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a, b))
     }
-    case class  GetBigDecimal1(a: Int, b: Int) extends ResultSetOp[BigDecimal] {
+    case class  GetBigDecimal1(a: String) extends ResultSetOp[BigDecimal] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a))
+    }
+    case class  GetBigDecimal2(a: Int) extends ResultSetOp[BigDecimal] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a))
+    }
+    case class  GetBigDecimal3(a: Int, b: Int) extends ResultSetOp[BigDecimal] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a, b))
-    }
-    case class  GetBigDecimal2(a: String) extends ResultSetOp[BigDecimal] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a))
-    }
-    case class  GetBigDecimal3(a: Int) extends ResultSetOp[BigDecimal] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a))
     }
     case class  GetBinaryStream(a: String) extends ResultSetOp[InputStream] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBinaryStream(a))
@@ -217,10 +216,10 @@ object resultset {
     case class  GetBlob1(a: Int) extends ResultSetOp[Blob] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBlob(a))
     }
-    case class  GetBoolean(a: Int) extends ResultSetOp[Boolean] {
+    case class  GetBoolean(a: String) extends ResultSetOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBoolean(a))
     }
-    case class  GetBoolean1(a: String) extends ResultSetOp[Boolean] {
+    case class  GetBoolean1(a: Int) extends ResultSetOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBoolean(a))
     }
     case class  GetByte(a: String) extends ResultSetOp[Byte] {
@@ -241,10 +240,10 @@ object resultset {
     case class  GetCharacterStream1(a: String) extends ResultSetOp[Reader] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getCharacterStream(a))
     }
-    case class  GetClob(a: Int) extends ResultSetOp[Clob] {
+    case class  GetClob(a: String) extends ResultSetOp[Clob] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getClob(a))
     }
-    case class  GetClob1(a: String) extends ResultSetOp[Clob] {
+    case class  GetClob1(a: Int) extends ResultSetOp[Clob] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getClob(a))
     }
     case object GetConcurrency extends ResultSetOp[Int] {
@@ -253,17 +252,17 @@ object resultset {
     case object GetCursorName extends ResultSetOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getCursorName())
     }
-    case class  GetDate(a: String) extends ResultSetOp[Date] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a))
-    }
-    case class  GetDate1(a: String, b: Calendar) extends ResultSetOp[Date] {
+    case class  GetDate(a: String, b: Calendar) extends ResultSetOp[Date] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a, b))
     }
-    case class  GetDate2(a: Int) extends ResultSetOp[Date] {
+    case class  GetDate1(a: Int, b: Calendar) extends ResultSetOp[Date] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a, b))
+    }
+    case class  GetDate2(a: String) extends ResultSetOp[Date] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a))
     }
-    case class  GetDate3(a: Int, b: Calendar) extends ResultSetOp[Date] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a, b))
+    case class  GetDate3(a: Int) extends ResultSetOp[Date] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a))
     }
     case class  GetDouble(a: String) extends ResultSetOp[Double] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDouble(a))
@@ -277,19 +276,19 @@ object resultset {
     case object GetFetchSize extends ResultSetOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getFetchSize())
     }
-    case class  GetFloat(a: String) extends ResultSetOp[Float] {
+    case class  GetFloat(a: Int) extends ResultSetOp[Float] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getFloat(a))
     }
-    case class  GetFloat1(a: Int) extends ResultSetOp[Float] {
+    case class  GetFloat1(a: String) extends ResultSetOp[Float] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getFloat(a))
     }
     case object GetHoldability extends ResultSetOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getHoldability())
     }
-    case class  GetInt(a: Int) extends ResultSetOp[Int] {
+    case class  GetInt(a: String) extends ResultSetOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getInt(a))
     }
-    case class  GetInt1(a: String) extends ResultSetOp[Int] {
+    case class  GetInt1(a: Int) extends ResultSetOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getInt(a))
     }
     case class  GetLong(a: String) extends ResultSetOp[Long] {
@@ -301,16 +300,16 @@ object resultset {
     case object GetMetaData extends ResultSetOp[ResultSetMetaData] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMetaData())
     }
-    case class  GetNCharacterStream(a: String) extends ResultSetOp[Reader] {
+    case class  GetNCharacterStream(a: Int) extends ResultSetOp[Reader] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNCharacterStream(a))
     }
-    case class  GetNCharacterStream1(a: Int) extends ResultSetOp[Reader] {
+    case class  GetNCharacterStream1(a: String) extends ResultSetOp[Reader] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNCharacterStream(a))
     }
-    case class  GetNClob(a: Int) extends ResultSetOp[NClob] {
+    case class  GetNClob(a: String) extends ResultSetOp[NClob] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNClob(a))
     }
-    case class  GetNClob1(a: String) extends ResultSetOp[NClob] {
+    case class  GetNClob1(a: Int) extends ResultSetOp[NClob] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNClob(a))
     }
     case class  GetNString(a: String) extends ResultSetOp[String] {
@@ -319,17 +318,17 @@ object resultset {
     case class  GetNString1(a: Int) extends ResultSetOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNString(a))
     }
-    case class  GetObject(a: Int, b: Map[String, Class[_]]) extends ResultSetOp[Object] {
+    case class  GetObject(a: String, b: Map[String, Class[_]]) extends ResultSetOp[Object] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
     }
-    case class  GetObject1(a: String) extends ResultSetOp[Object] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a))
+    case class  GetObject1(a: Int, b: Map[String, Class[_]]) extends ResultSetOp[Object] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
     }
     case class  GetObject2(a: Int) extends ResultSetOp[Object] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a))
     }
-    case class  GetObject3(a: String, b: Map[String, Class[_]]) extends ResultSetOp[Object] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
+    case class  GetObject3(a: String) extends ResultSetOp[Object] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a))
     }
     case class  GetObject4[T](a: Int, b: Class[T]) extends ResultSetOp[T] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
@@ -346,10 +345,10 @@ object resultset {
     case object GetRow extends ResultSetOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getRow())
     }
-    case class  GetRowId(a: Int) extends ResultSetOp[RowId] {
+    case class  GetRowId(a: String) extends ResultSetOp[RowId] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getRowId(a))
     }
-    case class  GetRowId1(a: String) extends ResultSetOp[RowId] {
+    case class  GetRowId1(a: Int) extends ResultSetOp[RowId] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getRowId(a))
     }
     case class  GetSQLXML(a: Int) extends ResultSetOp[SQLXML] {
@@ -379,31 +378,31 @@ object resultset {
     case class  GetTime1(a: String, b: Calendar) extends ResultSetOp[Time] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a, b))
     }
-    case class  GetTime2(a: String) extends ResultSetOp[Time] {
+    case class  GetTime2(a: Int) extends ResultSetOp[Time] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a))
     }
-    case class  GetTime3(a: Int) extends ResultSetOp[Time] {
+    case class  GetTime3(a: String) extends ResultSetOp[Time] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a))
     }
-    case class  GetTimestamp(a: String, b: Calendar) extends ResultSetOp[Timestamp] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a, b))
-    }
-    case class  GetTimestamp1(a: Int) extends ResultSetOp[Timestamp] {
+    case class  GetTimestamp(a: Int) extends ResultSetOp[Timestamp] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a))
     }
-    case class  GetTimestamp2(a: Int, b: Calendar) extends ResultSetOp[Timestamp] {
+    case class  GetTimestamp1(a: Int, b: Calendar) extends ResultSetOp[Timestamp] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a, b))
     }
-    case class  GetTimestamp3(a: String) extends ResultSetOp[Timestamp] {
+    case class  GetTimestamp2(a: String) extends ResultSetOp[Timestamp] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a))
+    }
+    case class  GetTimestamp3(a: String, b: Calendar) extends ResultSetOp[Timestamp] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a, b))
     }
     case object GetType extends ResultSetOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getType())
     }
-    case class  GetURL(a: String) extends ResultSetOp[URL] {
+    case class  GetURL(a: Int) extends ResultSetOp[URL] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getURL(a))
     }
-    case class  GetURL1(a: Int) extends ResultSetOp[URL] {
+    case class  GetURL1(a: String) extends ResultSetOp[URL] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getURL(a))
     }
     case class  GetUnicodeStream(a: String) extends ResultSetOp[InputStream] {
@@ -481,22 +480,22 @@ object resultset {
     case class  UpdateArray1(a: Int, b: SqlArray) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateArray(a, b))
     }
-    case class  UpdateAsciiStream(a: String, b: InputStream, c: Int) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateAsciiStream(a, b, c))
-    }
-    case class  UpdateAsciiStream1(a: Int, b: InputStream) extends ResultSetOp[Unit] {
+    case class  UpdateAsciiStream(a: String, b: InputStream) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateAsciiStream(a, b))
     }
-    case class  UpdateAsciiStream2(a: Int, b: InputStream, c: Long) extends ResultSetOp[Unit] {
+    case class  UpdateAsciiStream1(a: Int, b: InputStream, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateAsciiStream(a, b, c))
     }
-    case class  UpdateAsciiStream3(a: String, b: InputStream) extends ResultSetOp[Unit] {
+    case class  UpdateAsciiStream2(a: String, b: InputStream, c: Int) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateAsciiStream(a, b, c))
+    }
+    case class  UpdateAsciiStream3(a: Int, b: InputStream) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateAsciiStream(a, b))
     }
-    case class  UpdateAsciiStream4(a: Int, b: InputStream, c: Int) extends ResultSetOp[Unit] {
+    case class  UpdateAsciiStream4(a: String, b: InputStream, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateAsciiStream(a, b, c))
     }
-    case class  UpdateAsciiStream5(a: String, b: InputStream, c: Long) extends ResultSetOp[Unit] {
+    case class  UpdateAsciiStream5(a: Int, b: InputStream, c: Int) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateAsciiStream(a, b, c))
     }
     case class  UpdateBigDecimal(a: String, b: BigDecimal) extends ResultSetOp[Unit] {
@@ -505,58 +504,58 @@ object resultset {
     case class  UpdateBigDecimal1(a: Int, b: BigDecimal) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBigDecimal(a, b))
     }
-    case class  UpdateBinaryStream(a: Int, b: InputStream, c: Int) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b, c))
-    }
-    case class  UpdateBinaryStream1(a: String, b: InputStream, c: Long) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b, c))
-    }
-    case class  UpdateBinaryStream2(a: Int, b: InputStream) extends ResultSetOp[Unit] {
+    case class  UpdateBinaryStream(a: String, b: InputStream) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b))
     }
-    case class  UpdateBinaryStream3(a: String, b: InputStream, c: Int) extends ResultSetOp[Unit] {
+    case class  UpdateBinaryStream1(a: Int, b: InputStream, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b, c))
     }
-    case class  UpdateBinaryStream4(a: Int, b: InputStream, c: Long) extends ResultSetOp[Unit] {
+    case class  UpdateBinaryStream2(a: String, b: InputStream, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b, c))
     }
-    case class  UpdateBinaryStream5(a: String, b: InputStream) extends ResultSetOp[Unit] {
+    case class  UpdateBinaryStream3(a: Int, b: InputStream) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b))
     }
-    case class  UpdateBlob(a: Int, b: InputStream, c: Long) extends ResultSetOp[Unit] {
+    case class  UpdateBinaryStream4(a: String, b: InputStream, c: Int) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b, c))
+    }
+    case class  UpdateBinaryStream5(a: Int, b: InputStream, c: Int) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b, c))
+    }
+    case class  UpdateBlob(a: Int, b: Blob) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b))
+    }
+    case class  UpdateBlob1(a: String, b: Blob) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b))
+    }
+    case class  UpdateBlob2(a: String, b: InputStream, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b, c))
     }
-    case class  UpdateBlob1(a: String, b: InputStream, c: Long) extends ResultSetOp[Unit] {
+    case class  UpdateBlob3(a: Int, b: InputStream, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b, c))
     }
-    case class  UpdateBlob2(a: String, b: InputStream) extends ResultSetOp[Unit] {
+    case class  UpdateBlob4(a: Int, b: InputStream) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b))
     }
-    case class  UpdateBlob3(a: Int, b: InputStream) extends ResultSetOp[Unit] {
+    case class  UpdateBlob5(a: String, b: InputStream) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b))
     }
-    case class  UpdateBlob4(a: Int, b: Blob) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b))
-    }
-    case class  UpdateBlob5(a: String, b: Blob) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b))
-    }
-    case class  UpdateBoolean(a: String, b: Boolean) extends ResultSetOp[Unit] {
+    case class  UpdateBoolean(a: Int, b: Boolean) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBoolean(a, b))
     }
-    case class  UpdateBoolean1(a: Int, b: Boolean) extends ResultSetOp[Unit] {
+    case class  UpdateBoolean1(a: String, b: Boolean) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBoolean(a, b))
     }
-    case class  UpdateByte(a: Int, b: Byte) extends ResultSetOp[Unit] {
+    case class  UpdateByte(a: String, b: Byte) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateByte(a, b))
     }
-    case class  UpdateByte1(a: String, b: Byte) extends ResultSetOp[Unit] {
+    case class  UpdateByte1(a: Int, b: Byte) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateByte(a, b))
     }
-    case class  UpdateBytes(a: String, b: Array[Byte]) extends ResultSetOp[Unit] {
+    case class  UpdateBytes(a: Int, b: Array[Byte]) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBytes(a, b))
     }
-    case class  UpdateBytes1(a: Int, b: Array[Byte]) extends ResultSetOp[Unit] {
+    case class  UpdateBytes1(a: String, b: Array[Byte]) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBytes(a, b))
     }
     case class  UpdateCharacterStream(a: Int, b: Reader, c: Int) extends ResultSetOp[Unit] {
@@ -568,29 +567,29 @@ object resultset {
     case class  UpdateCharacterStream2(a: String, b: Reader, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateCharacterStream(a, b, c))
     }
-    case class  UpdateCharacterStream3(a: String, b: Reader) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateCharacterStream(a, b))
+    case class  UpdateCharacterStream3(a: Int, b: Reader, c: Long) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateCharacterStream(a, b, c))
     }
     case class  UpdateCharacterStream4(a: Int, b: Reader) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateCharacterStream(a, b))
     }
-    case class  UpdateCharacterStream5(a: Int, b: Reader, c: Long) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateCharacterStream(a, b, c))
+    case class  UpdateCharacterStream5(a: String, b: Reader) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateCharacterStream(a, b))
     }
-    case class  UpdateClob(a: String, b: Reader) extends ResultSetOp[Unit] {
+    case class  UpdateClob(a: Int, b: Reader) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateClob(a, b))
     }
-    case class  UpdateClob1(a: Int, b: Reader, c: Long) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateClob(a, b, c))
+    case class  UpdateClob1(a: Int, b: Clob) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateClob(a, b))
     }
-    case class  UpdateClob2(a: Int, b: Reader) extends ResultSetOp[Unit] {
+    case class  UpdateClob2(a: String, b: Reader) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateClob(a, b))
     }
     case class  UpdateClob3(a: String, b: Reader, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateClob(a, b, c))
     }
-    case class  UpdateClob4(a: Int, b: Clob) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateClob(a, b))
+    case class  UpdateClob4(a: Int, b: Reader, c: Long) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateClob(a, b, c))
     }
     case class  UpdateClob5(a: String, b: Clob) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateClob(a, b))
@@ -607,16 +606,16 @@ object resultset {
     case class  UpdateDouble1(a: Int, b: Double) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateDouble(a, b))
     }
-    case class  UpdateFloat(a: String, b: Float) extends ResultSetOp[Unit] {
+    case class  UpdateFloat(a: Int, b: Float) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateFloat(a, b))
     }
-    case class  UpdateFloat1(a: Int, b: Float) extends ResultSetOp[Unit] {
+    case class  UpdateFloat1(a: String, b: Float) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateFloat(a, b))
     }
-    case class  UpdateInt(a: String, b: Int) extends ResultSetOp[Unit] {
+    case class  UpdateInt(a: Int, b: Int) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateInt(a, b))
     }
-    case class  UpdateInt1(a: Int, b: Int) extends ResultSetOp[Unit] {
+    case class  UpdateInt1(a: String, b: Int) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateInt(a, b))
     }
     case class  UpdateLong(a: String, b: Long) extends ResultSetOp[Unit] {
@@ -625,35 +624,35 @@ object resultset {
     case class  UpdateLong1(a: Int, b: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateLong(a, b))
     }
-    case class  UpdateNCharacterStream(a: String, b: Reader, c: Long) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNCharacterStream(a, b, c))
+    case class  UpdateNCharacterStream(a: Int, b: Reader) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNCharacterStream(a, b))
     }
     case class  UpdateNCharacterStream1(a: String, b: Reader) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNCharacterStream(a, b))
     }
-    case class  UpdateNCharacterStream2(a: Int, b: Reader) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNCharacterStream(a, b))
-    }
-    case class  UpdateNCharacterStream3(a: Int, b: Reader, c: Long) extends ResultSetOp[Unit] {
+    case class  UpdateNCharacterStream2(a: Int, b: Reader, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNCharacterStream(a, b, c))
     }
-    case class  UpdateNClob(a: Int, b: Reader, c: Long) extends ResultSetOp[Unit] {
+    case class  UpdateNCharacterStream3(a: String, b: Reader, c: Long) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNCharacterStream(a, b, c))
+    }
+    case class  UpdateNClob(a: Int, b: NClob) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b))
+    }
+    case class  UpdateNClob1(a: String, b: NClob) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b))
+    }
+    case class  UpdateNClob2(a: Int, b: Reader) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b))
+    }
+    case class  UpdateNClob3(a: Int, b: Reader, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b, c))
     }
-    case class  UpdateNClob1(a: Int, b: Reader) extends ResultSetOp[Unit] {
+    case class  UpdateNClob4(a: String, b: Reader) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b))
     }
-    case class  UpdateNClob2(a: String, b: Reader, c: Long) extends ResultSetOp[Unit] {
+    case class  UpdateNClob5(a: String, b: Reader, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b, c))
-    }
-    case class  UpdateNClob3(a: String, b: Reader) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b))
-    }
-    case class  UpdateNClob4(a: Int, b: NClob) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b))
-    }
-    case class  UpdateNClob5(a: String, b: NClob) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b))
     }
     case class  UpdateNString(a: String, b: String) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNString(a, b))
@@ -661,49 +660,37 @@ object resultset {
     case class  UpdateNString1(a: Int, b: String) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNString(a, b))
     }
-    case class  UpdateNull(a: Int) extends ResultSetOp[Unit] {
+    case class  UpdateNull(a: String) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNull(a))
     }
-    case class  UpdateNull1(a: String) extends ResultSetOp[Unit] {
+    case class  UpdateNull1(a: Int) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNull(a))
     }
-    case class  UpdateObject(a: Int, b: Object, c: SQLType, d: Int) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b, c, d))
-    }
-    case class  UpdateObject1(a: String, b: Object, c: SQLType, d: Int) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b, c, d))
-    }
-    case class  UpdateObject2(a: Int, b: Object, c: SQLType) extends ResultSetOp[Unit] {
+    case class  UpdateObject(a: Int, b: Object, c: Int) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b, c))
     }
-    case class  UpdateObject3(a: Int, b: Object, c: Int) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b, c))
-    }
-    case class  UpdateObject4(a: Int, b: Object) extends ResultSetOp[Unit] {
+    case class  UpdateObject1(a: Int, b: Object) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b))
     }
-    case class  UpdateObject5(a: String, b: Object) extends ResultSetOp[Unit] {
+    case class  UpdateObject2(a: String, b: Object, c: Int) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b, c))
+    }
+    case class  UpdateObject3(a: String, b: Object) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b))
     }
-    case class  UpdateObject6(a: String, b: Object, c: Int) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b, c))
-    }
-    case class  UpdateObject7(a: String, b: Object, c: SQLType) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b, c))
-    }
-    case class  UpdateRef(a: String, b: Ref) extends ResultSetOp[Unit] {
+    case class  UpdateRef(a: Int, b: Ref) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateRef(a, b))
     }
-    case class  UpdateRef1(a: Int, b: Ref) extends ResultSetOp[Unit] {
+    case class  UpdateRef1(a: String, b: Ref) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateRef(a, b))
     }
     case object UpdateRow extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateRow())
     }
-    case class  UpdateRowId(a: Int, b: RowId) extends ResultSetOp[Unit] {
+    case class  UpdateRowId(a: String, b: RowId) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateRowId(a, b))
     }
-    case class  UpdateRowId1(a: String, b: RowId) extends ResultSetOp[Unit] {
+    case class  UpdateRowId1(a: Int, b: RowId) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateRowId(a, b))
     }
     case class  UpdateSQLXML(a: Int, b: SQLXML) extends ResultSetOp[Unit] {
@@ -718,10 +705,10 @@ object resultset {
     case class  UpdateShort1(a: Int, b: Short) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateShort(a, b))
     }
-    case class  UpdateString(a: String, b: String) extends ResultSetOp[Unit] {
+    case class  UpdateString(a: Int, b: String) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateString(a, b))
     }
-    case class  UpdateString1(a: Int, b: String) extends ResultSetOp[Unit] {
+    case class  UpdateString1(a: String, b: String) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateString(a, b))
     }
     case class  UpdateTime(a: String, b: Time) extends ResultSetOp[Unit] {
@@ -730,10 +717,10 @@ object resultset {
     case class  UpdateTime1(a: Int, b: Time) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateTime(a, b))
     }
-    case class  UpdateTimestamp(a: String, b: Timestamp) extends ResultSetOp[Unit] {
+    case class  UpdateTimestamp(a: Int, b: Timestamp) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateTimestamp(a, b))
     }
-    case class  UpdateTimestamp1(a: Int, b: Timestamp) extends ResultSetOp[Unit] {
+    case class  UpdateTimestamp1(a: String, b: Timestamp) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateTimestamp(a, b))
     }
     case object WasNull extends ResultSetOp[Boolean] {
@@ -944,13 +931,13 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getAsciiStream(a: Int): ResultSetIO[InputStream] =
+  def getAsciiStream(a: String): ResultSetIO[InputStream] =
     F.liftFC(GetAsciiStream(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getAsciiStream(a: String): ResultSetIO[InputStream] =
+  def getAsciiStream(a: Int): ResultSetIO[InputStream] =
     F.liftFC(GetAsciiStream1(a))
 
   /** 
@@ -962,20 +949,20 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getBigDecimal(a: Int, b: Int): ResultSetIO[BigDecimal] =
-    F.liftFC(GetBigDecimal1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def getBigDecimal(a: String): ResultSetIO[BigDecimal] =
-    F.liftFC(GetBigDecimal2(a))
+    F.liftFC(GetBigDecimal1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getBigDecimal(a: Int): ResultSetIO[BigDecimal] =
-    F.liftFC(GetBigDecimal3(a))
+    F.liftFC(GetBigDecimal2(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getBigDecimal(a: Int, b: Int): ResultSetIO[BigDecimal] =
+    F.liftFC(GetBigDecimal3(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1004,13 +991,13 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getBoolean(a: Int): ResultSetIO[Boolean] =
+  def getBoolean(a: String): ResultSetIO[Boolean] =
     F.liftFC(GetBoolean(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getBoolean(a: String): ResultSetIO[Boolean] =
+  def getBoolean(a: Int): ResultSetIO[Boolean] =
     F.liftFC(GetBoolean1(a))
 
   /** 
@@ -1052,13 +1039,13 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getClob(a: Int): ResultSetIO[Clob] =
+  def getClob(a: String): ResultSetIO[Clob] =
     F.liftFC(GetClob(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getClob(a: String): ResultSetIO[Clob] =
+  def getClob(a: Int): ResultSetIO[Clob] =
     F.liftFC(GetClob1(a))
 
   /** 
@@ -1076,26 +1063,26 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getDate(a: String): ResultSetIO[Date] =
-    F.liftFC(GetDate(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def getDate(a: String, b: Calendar): ResultSetIO[Date] =
-    F.liftFC(GetDate1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getDate(a: Int): ResultSetIO[Date] =
-    F.liftFC(GetDate2(a))
+    F.liftFC(GetDate(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getDate(a: Int, b: Calendar): ResultSetIO[Date] =
-    F.liftFC(GetDate3(a, b))
+    F.liftFC(GetDate1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getDate(a: String): ResultSetIO[Date] =
+    F.liftFC(GetDate2(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getDate(a: Int): ResultSetIO[Date] =
+    F.liftFC(GetDate3(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -1124,13 +1111,13 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getFloat(a: String): ResultSetIO[Float] =
+  def getFloat(a: Int): ResultSetIO[Float] =
     F.liftFC(GetFloat(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getFloat(a: Int): ResultSetIO[Float] =
+  def getFloat(a: String): ResultSetIO[Float] =
     F.liftFC(GetFloat1(a))
 
   /** 
@@ -1142,13 +1129,13 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getInt(a: Int): ResultSetIO[Int] =
+  def getInt(a: String): ResultSetIO[Int] =
     F.liftFC(GetInt(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getInt(a: String): ResultSetIO[Int] =
+  def getInt(a: Int): ResultSetIO[Int] =
     F.liftFC(GetInt1(a))
 
   /** 
@@ -1172,25 +1159,25 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getNCharacterStream(a: String): ResultSetIO[Reader] =
+  def getNCharacterStream(a: Int): ResultSetIO[Reader] =
     F.liftFC(GetNCharacterStream(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getNCharacterStream(a: Int): ResultSetIO[Reader] =
+  def getNCharacterStream(a: String): ResultSetIO[Reader] =
     F.liftFC(GetNCharacterStream1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getNClob(a: Int): ResultSetIO[NClob] =
+  def getNClob(a: String): ResultSetIO[NClob] =
     F.liftFC(GetNClob(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getNClob(a: String): ResultSetIO[NClob] =
+  def getNClob(a: Int): ResultSetIO[NClob] =
     F.liftFC(GetNClob1(a))
 
   /** 
@@ -1208,14 +1195,14 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getObject(a: Int, b: Map[String, Class[_]]): ResultSetIO[Object] =
+  def getObject(a: String, b: Map[String, Class[_]]): ResultSetIO[Object] =
     F.liftFC(GetObject(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getObject(a: String): ResultSetIO[Object] =
-    F.liftFC(GetObject1(a))
+  def getObject(a: Int, b: Map[String, Class[_]]): ResultSetIO[Object] =
+    F.liftFC(GetObject1(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1226,8 +1213,8 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getObject(a: String, b: Map[String, Class[_]]): ResultSetIO[Object] =
-    F.liftFC(GetObject3(a, b))
+  def getObject(a: String): ResultSetIO[Object] =
+    F.liftFC(GetObject3(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -1262,13 +1249,13 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getRowId(a: Int): ResultSetIO[RowId] =
+  def getRowId(a: String): ResultSetIO[RowId] =
     F.liftFC(GetRowId(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getRowId(a: String): ResultSetIO[RowId] =
+  def getRowId(a: Int): ResultSetIO[RowId] =
     F.liftFC(GetRowId1(a))
 
   /** 
@@ -1328,38 +1315,38 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getTime(a: String): ResultSetIO[Time] =
+  def getTime(a: Int): ResultSetIO[Time] =
     F.liftFC(GetTime2(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getTime(a: Int): ResultSetIO[Time] =
+  def getTime(a: String): ResultSetIO[Time] =
     F.liftFC(GetTime3(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getTimestamp(a: String, b: Calendar): ResultSetIO[Timestamp] =
-    F.liftFC(GetTimestamp(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def getTimestamp(a: Int): ResultSetIO[Timestamp] =
-    F.liftFC(GetTimestamp1(a))
+    F.liftFC(GetTimestamp(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getTimestamp(a: Int, b: Calendar): ResultSetIO[Timestamp] =
-    F.liftFC(GetTimestamp2(a, b))
+    F.liftFC(GetTimestamp1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getTimestamp(a: String): ResultSetIO[Timestamp] =
-    F.liftFC(GetTimestamp3(a))
+    F.liftFC(GetTimestamp2(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getTimestamp(a: String, b: Calendar): ResultSetIO[Timestamp] =
+    F.liftFC(GetTimestamp3(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1370,13 +1357,13 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getURL(a: String): ResultSetIO[URL] =
+  def getURL(a: Int): ResultSetIO[URL] =
     F.liftFC(GetURL(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getURL(a: Int): ResultSetIO[URL] =
+  def getURL(a: String): ResultSetIO[URL] =
     F.liftFC(GetURL1(a))
 
   /** 
@@ -1532,37 +1519,37 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateAsciiStream(a: String, b: InputStream, c: Int): ResultSetIO[Unit] =
-    F.liftFC(UpdateAsciiStream(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateAsciiStream(a: Int, b: InputStream): ResultSetIO[Unit] =
-    F.liftFC(UpdateAsciiStream1(a, b))
+  def updateAsciiStream(a: String, b: InputStream): ResultSetIO[Unit] =
+    F.liftFC(UpdateAsciiStream(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateAsciiStream(a: Int, b: InputStream, c: Long): ResultSetIO[Unit] =
+    F.liftFC(UpdateAsciiStream1(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateAsciiStream(a: String, b: InputStream, c: Int): ResultSetIO[Unit] =
     F.liftFC(UpdateAsciiStream2(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateAsciiStream(a: String, b: InputStream): ResultSetIO[Unit] =
+  def updateAsciiStream(a: Int, b: InputStream): ResultSetIO[Unit] =
     F.liftFC(UpdateAsciiStream3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateAsciiStream(a: Int, b: InputStream, c: Int): ResultSetIO[Unit] =
+  def updateAsciiStream(a: String, b: InputStream, c: Long): ResultSetIO[Unit] =
     F.liftFC(UpdateAsciiStream4(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateAsciiStream(a: String, b: InputStream, c: Long): ResultSetIO[Unit] =
+  def updateAsciiStream(a: Int, b: InputStream, c: Int): ResultSetIO[Unit] =
     F.liftFC(UpdateAsciiStream5(a, b, c))
 
   /** 
@@ -1580,109 +1567,109 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateBinaryStream(a: Int, b: InputStream, c: Int): ResultSetIO[Unit] =
-    F.liftFC(UpdateBinaryStream(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateBinaryStream(a: String, b: InputStream, c: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateBinaryStream1(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateBinaryStream(a: Int, b: InputStream): ResultSetIO[Unit] =
-    F.liftFC(UpdateBinaryStream2(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateBinaryStream(a: String, b: InputStream, c: Int): ResultSetIO[Unit] =
-    F.liftFC(UpdateBinaryStream3(a, b, c))
+  def updateBinaryStream(a: String, b: InputStream): ResultSetIO[Unit] =
+    F.liftFC(UpdateBinaryStream(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateBinaryStream(a: Int, b: InputStream, c: Long): ResultSetIO[Unit] =
+    F.liftFC(UpdateBinaryStream1(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateBinaryStream(a: String, b: InputStream, c: Long): ResultSetIO[Unit] =
+    F.liftFC(UpdateBinaryStream2(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateBinaryStream(a: Int, b: InputStream): ResultSetIO[Unit] =
+    F.liftFC(UpdateBinaryStream3(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateBinaryStream(a: String, b: InputStream, c: Int): ResultSetIO[Unit] =
     F.liftFC(UpdateBinaryStream4(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateBinaryStream(a: String, b: InputStream): ResultSetIO[Unit] =
-    F.liftFC(UpdateBinaryStream5(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateBlob(a: Int, b: InputStream, c: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateBlob(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateBlob(a: String, b: InputStream, c: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateBlob1(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateBlob(a: String, b: InputStream): ResultSetIO[Unit] =
-    F.liftFC(UpdateBlob2(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateBlob(a: Int, b: InputStream): ResultSetIO[Unit] =
-    F.liftFC(UpdateBlob3(a, b))
+  def updateBinaryStream(a: Int, b: InputStream, c: Int): ResultSetIO[Unit] =
+    F.liftFC(UpdateBinaryStream5(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateBlob(a: Int, b: Blob): ResultSetIO[Unit] =
-    F.liftFC(UpdateBlob4(a, b))
+    F.liftFC(UpdateBlob(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateBlob(a: String, b: Blob): ResultSetIO[Unit] =
+    F.liftFC(UpdateBlob1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateBlob(a: String, b: InputStream, c: Long): ResultSetIO[Unit] =
+    F.liftFC(UpdateBlob2(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateBlob(a: Int, b: InputStream, c: Long): ResultSetIO[Unit] =
+    F.liftFC(UpdateBlob3(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateBlob(a: Int, b: InputStream): ResultSetIO[Unit] =
+    F.liftFC(UpdateBlob4(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateBlob(a: String, b: InputStream): ResultSetIO[Unit] =
     F.liftFC(UpdateBlob5(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateBoolean(a: String, b: Boolean): ResultSetIO[Unit] =
+  def updateBoolean(a: Int, b: Boolean): ResultSetIO[Unit] =
     F.liftFC(UpdateBoolean(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateBoolean(a: Int, b: Boolean): ResultSetIO[Unit] =
+  def updateBoolean(a: String, b: Boolean): ResultSetIO[Unit] =
     F.liftFC(UpdateBoolean1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateByte(a: Int, b: Byte): ResultSetIO[Unit] =
+  def updateByte(a: String, b: Byte): ResultSetIO[Unit] =
     F.liftFC(UpdateByte(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateByte(a: String, b: Byte): ResultSetIO[Unit] =
+  def updateByte(a: Int, b: Byte): ResultSetIO[Unit] =
     F.liftFC(UpdateByte1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateBytes(a: String, b: Array[Byte]): ResultSetIO[Unit] =
+  def updateBytes(a: Int, b: Array[Byte]): ResultSetIO[Unit] =
     F.liftFC(UpdateBytes(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateBytes(a: Int, b: Array[Byte]): ResultSetIO[Unit] =
+  def updateBytes(a: String, b: Array[Byte]): ResultSetIO[Unit] =
     F.liftFC(UpdateBytes1(a, b))
 
   /** 
@@ -1706,8 +1693,8 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateCharacterStream(a: String, b: Reader): ResultSetIO[Unit] =
-    F.liftFC(UpdateCharacterStream3(a, b))
+  def updateCharacterStream(a: Int, b: Reader, c: Long): ResultSetIO[Unit] =
+    F.liftFC(UpdateCharacterStream3(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -1718,25 +1705,25 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateCharacterStream(a: Int, b: Reader, c: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateCharacterStream5(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateClob(a: String, b: Reader): ResultSetIO[Unit] =
-    F.liftFC(UpdateClob(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateClob(a: Int, b: Reader, c: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateClob1(a, b, c))
+  def updateCharacterStream(a: String, b: Reader): ResultSetIO[Unit] =
+    F.liftFC(UpdateCharacterStream5(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateClob(a: Int, b: Reader): ResultSetIO[Unit] =
+    F.liftFC(UpdateClob(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateClob(a: Int, b: Clob): ResultSetIO[Unit] =
+    F.liftFC(UpdateClob1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateClob(a: String, b: Reader): ResultSetIO[Unit] =
     F.liftFC(UpdateClob2(a, b))
 
   /** 
@@ -1748,8 +1735,8 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateClob(a: Int, b: Clob): ResultSetIO[Unit] =
-    F.liftFC(UpdateClob4(a, b))
+  def updateClob(a: Int, b: Reader, c: Long): ResultSetIO[Unit] =
+    F.liftFC(UpdateClob4(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -1784,25 +1771,25 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateFloat(a: String, b: Float): ResultSetIO[Unit] =
+  def updateFloat(a: Int, b: Float): ResultSetIO[Unit] =
     F.liftFC(UpdateFloat(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateFloat(a: Int, b: Float): ResultSetIO[Unit] =
+  def updateFloat(a: String, b: Float): ResultSetIO[Unit] =
     F.liftFC(UpdateFloat1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateInt(a: String, b: Int): ResultSetIO[Unit] =
+  def updateInt(a: Int, b: Int): ResultSetIO[Unit] =
     F.liftFC(UpdateInt(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateInt(a: Int, b: Int): ResultSetIO[Unit] =
+  def updateInt(a: String, b: Int): ResultSetIO[Unit] =
     F.liftFC(UpdateInt1(a, b))
 
   /** 
@@ -1820,8 +1807,8 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateNCharacterStream(a: String, b: Reader, c: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateNCharacterStream(a, b, c))
+  def updateNCharacterStream(a: Int, b: Reader): ResultSetIO[Unit] =
+    F.liftFC(UpdateNCharacterStream(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1832,50 +1819,50 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateNCharacterStream(a: Int, b: Reader): ResultSetIO[Unit] =
-    F.liftFC(UpdateNCharacterStream2(a, b))
+  def updateNCharacterStream(a: Int, b: Reader, c: Long): ResultSetIO[Unit] =
+    F.liftFC(UpdateNCharacterStream2(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateNCharacterStream(a: Int, b: Reader, c: Long): ResultSetIO[Unit] =
+  def updateNCharacterStream(a: String, b: Reader, c: Long): ResultSetIO[Unit] =
     F.liftFC(UpdateNCharacterStream3(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateNClob(a: Int, b: Reader, c: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateNClob(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateNClob(a: Int, b: Reader): ResultSetIO[Unit] =
-    F.liftFC(UpdateNClob1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateNClob(a: String, b: Reader, c: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateNClob2(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateNClob(a: String, b: Reader): ResultSetIO[Unit] =
-    F.liftFC(UpdateNClob3(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def updateNClob(a: Int, b: NClob): ResultSetIO[Unit] =
-    F.liftFC(UpdateNClob4(a, b))
+    F.liftFC(UpdateNClob(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateNClob(a: String, b: NClob): ResultSetIO[Unit] =
-    F.liftFC(UpdateNClob5(a, b))
+    F.liftFC(UpdateNClob1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateNClob(a: Int, b: Reader): ResultSetIO[Unit] =
+    F.liftFC(UpdateNClob2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateNClob(a: Int, b: Reader, c: Long): ResultSetIO[Unit] =
+    F.liftFC(UpdateNClob3(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateNClob(a: String, b: Reader): ResultSetIO[Unit] =
+    F.liftFC(UpdateNClob4(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateNClob(a: String, b: Reader, c: Long): ResultSetIO[Unit] =
+    F.liftFC(UpdateNClob5(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -1892,73 +1879,49 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateNull(a: Int): ResultSetIO[Unit] =
+  def updateNull(a: String): ResultSetIO[Unit] =
     F.liftFC(UpdateNull(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateNull(a: String): ResultSetIO[Unit] =
+  def updateNull(a: Int): ResultSetIO[Unit] =
     F.liftFC(UpdateNull1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateObject(a: Int, b: Object, c: SQLType, d: Int): ResultSetIO[Unit] =
-    F.liftFC(UpdateObject(a, b, c, d))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateObject(a: String, b: Object, c: SQLType, d: Int): ResultSetIO[Unit] =
-    F.liftFC(UpdateObject1(a, b, c, d))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateObject(a: Int, b: Object, c: SQLType): ResultSetIO[Unit] =
-    F.liftFC(UpdateObject2(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def updateObject(a: Int, b: Object, c: Int): ResultSetIO[Unit] =
-    F.liftFC(UpdateObject3(a, b, c))
+    F.liftFC(UpdateObject(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateObject(a: Int, b: Object): ResultSetIO[Unit] =
-    F.liftFC(UpdateObject4(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateObject(a: String, b: Object): ResultSetIO[Unit] =
-    F.liftFC(UpdateObject5(a, b))
+    F.liftFC(UpdateObject1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateObject(a: String, b: Object, c: Int): ResultSetIO[Unit] =
-    F.liftFC(UpdateObject6(a, b, c))
+    F.liftFC(UpdateObject2(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateObject(a: String, b: Object, c: SQLType): ResultSetIO[Unit] =
-    F.liftFC(UpdateObject7(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateRef(a: String, b: Ref): ResultSetIO[Unit] =
-    F.liftFC(UpdateRef(a, b))
+  def updateObject(a: String, b: Object): ResultSetIO[Unit] =
+    F.liftFC(UpdateObject3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateRef(a: Int, b: Ref): ResultSetIO[Unit] =
+    F.liftFC(UpdateRef(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateRef(a: String, b: Ref): ResultSetIO[Unit] =
     F.liftFC(UpdateRef1(a, b))
 
   /** 
@@ -1970,13 +1933,13 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateRowId(a: Int, b: RowId): ResultSetIO[Unit] =
+  def updateRowId(a: String, b: RowId): ResultSetIO[Unit] =
     F.liftFC(UpdateRowId(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateRowId(a: String, b: RowId): ResultSetIO[Unit] =
+  def updateRowId(a: Int, b: RowId): ResultSetIO[Unit] =
     F.liftFC(UpdateRowId1(a, b))
 
   /** 
@@ -2006,13 +1969,13 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateString(a: String, b: String): ResultSetIO[Unit] =
+  def updateString(a: Int, b: String): ResultSetIO[Unit] =
     F.liftFC(UpdateString(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateString(a: Int, b: String): ResultSetIO[Unit] =
+  def updateString(a: String, b: String): ResultSetIO[Unit] =
     F.liftFC(UpdateString1(a, b))
 
   /** 
@@ -2030,13 +1993,13 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateTimestamp(a: String, b: Timestamp): ResultSetIO[Unit] =
+  def updateTimestamp(a: Int, b: Timestamp): ResultSetIO[Unit] =
     F.liftFC(UpdateTimestamp(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateTimestamp(a: Int, b: Timestamp): ResultSetIO[Unit] =
+  def updateTimestamp(a: String, b: Timestamp): ResultSetIO[Unit] =
     F.liftFC(UpdateTimestamp1(a, b))
 
   /** 

--- a/core/src/main/scala/doobie/free/sqlinput.scala
+++ b/core/src/main/scala/doobie/free/sqlinput.scala
@@ -7,7 +7,6 @@ import doobie.util.capture._
 
 import java.io.InputStream
 import java.io.Reader
-import java.lang.Class
 import java.lang.Object
 import java.lang.String
 import java.math.BigDecimal
@@ -200,10 +199,7 @@ object sqlinput {
     case object ReadNString extends SQLInputOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readNString())
     }
-    case class  ReadObject[T](a: Class[T]) extends SQLInputOp[T] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readObject(a))
-    }
-    case object ReadObject1 extends SQLInputOp[Object] {
+    case object ReadObject extends SQLInputOp[Object] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readObject())
     }
     case object ReadRef extends SQLInputOp[Ref] {
@@ -474,14 +470,8 @@ object sqlinput {
   /** 
    * @group Constructors (Primitives)
    */
-  def readObject[T](a: Class[T]): SQLInputIO[T] =
-    F.liftFC(ReadObject(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   val readObject: SQLInputIO[Object] =
-    F.liftFC(ReadObject1)
+    F.liftFC(ReadObject)
 
   /** 
    * @group Constructors (Primitives)

--- a/core/src/main/scala/doobie/free/sqlinput.scala
+++ b/core/src/main/scala/doobie/free/sqlinput.scala
@@ -7,6 +7,7 @@ import doobie.util.capture._
 
 import java.io.InputStream
 import java.io.Reader
+import java.lang.Class
 import java.lang.Object
 import java.lang.String
 import java.math.BigDecimal
@@ -80,7 +81,11 @@ object sqlinput {
    * Sum type of primitive operations over a `java.sql.SQLInput`.
    * @group Algebra 
    */
-  sealed trait SQLInputOp[A]
+  sealed trait SQLInputOp[A] {
+    protected def primitive[M[_]: Monad: Capture](f: SQLInput => A): Kleisli[M, SQLInput, A] = 
+      Kleisli((s: SQLInput) => Capture[M].apply(f(s)))
+    def defaultTransK[M[_]: Monad: Catchable: Capture]: Kleisli[M, SQLInput, A]
+  }
 
   /** 
    * Module of constructors for `SQLInputOp`. These are rarely useful outside of the implementation;
@@ -90,52 +95,144 @@ object sqlinput {
   object SQLInputOp {
     
     // Lifting
-    case class LiftBlobIO[A](s: Blob, action: BlobIO[A]) extends SQLInputOp[A]
-    case class LiftCallableStatementIO[A](s: CallableStatement, action: CallableStatementIO[A]) extends SQLInputOp[A]
-    case class LiftClobIO[A](s: Clob, action: ClobIO[A]) extends SQLInputOp[A]
-    case class LiftConnectionIO[A](s: Connection, action: ConnectionIO[A]) extends SQLInputOp[A]
-    case class LiftDatabaseMetaDataIO[A](s: DatabaseMetaData, action: DatabaseMetaDataIO[A]) extends SQLInputOp[A]
-    case class LiftDriverIO[A](s: Driver, action: DriverIO[A]) extends SQLInputOp[A]
-    case class LiftNClobIO[A](s: NClob, action: NClobIO[A]) extends SQLInputOp[A]
-    case class LiftPreparedStatementIO[A](s: PreparedStatement, action: PreparedStatementIO[A]) extends SQLInputOp[A]
-    case class LiftRefIO[A](s: Ref, action: RefIO[A]) extends SQLInputOp[A]
-    case class LiftResultSetIO[A](s: ResultSet, action: ResultSetIO[A]) extends SQLInputOp[A]
-    case class LiftSQLDataIO[A](s: SQLData, action: SQLDataIO[A]) extends SQLInputOp[A]
-    case class LiftSQLOutputIO[A](s: SQLOutput, action: SQLOutputIO[A]) extends SQLInputOp[A]
-    case class LiftStatementIO[A](s: Statement, action: StatementIO[A]) extends SQLInputOp[A]
+    case class LiftBlobIO[A](s: Blob, action: BlobIO[A]) extends SQLInputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftCallableStatementIO[A](s: CallableStatement, action: CallableStatementIO[A]) extends SQLInputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftClobIO[A](s: Clob, action: ClobIO[A]) extends SQLInputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftConnectionIO[A](s: Connection, action: ConnectionIO[A]) extends SQLInputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftDatabaseMetaDataIO[A](s: DatabaseMetaData, action: DatabaseMetaDataIO[A]) extends SQLInputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftDriverIO[A](s: Driver, action: DriverIO[A]) extends SQLInputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftNClobIO[A](s: NClob, action: NClobIO[A]) extends SQLInputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftPreparedStatementIO[A](s: PreparedStatement, action: PreparedStatementIO[A]) extends SQLInputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftRefIO[A](s: Ref, action: RefIO[A]) extends SQLInputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftResultSetIO[A](s: ResultSet, action: ResultSetIO[A]) extends SQLInputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftSQLDataIO[A](s: SQLData, action: SQLDataIO[A]) extends SQLInputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftSQLOutputIO[A](s: SQLOutput, action: SQLOutputIO[A]) extends SQLInputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftStatementIO[A](s: Statement, action: StatementIO[A]) extends SQLInputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
 
     // Combinators
-    case class Attempt[A](action: SQLInputIO[A]) extends SQLInputOp[Throwable \/ A]
-    case class Pure[A](a: () => A) extends SQLInputOp[A]
+    case class Attempt[A](action: SQLInputIO[A]) extends SQLInputOp[Throwable \/ A] {
+      import scalaz._, Scalaz._
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = 
+        Predef.implicitly[Catchable[Kleisli[M, SQLInput, ?]]].attempt(action.transK[M])
+    }
+    case class Pure[A](a: () => A) extends SQLInputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_ => a())
+    }
+    case class Raw[A](f: SQLInput => A) extends SQLInputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(f)
+    }
 
     // Primitive Operations
-    case object ReadArray extends SQLInputOp[SqlArray]
-    case object ReadAsciiStream extends SQLInputOp[InputStream]
-    case object ReadBigDecimal extends SQLInputOp[BigDecimal]
-    case object ReadBinaryStream extends SQLInputOp[InputStream]
-    case object ReadBlob extends SQLInputOp[Blob]
-    case object ReadBoolean extends SQLInputOp[Boolean]
-    case object ReadByte extends SQLInputOp[Byte]
-    case object ReadBytes extends SQLInputOp[Array[Byte]]
-    case object ReadCharacterStream extends SQLInputOp[Reader]
-    case object ReadClob extends SQLInputOp[Clob]
-    case object ReadDate extends SQLInputOp[Date]
-    case object ReadDouble extends SQLInputOp[Double]
-    case object ReadFloat extends SQLInputOp[Float]
-    case object ReadInt extends SQLInputOp[Int]
-    case object ReadLong extends SQLInputOp[Long]
-    case object ReadNClob extends SQLInputOp[NClob]
-    case object ReadNString extends SQLInputOp[String]
-    case object ReadObject extends SQLInputOp[Object]
-    case object ReadRef extends SQLInputOp[Ref]
-    case object ReadRowId extends SQLInputOp[RowId]
-    case object ReadSQLXML extends SQLInputOp[SQLXML]
-    case object ReadShort extends SQLInputOp[Short]
-    case object ReadString extends SQLInputOp[String]
-    case object ReadTime extends SQLInputOp[Time]
-    case object ReadTimestamp extends SQLInputOp[Timestamp]
-    case object ReadURL extends SQLInputOp[URL]
-    case object WasNull extends SQLInputOp[Boolean]
+    case object ReadArray extends SQLInputOp[SqlArray] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readArray())
+    }
+    case object ReadAsciiStream extends SQLInputOp[InputStream] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readAsciiStream())
+    }
+    case object ReadBigDecimal extends SQLInputOp[BigDecimal] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readBigDecimal())
+    }
+    case object ReadBinaryStream extends SQLInputOp[InputStream] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readBinaryStream())
+    }
+    case object ReadBlob extends SQLInputOp[Blob] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readBlob())
+    }
+    case object ReadBoolean extends SQLInputOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readBoolean())
+    }
+    case object ReadByte extends SQLInputOp[Byte] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readByte())
+    }
+    case object ReadBytes extends SQLInputOp[Array[Byte]] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readBytes())
+    }
+    case object ReadCharacterStream extends SQLInputOp[Reader] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readCharacterStream())
+    }
+    case object ReadClob extends SQLInputOp[Clob] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readClob())
+    }
+    case object ReadDate extends SQLInputOp[Date] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readDate())
+    }
+    case object ReadDouble extends SQLInputOp[Double] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readDouble())
+    }
+    case object ReadFloat extends SQLInputOp[Float] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readFloat())
+    }
+    case object ReadInt extends SQLInputOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readInt())
+    }
+    case object ReadLong extends SQLInputOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readLong())
+    }
+    case object ReadNClob extends SQLInputOp[NClob] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readNClob())
+    }
+    case object ReadNString extends SQLInputOp[String] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readNString())
+    }
+    case class  ReadObject[T](a: Class[T]) extends SQLInputOp[T] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readObject(a))
+    }
+    case object ReadObject1 extends SQLInputOp[Object] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readObject())
+    }
+    case object ReadRef extends SQLInputOp[Ref] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readRef())
+    }
+    case object ReadRowId extends SQLInputOp[RowId] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readRowId())
+    }
+    case object ReadSQLXML extends SQLInputOp[SQLXML] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readSQLXML())
+    }
+    case object ReadShort extends SQLInputOp[Short] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readShort())
+    }
+    case object ReadString extends SQLInputOp[String] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readString())
+    }
+    case object ReadTime extends SQLInputOp[Time] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readTime())
+    }
+    case object ReadTimestamp extends SQLInputOp[Timestamp] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readTimestamp())
+    }
+    case object ReadURL extends SQLInputOp[URL] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readURL())
+    }
+    case object WasNull extends SQLInputOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.wasNull())
+    }
 
   }
   import SQLInputOp._ // We use these immediately
@@ -265,6 +362,13 @@ object sqlinput {
   def delay[A](a: => A): SQLInputIO[A] =
     F.liftFC(Pure(a _))
 
+  /**
+   * Backdoor for arbitrary computations on the underlying SQLInput.
+   * @group Constructors (Lifting)
+   */
+  def raw[A](f: SQLInput => A): SQLInputIO[A] =
+    F.liftFC(Raw(f))
+
   /** 
    * @group Constructors (Primitives)
    */
@@ -370,8 +474,14 @@ object sqlinput {
   /** 
    * @group Constructors (Primitives)
    */
+  def readObject[T](a: Class[T]): SQLInputIO[T] =
+    F.liftFC(ReadObject(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
   val readObject: SQLInputIO[Object] =
-    F.liftFC(ReadObject)
+    F.liftFC(ReadObject1)
 
   /** 
    * @group Constructors (Primitives)
@@ -431,68 +541,10 @@ object sqlinput {
   * Natural transformation from `SQLInputOp` to `Kleisli` for the given `M`, consuming a `java.sql.SQLInput`. 
   * @group Algebra
   */
- def kleisliTrans[M[_]: Monad: Catchable: Capture]: SQLInputOp ~> ({type l[a] = Kleisli[M, SQLInput, a]})#l =
-   new (SQLInputOp ~> ({type l[a] = Kleisli[M, SQLInput, a]})#l) {
-     import scalaz.syntax.catchable._
-
-     val L = Predef.implicitly[Capture[M]]
-
-     def primitive[A](f: SQLInput => A): Kleisli[M, SQLInput, A] =
-       Kleisli(s => L.apply(f(s)))
-
-     def apply[A](op: SQLInputOp[A]): Kleisli[M, SQLInput, A] = 
-       op match {
-
-        // Lifting
-        case LiftBlobIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftCallableStatementIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftClobIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftConnectionIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftDatabaseMetaDataIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftDriverIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftNClobIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftPreparedStatementIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftRefIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftResultSetIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftSQLDataIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftSQLOutputIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftStatementIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-  
-        // Combinators
-        case Pure(a) => primitive(_ => a())
-        case Attempt(a) => a.transK[M].attempt
-  
-        // Primitive Operations
-        case ReadArray => primitive(_.readArray)
-        case ReadAsciiStream => primitive(_.readAsciiStream)
-        case ReadBigDecimal => primitive(_.readBigDecimal)
-        case ReadBinaryStream => primitive(_.readBinaryStream)
-        case ReadBlob => primitive(_.readBlob)
-        case ReadBoolean => primitive(_.readBoolean)
-        case ReadByte => primitive(_.readByte)
-        case ReadBytes => primitive(_.readBytes)
-        case ReadCharacterStream => primitive(_.readCharacterStream)
-        case ReadClob => primitive(_.readClob)
-        case ReadDate => primitive(_.readDate)
-        case ReadDouble => primitive(_.readDouble)
-        case ReadFloat => primitive(_.readFloat)
-        case ReadInt => primitive(_.readInt)
-        case ReadLong => primitive(_.readLong)
-        case ReadNClob => primitive(_.readNClob)
-        case ReadNString => primitive(_.readNString)
-        case ReadObject => primitive(_.readObject)
-        case ReadRef => primitive(_.readRef)
-        case ReadRowId => primitive(_.readRowId)
-        case ReadSQLXML => primitive(_.readSQLXML)
-        case ReadShort => primitive(_.readShort)
-        case ReadString => primitive(_.readString)
-        case ReadTime => primitive(_.readTime)
-        case ReadTimestamp => primitive(_.readTimestamp)
-        case ReadURL => primitive(_.readURL)
-        case WasNull => primitive(_.wasNull)
-  
-      }
-  
+  def kleisliTrans[M[_]: Monad: Catchable: Capture]: SQLInputOp ~> Kleisli[M, SQLInput, ?] =
+    new (SQLInputOp ~> Kleisli[M, SQLInput, ?]) {
+      def apply[A](op: SQLInputOp[A]): Kleisli[M, SQLInput, A] =
+        op.defaultTransK[M]
     }
 
   /**
@@ -501,7 +553,7 @@ object sqlinput {
    */
   implicit class SQLInputIOOps[A](ma: SQLInputIO[A]) {
     def transK[M[_]: Monad: Catchable: Capture]: Kleisli[M, SQLInput, A] =
-      F.runFC[SQLInputOp,({type l[a]=Kleisli[M,SQLInput,a]})#l,A](ma)(kleisliTrans[M])
+      F.runFC[SQLInputOp, Kleisli[M, SQLInput, ?], A](ma)(kleisliTrans[M])
   }
 
 }

--- a/core/src/main/scala/doobie/free/sqloutput.scala
+++ b/core/src/main/scala/doobie/free/sqloutput.scala
@@ -7,7 +7,6 @@ import doobie.util.capture._
 
 import java.io.InputStream
 import java.io.Reader
-import java.lang.Object
 import java.lang.String
 import java.math.BigDecimal
 import java.net.URL
@@ -26,7 +25,6 @@ import java.sql.RowId
 import java.sql.SQLData
 import java.sql.SQLInput
 import java.sql.SQLOutput
-import java.sql.SQLType
 import java.sql.SQLXML
 import java.sql.Statement
 import java.sql.Struct
@@ -201,10 +199,7 @@ object sqloutput {
     case class  WriteNString(a: String) extends SQLOutputOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeNString(a))
     }
-    case class  WriteObject(a: Object, b: SQLType) extends SQLOutputOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeObject(a, b))
-    }
-    case class  WriteObject1(a: SQLData) extends SQLOutputOp[Unit] {
+    case class  WriteObject(a: SQLData) extends SQLOutputOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeObject(a))
     }
     case class  WriteRef(a: Ref) extends SQLOutputOp[Unit] {
@@ -475,14 +470,8 @@ object sqloutput {
   /** 
    * @group Constructors (Primitives)
    */
-  def writeObject(a: Object, b: SQLType): SQLOutputIO[Unit] =
-    F.liftFC(WriteObject(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def writeObject(a: SQLData): SQLOutputIO[Unit] =
-    F.liftFC(WriteObject1(a))
+    F.liftFC(WriteObject(a))
 
   /** 
    * @group Constructors (Primitives)

--- a/core/src/main/scala/doobie/free/sqloutput.scala
+++ b/core/src/main/scala/doobie/free/sqloutput.scala
@@ -7,6 +7,7 @@ import doobie.util.capture._
 
 import java.io.InputStream
 import java.io.Reader
+import java.lang.Object
 import java.lang.String
 import java.math.BigDecimal
 import java.net.URL
@@ -25,6 +26,7 @@ import java.sql.RowId
 import java.sql.SQLData
 import java.sql.SQLInput
 import java.sql.SQLOutput
+import java.sql.SQLType
 import java.sql.SQLXML
 import java.sql.Statement
 import java.sql.Struct
@@ -80,7 +82,11 @@ object sqloutput {
    * Sum type of primitive operations over a `java.sql.SQLOutput`.
    * @group Algebra 
    */
-  sealed trait SQLOutputOp[A]
+  sealed trait SQLOutputOp[A] {
+    protected def primitive[M[_]: Monad: Capture](f: SQLOutput => A): Kleisli[M, SQLOutput, A] = 
+      Kleisli((s: SQLOutput) => Capture[M].apply(f(s)))
+    def defaultTransK[M[_]: Monad: Catchable: Capture]: Kleisli[M, SQLOutput, A]
+  }
 
   /** 
    * Module of constructors for `SQLOutputOp`. These are rarely useful outside of the implementation;
@@ -90,52 +96,144 @@ object sqloutput {
   object SQLOutputOp {
     
     // Lifting
-    case class LiftBlobIO[A](s: Blob, action: BlobIO[A]) extends SQLOutputOp[A]
-    case class LiftCallableStatementIO[A](s: CallableStatement, action: CallableStatementIO[A]) extends SQLOutputOp[A]
-    case class LiftClobIO[A](s: Clob, action: ClobIO[A]) extends SQLOutputOp[A]
-    case class LiftConnectionIO[A](s: Connection, action: ConnectionIO[A]) extends SQLOutputOp[A]
-    case class LiftDatabaseMetaDataIO[A](s: DatabaseMetaData, action: DatabaseMetaDataIO[A]) extends SQLOutputOp[A]
-    case class LiftDriverIO[A](s: Driver, action: DriverIO[A]) extends SQLOutputOp[A]
-    case class LiftNClobIO[A](s: NClob, action: NClobIO[A]) extends SQLOutputOp[A]
-    case class LiftPreparedStatementIO[A](s: PreparedStatement, action: PreparedStatementIO[A]) extends SQLOutputOp[A]
-    case class LiftRefIO[A](s: Ref, action: RefIO[A]) extends SQLOutputOp[A]
-    case class LiftResultSetIO[A](s: ResultSet, action: ResultSetIO[A]) extends SQLOutputOp[A]
-    case class LiftSQLDataIO[A](s: SQLData, action: SQLDataIO[A]) extends SQLOutputOp[A]
-    case class LiftSQLInputIO[A](s: SQLInput, action: SQLInputIO[A]) extends SQLOutputOp[A]
-    case class LiftStatementIO[A](s: Statement, action: StatementIO[A]) extends SQLOutputOp[A]
+    case class LiftBlobIO[A](s: Blob, action: BlobIO[A]) extends SQLOutputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftCallableStatementIO[A](s: CallableStatement, action: CallableStatementIO[A]) extends SQLOutputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftClobIO[A](s: Clob, action: ClobIO[A]) extends SQLOutputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftConnectionIO[A](s: Connection, action: ConnectionIO[A]) extends SQLOutputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftDatabaseMetaDataIO[A](s: DatabaseMetaData, action: DatabaseMetaDataIO[A]) extends SQLOutputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftDriverIO[A](s: Driver, action: DriverIO[A]) extends SQLOutputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftNClobIO[A](s: NClob, action: NClobIO[A]) extends SQLOutputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftPreparedStatementIO[A](s: PreparedStatement, action: PreparedStatementIO[A]) extends SQLOutputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftRefIO[A](s: Ref, action: RefIO[A]) extends SQLOutputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftResultSetIO[A](s: ResultSet, action: ResultSetIO[A]) extends SQLOutputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftSQLDataIO[A](s: SQLData, action: SQLDataIO[A]) extends SQLOutputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftSQLInputIO[A](s: SQLInput, action: SQLInputIO[A]) extends SQLOutputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftStatementIO[A](s: Statement, action: StatementIO[A]) extends SQLOutputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
 
     // Combinators
-    case class Attempt[A](action: SQLOutputIO[A]) extends SQLOutputOp[Throwable \/ A]
-    case class Pure[A](a: () => A) extends SQLOutputOp[A]
+    case class Attempt[A](action: SQLOutputIO[A]) extends SQLOutputOp[Throwable \/ A] {
+      import scalaz._, Scalaz._
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = 
+        Predef.implicitly[Catchable[Kleisli[M, SQLOutput, ?]]].attempt(action.transK[M])
+    }
+    case class Pure[A](a: () => A) extends SQLOutputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_ => a())
+    }
+    case class Raw[A](f: SQLOutput => A) extends SQLOutputOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(f)
+    }
 
     // Primitive Operations
-    case class  WriteArray(a: SqlArray) extends SQLOutputOp[Unit]
-    case class  WriteAsciiStream(a: InputStream) extends SQLOutputOp[Unit]
-    case class  WriteBigDecimal(a: BigDecimal) extends SQLOutputOp[Unit]
-    case class  WriteBinaryStream(a: InputStream) extends SQLOutputOp[Unit]
-    case class  WriteBlob(a: Blob) extends SQLOutputOp[Unit]
-    case class  WriteBoolean(a: Boolean) extends SQLOutputOp[Unit]
-    case class  WriteByte(a: Byte) extends SQLOutputOp[Unit]
-    case class  WriteBytes(a: Array[Byte]) extends SQLOutputOp[Unit]
-    case class  WriteCharacterStream(a: Reader) extends SQLOutputOp[Unit]
-    case class  WriteClob(a: Clob) extends SQLOutputOp[Unit]
-    case class  WriteDate(a: Date) extends SQLOutputOp[Unit]
-    case class  WriteDouble(a: Double) extends SQLOutputOp[Unit]
-    case class  WriteFloat(a: Float) extends SQLOutputOp[Unit]
-    case class  WriteInt(a: Int) extends SQLOutputOp[Unit]
-    case class  WriteLong(a: Long) extends SQLOutputOp[Unit]
-    case class  WriteNClob(a: NClob) extends SQLOutputOp[Unit]
-    case class  WriteNString(a: String) extends SQLOutputOp[Unit]
-    case class  WriteObject(a: SQLData) extends SQLOutputOp[Unit]
-    case class  WriteRef(a: Ref) extends SQLOutputOp[Unit]
-    case class  WriteRowId(a: RowId) extends SQLOutputOp[Unit]
-    case class  WriteSQLXML(a: SQLXML) extends SQLOutputOp[Unit]
-    case class  WriteShort(a: Short) extends SQLOutputOp[Unit]
-    case class  WriteString(a: String) extends SQLOutputOp[Unit]
-    case class  WriteStruct(a: Struct) extends SQLOutputOp[Unit]
-    case class  WriteTime(a: Time) extends SQLOutputOp[Unit]
-    case class  WriteTimestamp(a: Timestamp) extends SQLOutputOp[Unit]
-    case class  WriteURL(a: URL) extends SQLOutputOp[Unit]
+    case class  WriteArray(a: SqlArray) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeArray(a))
+    }
+    case class  WriteAsciiStream(a: InputStream) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeAsciiStream(a))
+    }
+    case class  WriteBigDecimal(a: BigDecimal) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeBigDecimal(a))
+    }
+    case class  WriteBinaryStream(a: InputStream) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeBinaryStream(a))
+    }
+    case class  WriteBlob(a: Blob) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeBlob(a))
+    }
+    case class  WriteBoolean(a: Boolean) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeBoolean(a))
+    }
+    case class  WriteByte(a: Byte) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeByte(a))
+    }
+    case class  WriteBytes(a: Array[Byte]) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeBytes(a))
+    }
+    case class  WriteCharacterStream(a: Reader) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeCharacterStream(a))
+    }
+    case class  WriteClob(a: Clob) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeClob(a))
+    }
+    case class  WriteDate(a: Date) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeDate(a))
+    }
+    case class  WriteDouble(a: Double) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeDouble(a))
+    }
+    case class  WriteFloat(a: Float) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeFloat(a))
+    }
+    case class  WriteInt(a: Int) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeInt(a))
+    }
+    case class  WriteLong(a: Long) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeLong(a))
+    }
+    case class  WriteNClob(a: NClob) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeNClob(a))
+    }
+    case class  WriteNString(a: String) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeNString(a))
+    }
+    case class  WriteObject(a: Object, b: SQLType) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeObject(a, b))
+    }
+    case class  WriteObject1(a: SQLData) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeObject(a))
+    }
+    case class  WriteRef(a: Ref) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeRef(a))
+    }
+    case class  WriteRowId(a: RowId) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeRowId(a))
+    }
+    case class  WriteSQLXML(a: SQLXML) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeSQLXML(a))
+    }
+    case class  WriteShort(a: Short) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeShort(a))
+    }
+    case class  WriteString(a: String) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeString(a))
+    }
+    case class  WriteStruct(a: Struct) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeStruct(a))
+    }
+    case class  WriteTime(a: Time) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeTime(a))
+    }
+    case class  WriteTimestamp(a: Timestamp) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeTimestamp(a))
+    }
+    case class  WriteURL(a: URL) extends SQLOutputOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeURL(a))
+    }
 
   }
   import SQLOutputOp._ // We use these immediately
@@ -265,6 +363,13 @@ object sqloutput {
   def delay[A](a: => A): SQLOutputIO[A] =
     F.liftFC(Pure(a _))
 
+  /**
+   * Backdoor for arbitrary computations on the underlying SQLOutput.
+   * @group Constructors (Lifting)
+   */
+  def raw[A](f: SQLOutput => A): SQLOutputIO[A] =
+    F.liftFC(Raw(f))
+
   /** 
    * @group Constructors (Primitives)
    */
@@ -370,8 +475,14 @@ object sqloutput {
   /** 
    * @group Constructors (Primitives)
    */
+  def writeObject(a: Object, b: SQLType): SQLOutputIO[Unit] =
+    F.liftFC(WriteObject(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
   def writeObject(a: SQLData): SQLOutputIO[Unit] =
-    F.liftFC(WriteObject(a))
+    F.liftFC(WriteObject1(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -431,68 +542,10 @@ object sqloutput {
   * Natural transformation from `SQLOutputOp` to `Kleisli` for the given `M`, consuming a `java.sql.SQLOutput`. 
   * @group Algebra
   */
- def kleisliTrans[M[_]: Monad: Catchable: Capture]: SQLOutputOp ~> ({type l[a] = Kleisli[M, SQLOutput, a]})#l =
-   new (SQLOutputOp ~> ({type l[a] = Kleisli[M, SQLOutput, a]})#l) {
-     import scalaz.syntax.catchable._
-
-     val L = Predef.implicitly[Capture[M]]
-
-     def primitive[A](f: SQLOutput => A): Kleisli[M, SQLOutput, A] =
-       Kleisli(s => L.apply(f(s)))
-
-     def apply[A](op: SQLOutputOp[A]): Kleisli[M, SQLOutput, A] = 
-       op match {
-
-        // Lifting
-        case LiftBlobIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftCallableStatementIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftClobIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftConnectionIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftDatabaseMetaDataIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftDriverIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftNClobIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftPreparedStatementIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftRefIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftResultSetIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftSQLDataIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftSQLInputIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftStatementIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-  
-        // Combinators
-        case Pure(a) => primitive(_ => a())
-        case Attempt(a) => a.transK[M].attempt
-  
-        // Primitive Operations
-        case WriteArray(a) => primitive(_.writeArray(a))
-        case WriteAsciiStream(a) => primitive(_.writeAsciiStream(a))
-        case WriteBigDecimal(a) => primitive(_.writeBigDecimal(a))
-        case WriteBinaryStream(a) => primitive(_.writeBinaryStream(a))
-        case WriteBlob(a) => primitive(_.writeBlob(a))
-        case WriteBoolean(a) => primitive(_.writeBoolean(a))
-        case WriteByte(a) => primitive(_.writeByte(a))
-        case WriteBytes(a) => primitive(_.writeBytes(a))
-        case WriteCharacterStream(a) => primitive(_.writeCharacterStream(a))
-        case WriteClob(a) => primitive(_.writeClob(a))
-        case WriteDate(a) => primitive(_.writeDate(a))
-        case WriteDouble(a) => primitive(_.writeDouble(a))
-        case WriteFloat(a) => primitive(_.writeFloat(a))
-        case WriteInt(a) => primitive(_.writeInt(a))
-        case WriteLong(a) => primitive(_.writeLong(a))
-        case WriteNClob(a) => primitive(_.writeNClob(a))
-        case WriteNString(a) => primitive(_.writeNString(a))
-        case WriteObject(a) => primitive(_.writeObject(a))
-        case WriteRef(a) => primitive(_.writeRef(a))
-        case WriteRowId(a) => primitive(_.writeRowId(a))
-        case WriteSQLXML(a) => primitive(_.writeSQLXML(a))
-        case WriteShort(a) => primitive(_.writeShort(a))
-        case WriteString(a) => primitive(_.writeString(a))
-        case WriteStruct(a) => primitive(_.writeStruct(a))
-        case WriteTime(a) => primitive(_.writeTime(a))
-        case WriteTimestamp(a) => primitive(_.writeTimestamp(a))
-        case WriteURL(a) => primitive(_.writeURL(a))
-  
-      }
-  
+  def kleisliTrans[M[_]: Monad: Catchable: Capture]: SQLOutputOp ~> Kleisli[M, SQLOutput, ?] =
+    new (SQLOutputOp ~> Kleisli[M, SQLOutput, ?]) {
+      def apply[A](op: SQLOutputOp[A]): Kleisli[M, SQLOutput, A] =
+        op.defaultTransK[M]
     }
 
   /**
@@ -501,7 +554,7 @@ object sqloutput {
    */
   implicit class SQLOutputIOOps[A](ma: SQLOutputIO[A]) {
     def transK[M[_]: Monad: Catchable: Capture]: Kleisli[M, SQLOutput, A] =
-      F.runFC[SQLOutputOp,({type l[a]=Kleisli[M,SQLOutput,a]})#l,A](ma)(kleisliTrans[M])
+      F.runFC[SQLOutputOp, Kleisli[M, SQLOutput, ?], A](ma)(kleisliTrans[M])
   }
 
 }

--- a/core/src/main/scala/doobie/free/statement.scala
+++ b/core/src/main/scala/doobie/free/statement.scala
@@ -161,47 +161,32 @@ object statement {
     case class  Execute(a: String) extends StatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a))
     }
-    case class  Execute1(a: String, b: Array[String]) extends StatementOp[Boolean] {
+    case class  Execute1(a: String, b: Array[Int]) extends StatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
     }
-    case class  Execute2(a: String, b: Array[Int]) extends StatementOp[Boolean] {
+    case class  Execute2(a: String, b: Int) extends StatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
     }
-    case class  Execute3(a: String, b: Int) extends StatementOp[Boolean] {
+    case class  Execute3(a: String, b: Array[String]) extends StatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
     }
     case object ExecuteBatch extends StatementOp[Array[Int]] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeBatch())
     }
-    case object ExecuteLargeBatch extends StatementOp[Array[Long]] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeBatch())
-    }
-    case class  ExecuteLargeUpdate(a: String, b: Array[String]) extends StatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
-    }
-    case class  ExecuteLargeUpdate1(a: String, b: Array[Int]) extends StatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
-    }
-    case class  ExecuteLargeUpdate2(a: String, b: Int) extends StatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
-    }
-    case class  ExecuteLargeUpdate3(a: String) extends StatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a))
-    }
     case class  ExecuteQuery(a: String) extends StatementOp[ResultSet] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeQuery(a))
     }
-    case class  ExecuteUpdate(a: String) extends StatementOp[Int] {
+    case class  ExecuteUpdate(a: String, b: Array[String]) extends StatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
+    }
+    case class  ExecuteUpdate1(a: String, b: Int) extends StatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
+    }
+    case class  ExecuteUpdate2(a: String, b: Array[Int]) extends StatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
+    }
+    case class  ExecuteUpdate3(a: String) extends StatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a))
-    }
-    case class  ExecuteUpdate1(a: String, b: Array[Int]) extends StatementOp[Int] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
-    }
-    case class  ExecuteUpdate2(a: String, b: Int) extends StatementOp[Int] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
-    }
-    case class  ExecuteUpdate3(a: String, b: Array[String]) extends StatementOp[Int] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
     }
     case object GetConnection extends StatementOp[Connection] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getConnection())
@@ -215,23 +200,17 @@ object statement {
     case object GetGeneratedKeys extends StatementOp[ResultSet] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getGeneratedKeys())
     }
-    case object GetLargeMaxRows extends StatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeMaxRows())
-    }
-    case object GetLargeUpdateCount extends StatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeUpdateCount())
-    }
     case object GetMaxFieldSize extends StatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMaxFieldSize())
     }
     case object GetMaxRows extends StatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMaxRows())
     }
-    case class  GetMoreResults(a: Int) extends StatementOp[Boolean] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMoreResults(a))
-    }
-    case object GetMoreResults1 extends StatementOp[Boolean] {
+    case object GetMoreResults extends StatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMoreResults())
+    }
+    case class  GetMoreResults1(a: Int) extends StatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMoreResults(a))
     }
     case object GetQueryTimeout extends StatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getQueryTimeout())
@@ -277,9 +256,6 @@ object statement {
     }
     case class  SetFetchSize(a: Int) extends StatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setFetchSize(a))
-    }
-    case class  SetLargeMaxRows(a: Long) extends StatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setLargeMaxRows(a))
     }
     case class  SetMaxFieldSize(a: Int) extends StatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setMaxFieldSize(a))
@@ -477,19 +453,19 @@ object statement {
   /** 
    * @group Constructors (Primitives)
    */
-  def execute(a: String, b: Array[String]): StatementIO[Boolean] =
+  def execute(a: String, b: Array[Int]): StatementIO[Boolean] =
     F.liftFC(Execute1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def execute(a: String, b: Array[Int]): StatementIO[Boolean] =
+  def execute(a: String, b: Int): StatementIO[Boolean] =
     F.liftFC(Execute2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def execute(a: String, b: Int): StatementIO[Boolean] =
+  def execute(a: String, b: Array[String]): StatementIO[Boolean] =
     F.liftFC(Execute3(a, b))
 
   /** 
@@ -501,62 +477,32 @@ object statement {
   /** 
    * @group Constructors (Primitives)
    */
-  val executeLargeBatch: StatementIO[Array[Long]] =
-    F.liftFC(ExecuteLargeBatch)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String, b: Array[String]): StatementIO[Long] =
-    F.liftFC(ExecuteLargeUpdate(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String, b: Array[Int]): StatementIO[Long] =
-    F.liftFC(ExecuteLargeUpdate1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String, b: Int): StatementIO[Long] =
-    F.liftFC(ExecuteLargeUpdate2(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String): StatementIO[Long] =
-    F.liftFC(ExecuteLargeUpdate3(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def executeQuery(a: String): StatementIO[ResultSet] =
     F.liftFC(ExecuteQuery(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def executeUpdate(a: String): StatementIO[Int] =
-    F.liftFC(ExecuteUpdate(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeUpdate(a: String, b: Array[Int]): StatementIO[Int] =
-    F.liftFC(ExecuteUpdate1(a, b))
+  def executeUpdate(a: String, b: Array[String]): StatementIO[Int] =
+    F.liftFC(ExecuteUpdate(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def executeUpdate(a: String, b: Int): StatementIO[Int] =
+    F.liftFC(ExecuteUpdate1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeUpdate(a: String, b: Array[Int]): StatementIO[Int] =
     F.liftFC(ExecuteUpdate2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def executeUpdate(a: String, b: Array[String]): StatementIO[Int] =
-    F.liftFC(ExecuteUpdate3(a, b))
+  def executeUpdate(a: String): StatementIO[Int] =
+    F.liftFC(ExecuteUpdate3(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -585,18 +531,6 @@ object statement {
   /** 
    * @group Constructors (Primitives)
    */
-  val getLargeMaxRows: StatementIO[Long] =
-    F.liftFC(GetLargeMaxRows)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val getLargeUpdateCount: StatementIO[Long] =
-    F.liftFC(GetLargeUpdateCount)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   val getMaxFieldSize: StatementIO[Int] =
     F.liftFC(GetMaxFieldSize)
 
@@ -609,14 +543,14 @@ object statement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getMoreResults(a: Int): StatementIO[Boolean] =
-    F.liftFC(GetMoreResults(a))
+  val getMoreResults: StatementIO[Boolean] =
+    F.liftFC(GetMoreResults)
 
   /** 
    * @group Constructors (Primitives)
    */
-  val getMoreResults: StatementIO[Boolean] =
-    F.liftFC(GetMoreResults1)
+  def getMoreResults(a: Int): StatementIO[Boolean] =
+    F.liftFC(GetMoreResults1(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -707,12 +641,6 @@ object statement {
    */
   def setFetchSize(a: Int): StatementIO[Unit] =
     F.liftFC(SetFetchSize(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setLargeMaxRows(a: Long): StatementIO[Unit] =
-    F.liftFC(SetLargeMaxRows(a))
 
   /** 
    * @group Constructors (Primitives)

--- a/core/src/main/scala/doobie/free/statement.scala
+++ b/core/src/main/scala/doobie/free/statement.scala
@@ -72,7 +72,11 @@ object statement {
    * Sum type of primitive operations over a `java.sql.Statement`.
    * @group Algebra 
    */
-  sealed trait StatementOp[A]
+  sealed trait StatementOp[A] {
+    protected def primitive[M[_]: Monad: Capture](f: Statement => A): Kleisli[M, Statement, A] = 
+      Kleisli((s: Statement) => Capture[M].apply(f(s)))
+    def defaultTransK[M[_]: Monad: Catchable: Capture]: Kleisli[M, Statement, A]
+  }
 
   /** 
    * Module of constructors for `StatementOp`. These are rarely useful outside of the implementation;
@@ -82,67 +86,216 @@ object statement {
   object StatementOp {
     
     // Lifting
-    case class LiftBlobIO[A](s: Blob, action: BlobIO[A]) extends StatementOp[A]
-    case class LiftCallableStatementIO[A](s: CallableStatement, action: CallableStatementIO[A]) extends StatementOp[A]
-    case class LiftClobIO[A](s: Clob, action: ClobIO[A]) extends StatementOp[A]
-    case class LiftConnectionIO[A](s: Connection, action: ConnectionIO[A]) extends StatementOp[A]
-    case class LiftDatabaseMetaDataIO[A](s: DatabaseMetaData, action: DatabaseMetaDataIO[A]) extends StatementOp[A]
-    case class LiftDriverIO[A](s: Driver, action: DriverIO[A]) extends StatementOp[A]
-    case class LiftNClobIO[A](s: NClob, action: NClobIO[A]) extends StatementOp[A]
-    case class LiftPreparedStatementIO[A](s: PreparedStatement, action: PreparedStatementIO[A]) extends StatementOp[A]
-    case class LiftRefIO[A](s: Ref, action: RefIO[A]) extends StatementOp[A]
-    case class LiftResultSetIO[A](s: ResultSet, action: ResultSetIO[A]) extends StatementOp[A]
-    case class LiftSQLDataIO[A](s: SQLData, action: SQLDataIO[A]) extends StatementOp[A]
-    case class LiftSQLInputIO[A](s: SQLInput, action: SQLInputIO[A]) extends StatementOp[A]
-    case class LiftSQLOutputIO[A](s: SQLOutput, action: SQLOutputIO[A]) extends StatementOp[A]
+    case class LiftBlobIO[A](s: Blob, action: BlobIO[A]) extends StatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftCallableStatementIO[A](s: CallableStatement, action: CallableStatementIO[A]) extends StatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftClobIO[A](s: Clob, action: ClobIO[A]) extends StatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftConnectionIO[A](s: Connection, action: ConnectionIO[A]) extends StatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftDatabaseMetaDataIO[A](s: DatabaseMetaData, action: DatabaseMetaDataIO[A]) extends StatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftDriverIO[A](s: Driver, action: DriverIO[A]) extends StatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftNClobIO[A](s: NClob, action: NClobIO[A]) extends StatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftPreparedStatementIO[A](s: PreparedStatement, action: PreparedStatementIO[A]) extends StatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftRefIO[A](s: Ref, action: RefIO[A]) extends StatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftResultSetIO[A](s: ResultSet, action: ResultSetIO[A]) extends StatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftSQLDataIO[A](s: SQLData, action: SQLDataIO[A]) extends StatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftSQLInputIO[A](s: SQLInput, action: SQLInputIO[A]) extends StatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
+    case class LiftSQLOutputIO[A](s: SQLOutput, action: SQLOutputIO[A]) extends StatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => action.transK[M].run(s))
+    }
 
     // Combinators
-    case class Attempt[A](action: StatementIO[A]) extends StatementOp[Throwable \/ A]
-    case class Pure[A](a: () => A) extends StatementOp[A]
+    case class Attempt[A](action: StatementIO[A]) extends StatementOp[Throwable \/ A] {
+      import scalaz._, Scalaz._
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = 
+        Predef.implicitly[Catchable[Kleisli[M, Statement, ?]]].attempt(action.transK[M])
+    }
+    case class Pure[A](a: () => A) extends StatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_ => a())
+    }
+    case class Raw[A](f: Statement => A) extends StatementOp[A] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(f)
+    }
 
     // Primitive Operations
-    case class  AddBatch(a: String) extends StatementOp[Unit]
-    case object Cancel extends StatementOp[Unit]
-    case object ClearBatch extends StatementOp[Unit]
-    case object ClearWarnings extends StatementOp[Unit]
-    case object Close extends StatementOp[Unit]
-    case class  Execute(a: String, b: Int) extends StatementOp[Boolean]
-    case class  Execute1(a: String) extends StatementOp[Boolean]
-    case class  Execute2(a: String, b: Array[Int]) extends StatementOp[Boolean]
-    case class  Execute3(a: String, b: Array[String]) extends StatementOp[Boolean]
-    case object ExecuteBatch extends StatementOp[Array[Int]]
-    case class  ExecuteQuery(a: String) extends StatementOp[ResultSet]
-    case class  ExecuteUpdate(a: String, b: Int) extends StatementOp[Int]
-    case class  ExecuteUpdate1(a: String) extends StatementOp[Int]
-    case class  ExecuteUpdate2(a: String, b: Array[String]) extends StatementOp[Int]
-    case class  ExecuteUpdate3(a: String, b: Array[Int]) extends StatementOp[Int]
-    case object GetConnection extends StatementOp[Connection]
-    case object GetFetchDirection extends StatementOp[Int]
-    case object GetFetchSize extends StatementOp[Int]
-    case object GetGeneratedKeys extends StatementOp[ResultSet]
-    case object GetMaxFieldSize extends StatementOp[Int]
-    case object GetMaxRows extends StatementOp[Int]
-    case class  GetMoreResults(a: Int) extends StatementOp[Boolean]
-    case object GetMoreResults1 extends StatementOp[Boolean]
-    case object GetQueryTimeout extends StatementOp[Int]
-    case object GetResultSet extends StatementOp[ResultSet]
-    case object GetResultSetConcurrency extends StatementOp[Int]
-    case object GetResultSetHoldability extends StatementOp[Int]
-    case object GetResultSetType extends StatementOp[Int]
-    case object GetUpdateCount extends StatementOp[Int]
-    case object GetWarnings extends StatementOp[SQLWarning]
-    case object IsClosed extends StatementOp[Boolean]
-    case object IsPoolable extends StatementOp[Boolean]
-    case class  IsWrapperFor(a: Class[_]) extends StatementOp[Boolean]
-    case class  SetCursorName(a: String) extends StatementOp[Unit]
-    case class  SetEscapeProcessing(a: Boolean) extends StatementOp[Unit]
-    case class  SetFetchDirection(a: Int) extends StatementOp[Unit]
-    case class  SetFetchSize(a: Int) extends StatementOp[Unit]
-    case class  SetMaxFieldSize(a: Int) extends StatementOp[Unit]
-    case class  SetMaxRows(a: Int) extends StatementOp[Unit]
-    case class  SetPoolable(a: Boolean) extends StatementOp[Unit]
-    case class  SetQueryTimeout(a: Int) extends StatementOp[Unit]
-    case class  Unwrap[T](a: Class[T]) extends StatementOp[T]
+    case class  AddBatch(a: String) extends StatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.addBatch(a))
+    }
+    case object Cancel extends StatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.cancel())
+    }
+    case object ClearBatch extends StatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.clearBatch())
+    }
+    case object ClearWarnings extends StatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.clearWarnings())
+    }
+    case object Close extends StatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.close())
+    }
+    case object CloseOnCompletion extends StatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.closeOnCompletion())
+    }
+    case class  Execute(a: String) extends StatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a))
+    }
+    case class  Execute1(a: String, b: Array[String]) extends StatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
+    }
+    case class  Execute2(a: String, b: Array[Int]) extends StatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
+    }
+    case class  Execute3(a: String, b: Int) extends StatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
+    }
+    case object ExecuteBatch extends StatementOp[Array[Int]] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeBatch())
+    }
+    case object ExecuteLargeBatch extends StatementOp[Array[Long]] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeBatch())
+    }
+    case class  ExecuteLargeUpdate(a: String, b: Array[String]) extends StatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
+    }
+    case class  ExecuteLargeUpdate1(a: String, b: Array[Int]) extends StatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
+    }
+    case class  ExecuteLargeUpdate2(a: String, b: Int) extends StatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
+    }
+    case class  ExecuteLargeUpdate3(a: String) extends StatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a))
+    }
+    case class  ExecuteQuery(a: String) extends StatementOp[ResultSet] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeQuery(a))
+    }
+    case class  ExecuteUpdate(a: String) extends StatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a))
+    }
+    case class  ExecuteUpdate1(a: String, b: Array[Int]) extends StatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
+    }
+    case class  ExecuteUpdate2(a: String, b: Int) extends StatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
+    }
+    case class  ExecuteUpdate3(a: String, b: Array[String]) extends StatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
+    }
+    case object GetConnection extends StatementOp[Connection] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getConnection())
+    }
+    case object GetFetchDirection extends StatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getFetchDirection())
+    }
+    case object GetFetchSize extends StatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getFetchSize())
+    }
+    case object GetGeneratedKeys extends StatementOp[ResultSet] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getGeneratedKeys())
+    }
+    case object GetLargeMaxRows extends StatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeMaxRows())
+    }
+    case object GetLargeUpdateCount extends StatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeUpdateCount())
+    }
+    case object GetMaxFieldSize extends StatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMaxFieldSize())
+    }
+    case object GetMaxRows extends StatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMaxRows())
+    }
+    case class  GetMoreResults(a: Int) extends StatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMoreResults(a))
+    }
+    case object GetMoreResults1 extends StatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMoreResults())
+    }
+    case object GetQueryTimeout extends StatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getQueryTimeout())
+    }
+    case object GetResultSet extends StatementOp[ResultSet] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getResultSet())
+    }
+    case object GetResultSetConcurrency extends StatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getResultSetConcurrency())
+    }
+    case object GetResultSetHoldability extends StatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getResultSetHoldability())
+    }
+    case object GetResultSetType extends StatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getResultSetType())
+    }
+    case object GetUpdateCount extends StatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getUpdateCount())
+    }
+    case object GetWarnings extends StatementOp[SQLWarning] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getWarnings())
+    }
+    case object IsCloseOnCompletion extends StatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.isCloseOnCompletion())
+    }
+    case object IsClosed extends StatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.isClosed())
+    }
+    case object IsPoolable extends StatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.isPoolable())
+    }
+    case class  IsWrapperFor(a: Class[_]) extends StatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.isWrapperFor(a))
+    }
+    case class  SetCursorName(a: String) extends StatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCursorName(a))
+    }
+    case class  SetEscapeProcessing(a: Boolean) extends StatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setEscapeProcessing(a))
+    }
+    case class  SetFetchDirection(a: Int) extends StatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setFetchDirection(a))
+    }
+    case class  SetFetchSize(a: Int) extends StatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setFetchSize(a))
+    }
+    case class  SetLargeMaxRows(a: Long) extends StatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setLargeMaxRows(a))
+    }
+    case class  SetMaxFieldSize(a: Int) extends StatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setMaxFieldSize(a))
+    }
+    case class  SetMaxRows(a: Int) extends StatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setMaxRows(a))
+    }
+    case class  SetPoolable(a: Boolean) extends StatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setPoolable(a))
+    }
+    case class  SetQueryTimeout(a: Int) extends StatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setQueryTimeout(a))
+    }
+    case class  Unwrap[T](a: Class[T]) extends StatementOp[T] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.unwrap(a))
+    }
 
   }
   import StatementOp._ // We use these immediately
@@ -272,6 +425,13 @@ object statement {
   def delay[A](a: => A): StatementIO[A] =
     F.liftFC(Pure(a _))
 
+  /**
+   * Backdoor for arbitrary computations on the underlying Statement.
+   * @group Constructors (Lifting)
+   */
+  def raw[A](f: Statement => A): StatementIO[A] =
+    F.liftFC(Raw(f))
+
   /** 
    * @group Constructors (Primitives)
    */
@@ -305,14 +465,20 @@ object statement {
   /** 
    * @group Constructors (Primitives)
    */
-  def execute(a: String, b: Int): StatementIO[Boolean] =
-    F.liftFC(Execute(a, b))
+  val closeOnCompletion: StatementIO[Unit] =
+    F.liftFC(CloseOnCompletion)
 
   /** 
    * @group Constructors (Primitives)
    */
   def execute(a: String): StatementIO[Boolean] =
-    F.liftFC(Execute1(a))
+    F.liftFC(Execute(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def execute(a: String, b: Array[String]): StatementIO[Boolean] =
+    F.liftFC(Execute1(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -323,7 +489,7 @@ object statement {
   /** 
    * @group Constructors (Primitives)
    */
-  def execute(a: String, b: Array[String]): StatementIO[Boolean] =
+  def execute(a: String, b: Int): StatementIO[Boolean] =
     F.liftFC(Execute3(a, b))
 
   /** 
@@ -335,31 +501,61 @@ object statement {
   /** 
    * @group Constructors (Primitives)
    */
+  val executeLargeBatch: StatementIO[Array[Long]] =
+    F.liftFC(ExecuteLargeBatch)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String, b: Array[String]): StatementIO[Long] =
+    F.liftFC(ExecuteLargeUpdate(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String, b: Array[Int]): StatementIO[Long] =
+    F.liftFC(ExecuteLargeUpdate1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String, b: Int): StatementIO[Long] =
+    F.liftFC(ExecuteLargeUpdate2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String): StatementIO[Long] =
+    F.liftFC(ExecuteLargeUpdate3(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
   def executeQuery(a: String): StatementIO[ResultSet] =
     F.liftFC(ExecuteQuery(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def executeUpdate(a: String, b: Int): StatementIO[Int] =
-    F.liftFC(ExecuteUpdate(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def executeUpdate(a: String): StatementIO[Int] =
-    F.liftFC(ExecuteUpdate1(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeUpdate(a: String, b: Array[String]): StatementIO[Int] =
-    F.liftFC(ExecuteUpdate2(a, b))
+    F.liftFC(ExecuteUpdate(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def executeUpdate(a: String, b: Array[Int]): StatementIO[Int] =
+    F.liftFC(ExecuteUpdate1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeUpdate(a: String, b: Int): StatementIO[Int] =
+    F.liftFC(ExecuteUpdate2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeUpdate(a: String, b: Array[String]): StatementIO[Int] =
     F.liftFC(ExecuteUpdate3(a, b))
 
   /** 
@@ -385,6 +581,18 @@ object statement {
    */
   val getGeneratedKeys: StatementIO[ResultSet] =
     F.liftFC(GetGeneratedKeys)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val getLargeMaxRows: StatementIO[Long] =
+    F.liftFC(GetLargeMaxRows)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val getLargeUpdateCount: StatementIO[Long] =
+    F.liftFC(GetLargeUpdateCount)
 
   /** 
    * @group Constructors (Primitives)
@@ -455,6 +663,12 @@ object statement {
   /** 
    * @group Constructors (Primitives)
    */
+  val isCloseOnCompletion: StatementIO[Boolean] =
+    F.liftFC(IsCloseOnCompletion)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
   val isClosed: StatementIO[Boolean] =
     F.liftFC(IsClosed)
 
@@ -497,6 +711,12 @@ object statement {
   /** 
    * @group Constructors (Primitives)
    */
+  def setLargeMaxRows(a: Long): StatementIO[Unit] =
+    F.liftFC(SetLargeMaxRows(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
   def setMaxFieldSize(a: Int): StatementIO[Unit] =
     F.liftFC(SetMaxFieldSize(a))
 
@@ -528,83 +748,10 @@ object statement {
   * Natural transformation from `StatementOp` to `Kleisli` for the given `M`, consuming a `java.sql.Statement`. 
   * @group Algebra
   */
- def kleisliTrans[M[_]: Monad: Catchable: Capture]: StatementOp ~> ({type l[a] = Kleisli[M, Statement, a]})#l =
-   new (StatementOp ~> ({type l[a] = Kleisli[M, Statement, a]})#l) {
-     import scalaz.syntax.catchable._
-
-     val L = Predef.implicitly[Capture[M]]
-
-     def primitive[A](f: Statement => A): Kleisli[M, Statement, A] =
-       Kleisli(s => L.apply(f(s)))
-
-     def apply[A](op: StatementOp[A]): Kleisli[M, Statement, A] = 
-       op match {
-
-        // Lifting
-        case LiftBlobIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftCallableStatementIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftClobIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftConnectionIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftDatabaseMetaDataIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftDriverIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftNClobIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftPreparedStatementIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftRefIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftResultSetIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftSQLDataIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftSQLInputIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-        case LiftSQLOutputIO(s, k) => Kleisli(_ => k.transK[M].run(s))
-  
-        // Combinators
-        case Pure(a) => primitive(_ => a())
-        case Attempt(a) => a.transK[M].attempt
-  
-        // Primitive Operations
-        case AddBatch(a) => primitive(_.addBatch(a))
-        case Cancel => primitive(_.cancel)
-        case ClearBatch => primitive(_.clearBatch)
-        case ClearWarnings => primitive(_.clearWarnings)
-        case Close => primitive(_.close)
-        case Execute(a, b) => primitive(_.execute(a, b))
-        case Execute1(a) => primitive(_.execute(a))
-        case Execute2(a, b) => primitive(_.execute(a, b))
-        case Execute3(a, b) => primitive(_.execute(a, b))
-        case ExecuteBatch => primitive(_.executeBatch)
-        case ExecuteQuery(a) => primitive(_.executeQuery(a))
-        case ExecuteUpdate(a, b) => primitive(_.executeUpdate(a, b))
-        case ExecuteUpdate1(a) => primitive(_.executeUpdate(a))
-        case ExecuteUpdate2(a, b) => primitive(_.executeUpdate(a, b))
-        case ExecuteUpdate3(a, b) => primitive(_.executeUpdate(a, b))
-        case GetConnection => primitive(_.getConnection)
-        case GetFetchDirection => primitive(_.getFetchDirection)
-        case GetFetchSize => primitive(_.getFetchSize)
-        case GetGeneratedKeys => primitive(_.getGeneratedKeys)
-        case GetMaxFieldSize => primitive(_.getMaxFieldSize)
-        case GetMaxRows => primitive(_.getMaxRows)
-        case GetMoreResults(a) => primitive(_.getMoreResults(a))
-        case GetMoreResults1 => primitive(_.getMoreResults)
-        case GetQueryTimeout => primitive(_.getQueryTimeout)
-        case GetResultSet => primitive(_.getResultSet)
-        case GetResultSetConcurrency => primitive(_.getResultSetConcurrency)
-        case GetResultSetHoldability => primitive(_.getResultSetHoldability)
-        case GetResultSetType => primitive(_.getResultSetType)
-        case GetUpdateCount => primitive(_.getUpdateCount)
-        case GetWarnings => primitive(_.getWarnings)
-        case IsClosed => primitive(_.isClosed)
-        case IsPoolable => primitive(_.isPoolable)
-        case IsWrapperFor(a) => primitive(_.isWrapperFor(a))
-        case SetCursorName(a) => primitive(_.setCursorName(a))
-        case SetEscapeProcessing(a) => primitive(_.setEscapeProcessing(a))
-        case SetFetchDirection(a) => primitive(_.setFetchDirection(a))
-        case SetFetchSize(a) => primitive(_.setFetchSize(a))
-        case SetMaxFieldSize(a) => primitive(_.setMaxFieldSize(a))
-        case SetMaxRows(a) => primitive(_.setMaxRows(a))
-        case SetPoolable(a) => primitive(_.setPoolable(a))
-        case SetQueryTimeout(a) => primitive(_.setQueryTimeout(a))
-        case Unwrap(a) => primitive(_.unwrap(a))
-  
-      }
-  
+  def kleisliTrans[M[_]: Monad: Catchable: Capture]: StatementOp ~> Kleisli[M, Statement, ?] =
+    new (StatementOp ~> Kleisli[M, Statement, ?]) {
+      def apply[A](op: StatementOp[A]): Kleisli[M, Statement, A] =
+        op.defaultTransK[M]
     }
 
   /**
@@ -613,7 +760,7 @@ object statement {
    */
   implicit class StatementIOOps[A](ma: StatementIO[A]) {
     def transK[M[_]: Monad: Catchable: Capture]: Kleisli[M, Statement, A] =
-      F.runFC[StatementOp,({type l[a]=Kleisli[M,Statement,a]})#l,A](ma)(kleisliTrans[M])
+      F.runFC[StatementOp, Kleisli[M, Statement, ?], A](ma)(kleisliTrans[M])
   }
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,6 +17,6 @@ resolvers += Resolver.url(
     url("http://dl.bintray.com/content/tpolecat/sbt-plugin-releases"))(
         Resolver.ivyStylePatterns)
 
-addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.3.2")
+addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.4.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.1")


### PR DESCRIPTION
- `freeGen` now works again. This resolves #162. Note that it must be run only under Java 7, otherwise CI will fail due to methods added in Java 8. If someone requires it we could have multiple versions, but I would prefer not to.
- Free algebras are new inverted with respect to the expression problem, and a `raw` constructor is exposed. Both are distasteful but necessary for performance.
- Removed type lambdas in favor of KP syntax.
- Updated to tut 0.4.0 as required by #179.