### PR TITLE
kp 0.7.1, replace ProductTypeclass

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,8 +33,7 @@ lazy val commonSettings = Seq(
       "org.scalacheck" %% "scalacheck"  % "1.11.5" % "test",
       "org.specs2"     %% "specs2-core" % "3.6"    % "test"
     ),
-    resolvers += "bintray/non" at "http://dl.bintray.com/non/maven",
-    addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.5.2")
+    addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.7.1")
 )
 
 lazy val publishSettings = Seq(

--- a/core/src/main/scala/doobie/syntax/string.scala
+++ b/core/src/main/scala/doobie/syntax/string.scala
@@ -51,14 +51,14 @@ instance for each element in the REPL. See the FAQ in the Book of Doobie for mor
     /** There is an empty `Param` for `HNil`. */
     implicit val ParamHNil: Param[HNil] =
       new Param[HNil] {
-        val composite = Composite.typeClass.emptyProduct
+        val composite = Composite.emptyProduct
         val placeholders = Nil
       }
 
     /** Inductively we can cons a new `Param` onto the head of a `Param` of an `HList`. */
     implicit def ParamHList[H, T <: HList](implicit ph: Param[H], pt: Param[T]) =
       new Param[H :: T] {
-        val composite = Composite.typeClass.product[H,T](ph.composite, pt.composite)
+        val composite = Composite.product[H,T](ph.composite, pt.composite)
         val placeholders = ph.placeholders ++ pt.placeholders
       }
 

--- a/core/src/test/scala/doobie/util/composite.scala
+++ b/core/src/test/scala/doobie/util/composite.scala
@@ -52,6 +52,27 @@ object compositespec extends Specification {
       Composite[LenStr2].length must_== 1
     }
 
+    "work for products of ludicrous size (128)" in {
+      Composite[
+        Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+        Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
+        Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
+        Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
+        Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
+        Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
+        Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
+        Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+        Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+        Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
+        Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
+        Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
+        Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
+        Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
+        Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
+        Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: HNil]
+      true
+    }
+
   }
 
 }

--- a/core/src/test/scala/doobie/util/composite.scala
+++ b/core/src/test/scala/doobie/util/composite.scala
@@ -73,6 +73,33 @@ object compositespec extends Specification {
       true
     }
 
+    "work for specific example from #217" in {
+      trait LocalDateTime
+      implicit val MetaLocalDateTime: Meta[LocalDateTime] = null
+      Composite[
+        Option[String] :: Option[String] :: Option[String] :: Option[LocalDateTime] ::
+        Option[String] :: Option[String] :: Option[String] :: Option[String] ::
+        Option[String] :: Option[String] :: Option[String] :: Option[String] ::
+        Option[String] :: Option[String] :: Option[String] :: Option[String] ::
+        Option[String] :: Option[String] :: Option[String] :: Option[String] :: 
+        Option[String] :: Option[String] :: Option[LocalDateTime] :: Option[LocalDateTime] :: 
+        Option[LocalDateTime] :: Option[LocalDateTime] :: Option[String] :: Option[String] :: 
+        Option[String] :: Option[String] :: Option[String] :: Option[String] ::
+        Option[String] :: Option[String] :: Option[String] :: Option[String] ::
+        Option[String] :: Option[String] :: Option[String] :: Option[String] ::
+        Option[String] :: Option[String] :: Option[String] :: Option[String] ::
+        Option[String] :: Option[String] :: Option[String] :: Option[BigDecimal] :: 
+        Option[String] :: Option[BigDecimal] :: Option[BigDecimal] ::
+        Option[String] :: Option[String] :: Option[String] :: Option[String] ::
+        Option[String] :: Option[String] :: Option[String] :: Option[String] ::
+        Option[String] :: Option[String] :: Option[BigDecimal] :: Option[BigDecimal] ::
+        Option[String] :: Option[String] :: Option[String] :: Option[String] ::
+        Option[String] :: Option[String] :: Option[String] :: Option[String] ::
+        Option[String] :: Option[String] :: Option[BigDecimal] :: Option[BigDecimal] ::
+        Option[String] :: HNil]
+      true
+    }
+
   }
 
 }


### PR DESCRIPTION
This PR updates kind-projector and replaces `ProductTypeClass` with a more straightforward use of `Generic`. It also adds some tests that take a long time to compile ... `compositespec` takes about 40s on my machine, but it does terminate. This resolves #217 
