### PR TITLE
param typeclass, in-clause support

### DIFF
--- a/core/src/main/scala/doobie/imports.scala
+++ b/core/src/main/scala/doobie/imports.scala
@@ -112,11 +112,14 @@ object imports {
   /** @group Type Aliases */      type SqlState = doobie.enum.sqlstate.SqlState
   /** @group Companion Aliases */ val  SqlState = doobie.enum.sqlstate.SqlState
 
+  /** @group Type Aliases */      type Param[A] = doobie.syntax.string.Param[A]
+  /** @group Companion Aliases */ val  Param    = doobie.syntax.string.Param
 
   /** @group Type Aliases */ type Transactor[M[_]] = doobie.util.transactor.Transactor[M]
 
   /** @group Companion Aliases */ val DriverManagerTransactor = doobie.util.transactor.DriverManagerTransactor
   /** @group Companion Aliases */ val DataSourceTransactor = doobie.util.transactor.DataSourceTransactor
+
 
   /** @group Typeclass Instances */
   implicit val NameCatchable = doobie.util.name.NameCatchable

--- a/core/src/main/scala/doobie/syntax/string.scala
+++ b/core/src/main/scala/doobie/syntax/string.scala
@@ -16,9 +16,6 @@ import shapeless._
 /** Module defining the `sql` string interpolator. */
 object string {
 
-  /** 
-   * Typeclass for an `Atom` or singleton `NonEmptyList` of some atomic type.
-   */
   sealed trait Param[A] {
     val composite: Composite[A]
     val placeholders: List[Int]

--- a/core/src/test/scala/doobie/syntax/string.scala
+++ b/core/src/test/scala/doobie/syntax/string.scala
@@ -1,0 +1,72 @@
+package doobie.syntax
+
+import scalaz.NonEmptyList
+import doobie.imports._
+import shapeless._
+import shapeless.test.illTyped
+import org.specs2.mutable.Specification
+
+object stringspec extends Specification {
+
+  "sql interpolator" should {
+
+    "support no-param queries" in {
+      val q = sql"foo bar baz".query[Int]
+      q.sql must_=== "foo bar baz"
+    }
+
+    "support atomic types" in {
+      val a = 1
+      val b = "two"
+      val q = sql"foo $a bar $b baz".query[Int]
+      q.sql must_=== "foo ? bar ? baz"
+    }
+
+    "handle leading params" in {
+      val a = 1
+      val q = sql"$a bar baz".query[Int]
+      q.sql must_=== "? bar baz"
+    }
+
+    "support trailing params" in {
+      val b = "two"
+      val q = sql"foo bar $b".query[Int]
+      q.sql must_=== "foo bar ?"
+    }
+
+    "support sequence params" in {
+      val a = NonEmptyList(1,2,3)
+      implicit val pa = Param.many(a)
+      val q = sql"foo ${a : a.type} bar baz".query[Int]
+      q.sql must_=== "foo ?, ?, ? bar baz"
+    }
+
+    "support multiple distinct sequence params" in {
+      val a = NonEmptyList(1,2,3)
+      val b = NonEmptyList("foo", "bar")
+      implicit val pa = Param.many(a)
+      implicit val pb = Param.many(b)
+      val q = sql"foo ${a : a.type} bar ${b : b.type} baz".query[Int]
+      q.sql must_=== "foo ?, ?, ? bar ?, ? baz"
+    }
+
+    "support a combination of atomic and sequence params" in {
+      val a = NonEmptyList(1,2,3)
+      val b = NonEmptyList("foo", "bar")
+      implicit val pa = Param.many(a)
+      implicit val pb = Param.many(b)
+      val c = 42
+      val q = sql"foo ${a : a.type} bar ${b : b.type} baz $c".query[Int]
+      q.sql must_=== "foo ?, ?, ? bar ?, ? baz ?"
+    }
+
+    "not support product params" in {
+      val a = (1, "two")
+      Composite[(Int, String)]
+      illTyped(""" sql"foo $a bar baz".query[Int] """)
+      true
+    }
+
+  }
+
+}

--- a/doc/src/main/tut/05-Parameterized.md
+++ b/doc/src/main/tut/05-Parameterized.md
@@ -104,7 +104,7 @@ def populationIn(range: Range, codes: NonEmptyList[String]) = {
 There are a few things to notice here:
 
 - The `IN` clause must be non-empty, so `codes` is a `NonEmptyList`.
-- We must derive a `Param` instance for the *singleton type* of `codes`, which we do via `Param.many`. This derivation is legal for any `NonEmptyList[A]` given `Atom[A]`. You can have any number of `IN` arguments but each must have its own derived `Param` instance.
+- We must derive a `Param` instance for the *singleton type* of `codes`, which we do via `Param.many`. This derivation is legal for any `F[A]` given `Foldable1[F]` and `Atom[A]`. You can have any number of `IN` arguments but each must have its own derived `Param` instance.
 - When interpolating `codes` we must explicitly ascribe its singleton type `codes.type`.
 
 Running this query gives us the desired result.

--- a/doc/src/main/tut/05-Parameterized.md
+++ b/doc/src/main/tut/05-Parameterized.md
@@ -90,7 +90,7 @@ A common irritant when dealing with SQL literals is the desire to inline a *sequ
 
 ```tut:silent
 def populationIn(range: Range, codes: NonEmptyList[String]) = {
-  implicit val codesParam = doobie.syntax.string.Param.many(codes)
+  implicit val codesParam = Param.many(codes)
   sql"""
     select code, name, population, gnp 
     from country

--- a/doc/src/main/tut/05-Parameterized.md
+++ b/doc/src/main/tut/05-Parameterized.md
@@ -84,6 +84,35 @@ def populationIn(range: Range) = sql"""
 populationIn(150000000 to 200000000).quick.run 
 ```
 
+### Dealing with `IN` Clauses
+
+A common irritant when dealing with SQL literals is the desire to inline a *sequence* of arguments into an `IN` clause, but SQL does not support this notion (nor does JDBC do anything to assist). So as of version 0.2.3 **doobie** provides support in the form of some slightly inconvenient machinery.
+
+```tut:silent
+def populationIn(range: Range, codes: NonEmptyList[String]) = {
+  implicit val codesParam = doobie.syntax.string.Param.many(codes)
+  sql"""
+    select code, name, population, gnp 
+    from country
+    where population > ${range.min}
+    and   population < ${range.max}
+    and   code in (${codes : codes.type})
+  """.query[Country]
+}
+```
+
+There are a few things to notice here:
+
+- The `IN` clause must be non-empty, so `codes` is a `NonEmptyList`.
+- We must derive a `Param` instance for the *singleton type* of `codes`, which we do via `Param.many`. This derivation is legal for any `NonEmptyList[A]` given `Atom[A]`. You can have any number of `IN` arguments but each must have its own derived `Param` instance.
+- When interpolating `codes` we must explicitly ascribe its singleton type `codes.type`.
+
+Running this query gives us the desired result.
+
+```tut
+populationIn(100000000 to 300000000, NonEmptyList("USA", "BRA", "PAK", "GBR")).quick.run 
+```
+
 ### Diving Deeper
 
 In the previous chapter's *Diving Deeper* we saw how a query constructed with the `sql` interpolator is just sugar for the `process` constructor defined in the `doobie.hi.connection` module (aliased as `HC`). Here we see that the second parameter, a `PreparedStatementIO` program, is used to set the query parameters.

--- a/doc/src/main/tut/10-Custom-Mappings.md
+++ b/doc/src/main/tut/10-Custom-Mappings.md
@@ -89,7 +89,7 @@ Composite[PersonId].length
 
 However if we try to use this type for a *single* column value (i.e., as a query parameter, which requires an `Atom` instance), it doesn't compile.
 
-```tut:nofail
+```tut:fail
 sql"select * from person where id = $pid"
 ```
 


### PR DESCRIPTION
This adds a `Param` typeclass that's used only by the `sql` interpolator. This ensures that we can't use arbitrary `Composite` instances as parameters and thus resolves #202. It also provides a way to do `IN` clauses and thus resolves #80.