### PR TITLE
metadata analysis of query output

### DIFF
--- a/contrib/specs2/src/main/scala/doobie/contrib/specs2/specs2.scala
+++ b/contrib/specs2/src/main/scala/doobie/contrib/specs2/specs2.scala
@@ -49,6 +49,9 @@ object analysisspec {
     def check[A](q: Query0[A])(implicit A: TypeTag[A]) =
       checkAnalysis(s"Query0[${typeName(A)}]", q.stackFrame, q.sql, q.analysis)
 
+    def checkOutput[A](q: Query0[A])(implicit A: TypeTag[A]) =
+      checkAnalysis(s"Query0[${typeName(A)}]", q.stackFrame, q.sql, q.outputAnalysis)
+
     def check[A](q: Update[A])(implicit A: TypeTag[A]) =
       checkAnalysis(s"Update[${typeName(A)}]", q.stackFrame, q.sql, q.analysis)
 

--- a/core/src/main/scala/doobie/util/query.scala
+++ b/core/src/main/scala/doobie/util/query.scala
@@ -49,6 +49,12 @@ object query {
      */
     def analysis: ConnectionIO[Analysis] =
       HC.prepareQueryAnalysis[I, O](sql)
+    /**
+     * Program to construct an analysis of this query's SQL statement and result set column types.
+     * @group Diagnostics
+     */
+    def outputAnalysis: ConnectionIO[Analysis] =
+      HC.prepareQueryAnalysis0[O](sql)
 
     /**
      * Apply the argument `a` to construct a `Process` with effect type 
@@ -130,6 +136,7 @@ object query {
         def sql = outer.sql
         def stackFrame = outer.stackFrame
         def analysis = outer.analysis
+        def outputAnalysis = outer.outputAnalysis
         def process = outer.process(a)
         def to[F[_]](implicit cbf: CanBuildFrom[Nothing, B, F[B]]) = outer.to[F](a)
         def accumulate[F[_]: MonadPlus] = outer.accumulate[F](a)  
@@ -205,6 +212,12 @@ object query {
     def analysis: ConnectionIO[Analysis] 
 
     /** 
+     * Program to construct an analysis of this query's SQL statement and result set column types.
+     * @group Diagnostics
+     */
+    def outputAnalysis: ConnectionIO[Analysis]
+
+    /**
      * `Process` with effect type `[[doobie.free.connection.ConnectionIO ConnectionIO]]` yielding 
      * elements of type `B`. 
      * @group Results

--- a/core/src/main/scala/doobie/util/yolo.scala
+++ b/core/src/main/scala/doobie/util/yolo.scala
@@ -36,7 +36,13 @@ object yolo {
         q.sink(a => out(a.toString)).transact(xa)
 
       def check: M[Unit] =
-        (delay(showSql(q.sql)) >> q.analysis.attempt.flatMap {
+        doCheck(q.analysis)
+
+      def checkOutput: M[Unit] =
+        doCheck(q.outputAnalysis)
+
+      private def doCheck(a: ConnectionIO[Analysis]): M[Unit] =
+        (delay(showSql(q.sql)) >> a.attempt.flatMap {
           case -\/(e) => delay(failure("SQL Compiles and Typechecks", formatError(e.getMessage)))
           case \/-(a) => delay {
             success("SQL Compiles and Typechecks", None)
@@ -53,7 +59,13 @@ object yolo {
         q.toQuery0(i).quick
 
       def check: M[Unit] =
-        (delay(showSql(q.sql)) >> q.analysis.attempt.flatMap {
+        doCheck(q.analysis)
+
+      def checkOutput: M[Unit] =
+        doCheck(q.outputAnalysis)
+
+      private def doCheck(a: ConnectionIO[Analysis]): M[Unit] =
+        (delay(showSql(q.sql)) >> a.attempt.flatMap {
           case -\/(e) => delay(failure("SQL Compiles and Typechecks", formatError(e.getMessage)))
           case \/-(a) => delay {
             success("SQL Compiles and Typechecks", None)

--- a/doc/src/main/tut/06-Checking.md
+++ b/doc/src/main/tut/06-Checking.md
@@ -90,6 +90,18 @@ biggerThan(0).check.run
 
 **doobie** supports `check` for queries and updates in three ways: programmatically, via YOLO mode in the REPL, and via the `contrib-specs2` package, which allows checking to become part of your unit test suite. We will investigate this in the chapter on testing.
 
+### Working Around Bad Metadata
+
+Some drivers do not implement the JDBC metadata specification very well, which limits the usefulness of the query checking feature. MySQL and MS-SQL do a particularly rotten job in this department. In some cases queries simply cannot be checked because no metadata is available for the prepared statement (manifested as an exception) or the returned metadata is obviously inaccurate.
+
+However a common case is that *parameter* metadata is unavailable but *output column* metadata is. And in these cases there is a workaround: use `checkOutput` rather than `check`. This instructs **doobie** to punt on the input parameters and only check output columns. Unsatisfying but better than nothing.
+
+```tut:plain
+biggerThan(0).checkOutput.run
+```
+
+This option is also available in the `contrib-specs2` package.
+
 ### Diving Deeper
 
 The `check` logic requires both a database connection and concrete `Meta` instances that define column-level JDBC mappings. This could in principle happen at compile-time, but it's not clear that this is what you always want and it's potentially hairy to implement. So for now checking happens at unit-test time.


### PR DESCRIPTION
Forked from #230 ... added `checkOutput` to `Yolo`.

(Also rebased, not that it matters.)

In a lame way this
- resolves #231
- resolves #228 
- resolves #222 