### PR TITLE
Shapeless records

### DIFF
--- a/core/src/test/scala/doobie/util/composite.scala
+++ b/core/src/test/scala/doobie/util/composite.scala
@@ -1,6 +1,6 @@
 package doobie.util
 
-import shapeless._, shapeless.test._
+import shapeless._, shapeless.test._, shapeless.record._
 import doobie.imports._
 import org.specs2.mutable.Specification
 
@@ -30,6 +30,17 @@ object compositespec extends Specification {
       Composite[(Woozle, String)]
       Composite[(Int, Woozle :: Woozle :: String :: HNil)]
 
+      true
+    }
+
+    "exist for shapeless record types" in {
+
+      type DL = (Double, Long)
+      type A = Record.`'foo -> Int, 'bar -> String, 'baz -> DL, 'quz -> Woozle`.T
+      
+      Composite[A]
+      Composite[(A, A)]
+      
       true
     }
 

--- a/doc/src/main/tut/04-Selecting.md
+++ b/doc/src/main/tut/04-Selecting.md
@@ -102,12 +102,25 @@ We can select multiple columns, of course, and map them to a tuple. The `gnp` co
   .query[(String, String, Int, Option[Double])]
   .process.take(5).quick.run)
 ```
-**doobie** automatically supports row mappings for atomic column types, as well as options, tuples, `HList`s and case classes thereof. So let's try the same query with an `HList`:
+**doobie** automatically supports row mappings for atomic column types, as well as options, tuples, `HList`s, shapeless records, and case classes thereof. So let's try the same query with an `HList`:
 
 ```tut
 import shapeless._
+
 (sql"select code, name, population, gnp from country"
   .query[String :: String :: Int :: Option[Double] :: HNil]
+  .process.take(5).quick.run)
+```
+
+And with a shapeless record:
+
+```tut
+import shapeless.record.Record
+
+type Rec = Record.`'code -> String, 'name -> String, 'pop -> Int, 'gnp -> Option[Double]`.T
+
+(sql"select code, name, population, gnp from country"
+  .query[Rec]
   .process.take(5).quick.run)
 ```
 
@@ -123,7 +136,7 @@ case class Country(code: String, name: String, pop: Int, gnp: Option[Double])
   .process.take(5).quick.run)
 ```
 
-You can also nest case classes, `HList`s, and/or tuples arbitrarily as long as the eventual members are of supported columns types. For instance, here we map the same set of columns to a tuple of two case classes:
+You can also nest case classes, `HList`s, shapeless records, and/or tuples arbitrarily as long as the eventual members are of supported columns types. For instance, here we map the same set of columns to a tuple of two case classes:
 
 ```tut:silent
 case class Code(code: String)

--- a/doc/src/main/tut/10-Custom-Mappings.md
+++ b/doc/src/main/tut/10-Custom-Mappings.md
@@ -52,7 +52,7 @@ HPS.set(("foo", 42))
 Composite[(String,Int)].set(1, ("foo", 42))
 ```
 
-**doobie** can derive `Composite` instances for primitive column types, plus tuples, `HList`s. and case classes whose elements have `Composite` instances. These primitive column types are identified by `Atom` instances, which describe `null`-safe column mappings. These `Atom` instances are almost always derived from lower-level `null`-unsafe mappings specified by the `Meta` typeclass.
+**doobie** can derive `Composite` instances for primitive column types, plus tuples, `HList`s, shapeless records, and case classes whose elements have `Composite` instances. These primitive column types are identified by `Atom` instances, which describe `null`-safe column mappings. These `Atom` instances are almost always derived from lower-level `null`-unsafe mappings specified by the `Meta` typeclass.
 
 So our strategy for mapping custom types is to construct a new `Meta` instance (given `Meta[A]` you get `Atom[A]` and `Atom[Option[A]]` for free); and our strategy for multi-column mappings is to construct a new `Composite` instance. We consider both case below.
 
@@ -186,7 +186,7 @@ sql"select name, owner from pet".query[(String,String)].quick.run
 
 ### Composite by Invariant Map
 
-We get `Composite[A]` for free given `Atom[A]`, or for tuples, `HList`s, and case classes whose fields have `Composite` instances. This covers a lot of cases, but we still need a way to map other types. For example, what if we wanted to map a `java.awt.Point` across two columns? Because it's not a tuple or case class we can't do it for free, but we can get there via `xmap`. Here we map `Point` to a pair of `Int` columns.
+We get `Composite[A]` for free given `Atom[A]`, or for tuples, `HList`s, shapeless records, and case classes whose fields have `Composite` instances. This covers a lot of cases, but we still need a way to map other types. For example, what if we wanted to map a `java.awt.Point` across two columns? Because it's not a tuple or case class we can't do it for free, but we can get there via `xmap`. Here we map `Point` to a pair of `Int` columns.
 
 ```tut:silent
 implicit val Point2DComposite: Composite[Point] = 


### PR DESCRIPTION
This adds support for `Composite` of shapeless records, and resolves #144.