### PR TITLE
More DriverManagerTransactor ctors

### DIFF
--- a/doc/src/main/tut/12-Managing-Connections.md
+++ b/doc/src/main/tut/12-Managing-Connections.md
@@ -36,7 +36,7 @@ In addition to simply supplying a connection, a `Transactor` (by default) wraps 
 JDBC provides a bare-bones connection provider via `DriverManager.getConnection`, which has the advantage of being extremely simple: there is no connection pooling and thus no configuration required. The disadvantage is that it is quite a bit slower than pooling connection managers, and provides no upper bound on the number of concurrent connections.
 
 However, for experimentation as described in this book (and for situations where you really do want to ensure that you get a truly fresh connection right away) the `DriverManager` is ideal. Support in **doobie** is via `DriverManagerTransactor`. To construct one you must pass the name of the driver
-class, as well as the connect URL and user/password.
+class and a connect URL. Normally you will also pass a user/password (the API provides several variants matching the `DriverManager` static API).
 
 ```tut:silent
 val xa = DriverManagerTransactor[Task](


### PR DESCRIPTION
This adds some overloads to support variants of `DriverManager.getConnection`. Not a general solution but it resolves #170.