### PR TITLE
#237 Upgrade to scalaz-stream 0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: scala
 
 scala:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ scala:
 jdk:
   - oraclejdk8
 
-script: sbt ++$TRAVIS_SCALA_VERSION compile core/test h2/test postgres/test tut unidoc
+# TODO re-enable tut when dependency issues are resolved
+# script: sbt ++$TRAVIS_SCALA_VERSION compile core/test h2/test postgres/test tut unidoc
+script: sbt ++$TRAVIS_SCALA_VERSION compile core/test h2/test postgres/test unidoc
 
 addons:
   postgresql: "9.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: scala
 
 scala:
   - 2.12.0-M3
-  - 2.11.7
+  - 2.11.8
   - 2.10.6
 
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,7 @@ scala:
 jdk:
   - oraclejdk8
 
-# TODO re-enable tut when dependency issues are resolved
-# script: sbt ++$TRAVIS_SCALA_VERSION compile core/test h2/test postgres/test tut unidoc
-script: sbt ++$TRAVIS_SCALA_VERSION compile core/test h2/test postgres/test unidoc
+script: sbt ++$TRAVIS_SCALA_VERSION compile core/test h2/test postgres/test tuut unidoc
 
 addons:
   postgresql: "9.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: scala
 
 scala:
+  - 2.12.0-M3
   - 2.11.7
   - 2.10.5
 
 jdk:
-  - oraclejdk7
   - oraclejdk8
 
 script: sbt ++$TRAVIS_SCALA_VERSION compile core/test h2/test postgres/test tut unidoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: scala
 scala:
   - 2.12.0-M3
   - 2.11.7
-  - 2.10.5
+  - 2.10.6
 
 jdk:
   - oraclejdk8

--- a/bench/src/main/scala/doobie/bench/bench.scala
+++ b/bench/src/main/scala/doobie/bench/bench.scala
@@ -49,7 +49,7 @@ object bench {
       .list
       .transact(xa)
       .map(_.length)
-      .run
+      .unsafePerformSync
 
   // Reading via .list, which uses a lower-level collector
   def doobieBench(n: Int): Int = 
@@ -58,7 +58,7 @@ object bench {
       .list
       .transact(xa)
       .map(_.length)
-      .run
+      .unsafePerformSync
 
   // Reading via .vector, which uses a lower-level collector
   def doobieBenchV(n: Int): Int =
@@ -67,7 +67,7 @@ object bench {
       .vector
       .transact(xa)
       .map(_.length)
-      .run
+      .unsafePerformSync
 
   // Reading via .ilist, which uses a lower-level collector
   def doobieBenchI(n: Int): Int =
@@ -77,7 +77,7 @@ object bench {
       }
     } .transact(xa)
       .map(_.length)
-      .run
+      .unsafePerformSync
 
   case class Bench(warmups: Int, runs: Int, ns: List[Int]) {
     def test[A](n: Int)(f: Int => A): Double = {

--- a/build.sbt
+++ b/build.sbt
@@ -31,8 +31,8 @@ lazy val commonSettings = Seq(
       "-skip-packages", "scalaz"
     ),
     libraryDependencies ++= macroParadise(scalaVersion.value) ++ Seq(
-      "org.scalacheck" %% "scalacheck"  % "1.11.5" % "test",
-      "org.specs2"     %% "specs2-core" % "3.6.5"  % "test"
+      "org.scalacheck" %% "scalacheck"  % "1.13.0" % "test",
+      "org.specs2"     %% "specs2-core" % "3.7.1"  % "test"
     ),
     addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.7.1")
 )
@@ -100,9 +100,9 @@ lazy val core = project.in(file("core"))
   .settings(
     libraryDependencies ++= Seq(
       "org.scala-lang"    %  "scala-reflect"    % scalaVersion.value, // required for shapeless macros
-      "org.scalaz"        %% "scalaz-core"      % "7.1.4",
-      "org.scalaz"        %% "scalaz-effect"    % "7.1.4",
-      "org.scalaz.stream" %% "scalaz-stream"    % "0.8",
+      "org.scalaz"        %% "scalaz-core"      % "7.2.0",
+      "org.scalaz"        %% "scalaz-effect"    % "7.2.0",
+      "org.scalaz.stream" %% "scalaz-stream"    % "0.8a",
       "com.chuusai"       %% "shapeless"        % "2.2.5",
       "com.h2database"    %  "h2"               % "1.3.170" % "test"
     )
@@ -158,7 +158,7 @@ lazy val example = project.in(file("example"))
   .settings(doobieSettings)
   .settings(libraryDependencies ++= Seq(
       "com.h2database" %  "h2"         % "1.3.170",
-      "org.scalacheck" %% "scalacheck" % "1.11.5" % "test"
+      "org.scalacheck" %% "scalacheck" % "1.13.0" % "test"
     )
   )
   .settings(scalacOptions += "-deprecation")
@@ -212,7 +212,7 @@ lazy val specs2 = project.in(file("contrib/specs2"))
   .settings(name := "doobie-contrib-specs2")
   .settings(description := "Specs2 support for doobie.")
   .settings(doobieSettings ++ publishSettings)
-  .settings(libraryDependencies += "org.specs2" %% "specs2-core" % "3.6.5")
+  .settings(libraryDependencies += "org.specs2" %% "specs2-core" % "3.7.1")
   .dependsOn(core)
 
 lazy val docs = project.in(file("doc"))
@@ -240,7 +240,7 @@ lazy val docs = project.in(file("doc"))
       }
     }
   )
-  .settings(libraryDependencies += "io.argonaut" %% "argonaut" % "6.1-M4")
+  .settings(libraryDependencies += "io.argonaut" %% "argonaut" % "6.1")
   .dependsOn(core, postgres, specs2, hikari, h2)
 
 lazy val bench = project.in(file("bench"))

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ lazy val commonSettings = Seq(
     ),
     libraryDependencies ++= macroParadise(scalaVersion.value) ++ Seq(
       "org.scalacheck" %% "scalacheck"  % "1.11.5" % "test",
-      "org.specs2"     %% "specs2-core" % "3.6"    % "test"
+      "org.specs2"     %% "specs2-core" % "3.6.5"  % "test"
     ),
     addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.7.1")
 )
@@ -100,9 +100,9 @@ lazy val core = project.in(file("core"))
   .settings(
     libraryDependencies ++= Seq(
       "org.scala-lang"    %  "scala-reflect"    % scalaVersion.value, // required for shapeless macros
-      "org.scalaz"        %% "scalaz-core"      % "7.1.1",
-      "org.scalaz"        %% "scalaz-effect"    % "7.1.1",
-      "org.scalaz.stream" %% "scalaz-stream"    % "0.7.2a",
+      "org.scalaz"        %% "scalaz-core"      % "7.1.4",
+      "org.scalaz"        %% "scalaz-effect"    % "7.1.4",
+      "org.scalaz.stream" %% "scalaz-stream"    % "0.8",
       "com.chuusai"       %% "shapeless"        % "2.2.5",
       "com.h2database"    %  "h2"               % "1.3.170" % "test"
     )
@@ -212,7 +212,7 @@ lazy val specs2 = project.in(file("contrib/specs2"))
   .settings(name := "doobie-contrib-specs2")
   .settings(description := "Specs2 support for doobie.")
   .settings(doobieSettings ++ publishSettings)
-  .settings(libraryDependencies += "org.specs2" %% "specs2-core" % "3.6")
+  .settings(libraryDependencies += "org.specs2" %% "specs2-core" % "3.6.5")
   .dependsOn(core)
 
 lazy val docs = project.in(file("doc"))

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val buildSettings = Seq(
   organization := "org.tpolecat",
   licenses ++= Seq(("MIT", url("http://opensource.org/licenses/MIT"))),
   scalaVersion := "2.11.7",
-  crossScalaVersions := Seq("2.10.5", scalaVersion.value, "2.12.0-M3")
+  crossScalaVersions := Seq("2.10.6", scalaVersion.value, "2.12.0-M3")
 )
 
 lazy val commonSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import OsgiKeys._
 lazy val buildSettings = Seq(
   organization := "org.tpolecat",
   licenses ++= Seq(("MIT", url("http://opensource.org/licenses/MIT"))),
-  scalaVersion := "2.11.7",
+  scalaVersion := "2.11.8",
   crossScalaVersions := Seq("2.10.6", scalaVersion.value, "2.12.0-M3")
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -104,7 +104,7 @@ lazy val core = project.in(file("core"))
       "org.scalaz"        %% "scalaz-core"      % "7.2.0",
       "org.scalaz"        %% "scalaz-effect"    % "7.2.0",
       "org.scalaz.stream" %% "scalaz-stream"    % "0.8a",
-      "com.chuusai"       %% "shapeless"        % "2.2.5",
+      "com.chuusai"       %% "shapeless"        % "2.3.0-RC3",
       "com.h2database"    %  "h2"               % "1.3.170" % "test"
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -7,13 +7,14 @@ lazy val buildSettings = Seq(
   organization := "org.tpolecat",
   licenses ++= Seq(("MIT", url("http://opensource.org/licenses/MIT"))),
   scalaVersion := "2.11.7",
-  crossScalaVersions := Seq("2.10.5", scalaVersion.value)
+  crossScalaVersions := Seq("2.10.5", scalaVersion.value, "2.12.0-M3")
 )
 
 lazy val commonSettings = Seq(
     scalacOptions ++= Seq(
       "-encoding", "UTF-8", // 2 args
       "-feature",
+      "-deprecation",
       "-language:existentials",
       "-language:higherKinds",
       "-language:implicitConversions",
@@ -218,7 +219,7 @@ lazy val specs2 = project.in(file("contrib/specs2"))
 lazy val docs = project.in(file("doc"))
   .settings(doobieSettings)
   .settings(noPublishSettings)
-  .settings(tutSettings)
+  // .settings(tutSettings)
   .settings(
     initialCommands := """
       import doobie.imports._, scalaz._, Scalaz._, scalaz.concurrent.Task
@@ -240,7 +241,8 @@ lazy val docs = project.in(file("doc"))
       }
     }
   )
-  .settings(libraryDependencies += "io.argonaut" %% "argonaut" % "6.1")
+  // TODO wait for argonaut 6.2 milestone
+  // .settings(libraryDependencies += "io.argonaut" %% "argonaut" % "6.1")
   .dependsOn(core, postgres, specs2, hikari, h2)
 
 lazy val bench = project.in(file("bench"))

--- a/build.sbt
+++ b/build.sbt
@@ -240,14 +240,7 @@ lazy val docs = project.in(file("doc"))
       }
     }
   )
-  .settings(
-    // Temporarily depends on argonaut snapshot to compile tut
-    resolvers += Resolver.sonatypeRepo("snapshots"),
-    libraryDependencies ++= Seq(
-      "io.argonaut" %% "argonaut" % "6.2-SNAPSHOT" changing(),
-      "io.argonaut" %% "argonaut-scalaz" % "6.2-SNAPSHOT" changing()
-    )
-  )
+  .settings(libraryDependencies += "io.argonaut" %% "argonaut" % "6.1")
   .dependsOn(core, postgres, specs2, hikari, h2)
 
 lazy val bench = project.in(file("bench"))

--- a/build.sbt
+++ b/build.sbt
@@ -257,12 +257,9 @@ lazy val tuut = taskKey[Seq[(File, String)]]("Temporary task to conditionally sk
 // Temporarily skip tut for Scala 2.12
 // TODO remove after tut-core and argonaut for Scala 2.12 is released
 lazy val docSkipScala212Settings = Seq(
-  libraryDependencies := {
-    val ld = libraryDependencies.value
-    if (scalaVersion.value startsWith "2.12")
-      ld.filter(_.name != "tut-core")
-    else
-      ("io.argonaut" %% "argonaut" % "6.2-M1" +: ld)
+  libraryDependencies ++= {
+    if (scalaVersion.value startsWith "2.12") Nil
+    else Seq("io.argonaut" %% "argonaut" % "6.2-M1")
   },
   tuut := Def.taskDyn {
     if (scalaVersion.value startsWith "2.12")

--- a/build.sbt
+++ b/build.sbt
@@ -104,7 +104,7 @@ lazy val core = project.in(file("core"))
       "org.scalaz"        %% "scalaz-core"      % "7.2.0",
       "org.scalaz"        %% "scalaz-effect"    % "7.2.0",
       "org.scalaz.stream" %% "scalaz-stream"    % "0.8a",
-      "com.chuusai"       %% "shapeless"        % "2.3.0-RC3",
+      "com.chuusai"       %% "shapeless"        % "2.3.0",
       "com.h2database"    %  "h2"               % "1.3.170" % "test"
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -240,7 +240,14 @@ lazy val docs = project.in(file("doc"))
       }
     }
   )
-  .settings(libraryDependencies += "io.argonaut" %% "argonaut" % "6.1")
+  .settings(
+    // Temporarily depends on argonaut snapshot to compile tut
+    resolvers += Resolver.sonatypeRepo("snapshots"),
+    libraryDependencies ++= Seq(
+      "io.argonaut" %% "argonaut" % "6.2-SNAPSHOT" changing(),
+      "io.argonaut" %% "argonaut-scalaz" % "6.2-SNAPSHOT" changing()
+    )
+  )
   .dependsOn(core, postgres, specs2, hikari, h2)
 
 lazy val bench = project.in(file("bench"))

--- a/contrib/h2/src/test/scala/doobie/contrib/h2/h2types.scala
+++ b/contrib/h2/src/test/scala/doobie/contrib/h2/h2types.scala
@@ -31,19 +31,19 @@ object h2typesspec extends Specification {
   def testInOut[A](col: String, a: A)(implicit m: Meta[A]) =
     s"Mapping for $col as ${m.scalaType}" >> {
       s"write+read $col as ${m.scalaType}" in {
-        inOut(col, a).transact(xa).attemptRun must_== \/-(a)
+        inOut(col, a).transact(xa).unsafePerformSyncAttempt must_== \/-(a)
       }
       s"write+read $col as Option[${m.scalaType}] (Some)" in {
-        inOut[Option[A]](col, Some(a)).transact(xa).attemptRun must_== \/-(Some(a))
+        inOut[Option[A]](col, Some(a)).transact(xa).unsafePerformSyncAttempt must_== \/-(Some(a))
       }
       s"write+read $col as Option[${m.scalaType}] (None)" in {
-        inOut[Option[A]](col, None).transact(xa).attemptRun must_== \/-(None)
+        inOut[Option[A]](col, None).transact(xa).unsafePerformSyncAttempt must_== \/-(None)
       }
       s"write+read $col as Maybe[${m.scalaType}] (Just)" in {
-        inOut[Maybe[A]](col, Maybe.just(a)).transact(xa).attemptRun must_== \/-(Maybe.Just(a))
+        inOut[Maybe[A]](col, Maybe.just(a)).transact(xa).unsafePerformSyncAttempt must_== \/-(Maybe.Just(a))
       }
       s"write+read $col as Maybe[${m.scalaType}] (Empty)" in {
-        inOut[Maybe[A]](col, Maybe.empty[A]).transact(xa).attemptRun must_== \/-(Maybe.Empty())
+        inOut[Maybe[A]](col, Maybe.empty[A]).transact(xa).unsafePerformSyncAttempt must_== \/-(Maybe.Empty())
       }
     }
 
@@ -74,15 +74,15 @@ object h2typesspec extends Specification {
 
   "Mapping for Boolean" should {
     "pass query analysis for unascribed 'true'" in {
-      val a = sql"select true".query[Boolean].analysis.transact(xa).run
+      val a = sql"select true".query[Boolean].analysis.transact(xa).unsafePerformSync
       a.alignmentErrors must_== Nil
     }
     "pass query analysis for ascribed BIT" in {
-      val a = sql"select true::BIT".query[Boolean].analysis.transact(xa).run
+      val a = sql"select true::BIT".query[Boolean].analysis.transact(xa).unsafePerformSync
       a.alignmentErrors must_== Nil
     }
     "pass query analysis for ascribed BOOLEAN" in {
-      val a = sql"select true::BIT".query[Boolean].analysis.transact(xa).run
+      val a = sql"select true::BIT".query[Boolean].analysis.transact(xa).unsafePerformSync
       a.alignmentErrors must_== Nil
     }
   }

--- a/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgcopy.scala
+++ b/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgcopy.scala
@@ -46,7 +46,7 @@ object pgcopyspec extends Specification {
           _   <- PHC.pgGetCopyAPI(PFCM.copyOut(query, out))
         } yield new String(out.toByteArray, "UTF-8")
 
-      prog.transact(xa).run must_== fixture
+      prog.transact(xa).unsafePerformSync must_== fixture
 
     }
     

--- a/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pglargeobject.scala
+++ b/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pglargeobject.scala
@@ -26,7 +26,7 @@ object pglargeobjectspec extends Specification with FileEquality {
       val prog = PHLOM.createLOFromFile(1024 * 16, in) >>= { oid =>
         PHLOM.createFileFromLO(1024 * 16, oid, out) >> PHLOM.delete(oid)
       }
-      PHC.pgGetLargeObjectAPI(prog).transact(xa).run
+      PHC.pgGetLargeObjectAPI(prog).transact(xa).unsafePerformSync
       filesEqual(in, out)
     }
 

--- a/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgtypes.scala
+++ b/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgtypes.scala
@@ -33,26 +33,26 @@ object pgtypesspec extends Specification {
   def testInOut[A](col: String, a: A)(implicit m: Meta[A]) =
     s"Mapping for $col as ${m.scalaType}" >> {
       s"write+read $col as ${m.scalaType}" in {
-        inOut(col, a).transact(xa).attemptRun must_== \/-(a)
+        inOut(col, a).transact(xa).unsafePerformSyncAttempt must_== \/-(a)
       }
       s"write+read $col as Option[${m.scalaType}] (Some)" in {
-        inOut[Option[A]](col, Some(a)).transact(xa).attemptRun must_== \/-(Some(a))
+        inOut[Option[A]](col, Some(a)).transact(xa).unsafePerformSyncAttempt must_== \/-(Some(a))
       }
       s"write+read $col as Option[${m.scalaType}] (None)" in {
-        inOut[Option[A]](col, None).transact(xa).attemptRun must_== \/-(None)
+        inOut[Option[A]](col, None).transact(xa).unsafePerformSyncAttempt must_== \/-(None)
       }
       s"write+read $col as Maybe[${m.scalaType}] (Just)" in {
-        inOut[Maybe[A]](col, Maybe.just(a)).transact(xa).attemptRun must_== \/-(Maybe.Just(a))
+        inOut[Maybe[A]](col, Maybe.just(a)).transact(xa).unsafePerformSyncAttempt must_== \/-(Maybe.Just(a))
       }
       s"write+read $col as Maybe[${m.scalaType}] (Empty)" in {
-        inOut[Maybe[A]](col, Maybe.empty[A]).transact(xa).attemptRun must_== \/-(Maybe.Empty())
+        inOut[Maybe[A]](col, Maybe.empty[A]).transact(xa).unsafePerformSyncAttempt must_== \/-(Maybe.Empty())
       }
     }
 
   def testInOutNN[A](col: String, a: A)(implicit m: Atom[A]) =
     s"Mapping for $col as ${m.meta._1.scalaType}" >> {
       s"write+read $col as ${m.meta._1.scalaType}" in {
-        inOut(col, a).transact(xa).attemptRun must_== \/-(a)
+        inOut(col, a).transact(xa).unsafePerformSyncAttempt must_== \/-(a)
       }
     }
 

--- a/contrib/specs2/src/main/scala/doobie/contrib/specs2/specs2.scala
+++ b/contrib/specs2/src/main/scala/doobie/contrib/specs2/specs2.scala
@@ -60,7 +60,7 @@ object analysisspec {
 
     private def checkAnalysis(typeName: String, stackFrame: Option[StackTraceElement], sql: String, analysis: ConnectionIO[Analysis]) =
       s"$typeName defined at ${loc(stackFrame)}\n${sql.lines.map(s => "  " + s.trim).filterNot(_.isEmpty).mkString("\n")}" >> {
-        transactor.trans(analysis).attemptRun match {
+        transactor.trans(analysis).unsafePerformSyncAttempt match {
           case -\/(e) => Fragments("SQL Compiles and Typechecks" in failure(formatError(e.getMessage)))
           case \/-(a) => Fragments("SQL Compiles and Typechecks" in ok)
             Fragments.foreach(a.paramDescriptions)  { case (s, es) => s in assertEmpty(es, stackFrame) }

--- a/contrib/specs2/src/main/scala/doobie/contrib/specs2/specs2.scala
+++ b/contrib/specs2/src/main/scala/doobie/contrib/specs2/specs2.scala
@@ -60,7 +60,7 @@ object analysisspec {
 
     private def checkAnalysis(typeName: String, stackFrame: Option[StackTraceElement], sql: String, analysis: ConnectionIO[Analysis]) =
       s"$typeName defined at ${loc(stackFrame)}\n${sql.lines.map(s => "  " + s.trim).filterNot(_.isEmpty).mkString("\n")}" >> {
-        transactor.transact(analysis).attemptRun match {
+        transactor.trans(analysis).attemptRun match {
           case -\/(e) => Fragments("SQL Compiles and Typechecks" in failure(formatError(e.getMessage)))
           case \/-(a) => Fragments("SQL Compiles and Typechecks" in ok)
             Fragments.foreach(a.paramDescriptions)  { case (s, es) => s in assertEmpty(es, stackFrame) }

--- a/core/src/main/scala/doobie/free/blob.scala
+++ b/core/src/main/scala/doobie/free/blob.scala
@@ -46,7 +46,7 @@ import resultset.ResultSetIO
  *
  * `BlobIO` is a free monad that must be run via an interpreter, most commonly via
  * natural transformation of its underlying algebra `BlobOp` to another monad via
- * `Free.runFC`. 
+ * `Free#foldMap`.
  *
  * The library provides a natural transformation to `Kleisli[M, Blob, A]` for any
  * exception-trapping (`Catchable`) and effect-capturing (`Capture`) monad `M`. Such evidence is 

--- a/core/src/main/scala/doobie/free/blob.scala
+++ b/core/src/main/scala/doobie/free/blob.scala
@@ -1,6 +1,6 @@
 package doobie.free
 
-import scalaz.{ Catchable, Coyoneda, Free => F, Kleisli, Monad, ~>, \/ }
+import scalaz.{ Catchable, Free => F, Kleisli, Monad, ~>, \/ }
 import scalaz.concurrent.Task
 
 import doobie.util.capture._
@@ -96,7 +96,7 @@ object blob {
       }
 
     // Lifting
-    case class Lift[Op[_], A, J](j: J, action: F.FreeC[Op, A], mod: KleisliTrans.Aux[Op, J]) extends BlobOp[A] {
+    case class Lift[Op[_], A, J](j: J, action: F[Op, A], mod: KleisliTrans.Aux[Op, J]) extends BlobOp[A] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => mod.transK[M].apply(action).run(j))
     }
 
@@ -117,11 +117,11 @@ object blob {
     case object Free extends BlobOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.free())
     }
-    case class  GetBinaryStream(a: Long, b: Long) extends BlobOp[InputStream] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBinaryStream(a, b))
-    }
-    case object GetBinaryStream1 extends BlobOp[InputStream] {
+    case object GetBinaryStream extends BlobOp[InputStream] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBinaryStream())
+    }
+    case class  GetBinaryStream1(a: Long, b: Long) extends BlobOp[InputStream] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBinaryStream(a, b))
     }
     case class  GetBytes(a: Long, b: Int) extends BlobOp[Array[Byte]] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBytes(a, b))
@@ -129,20 +129,20 @@ object blob {
     case object Length extends BlobOp[Long] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.length())
     }
-    case class  Position(a: Array[Byte], b: Long) extends BlobOp[Long] {
+    case class  Position(a: Blob, b: Long) extends BlobOp[Long] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.position(a, b))
     }
-    case class  Position1(a: Blob, b: Long) extends BlobOp[Long] {
+    case class  Position1(a: Array[Byte], b: Long) extends BlobOp[Long] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.position(a, b))
     }
     case class  SetBinaryStream(a: Long) extends BlobOp[OutputStream] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a))
     }
-    case class  SetBytes(a: Long, b: Array[Byte]) extends BlobOp[Int] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBytes(a, b))
-    }
-    case class  SetBytes1(a: Long, b: Array[Byte], c: Int, d: Int) extends BlobOp[Int] {
+    case class  SetBytes(a: Long, b: Array[Byte], c: Int, d: Int) extends BlobOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBytes(a, b, c, d))
+    }
+    case class  SetBytes1(a: Long, b: Array[Byte]) extends BlobOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBytes(a, b))
     }
     case class  Truncate(a: Long) extends BlobOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.truncate(a))
@@ -156,14 +156,7 @@ object blob {
    * a `java.sql.Blob` and produces a value of type `A`. 
    * @group Algebra 
    */
-  type BlobIO[A] = F.FreeC[BlobOp, A]
-
-  /**
-   * Monad instance for [[BlobIO]] (can't be inferred).
-   * @group Typeclass Instances 
-   */
-  implicit val MonadBlobIO: Monad[BlobIO] = 
-    F.freeMonad[({type λ[α] = Coyoneda[BlobOp, α]})#λ]
+  type BlobIO[A] = F[BlobOp, A]
 
   /**
    * Catchable instance for [[BlobIO]].
@@ -188,95 +181,95 @@ object blob {
    * Lift a different type of program that has a default Kleisli interpreter.
    * @group Constructors (Lifting)
    */
-  def lift[Op[_], A, J](j: J, action: F.FreeC[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): BlobIO[A] =
-    F.liftFC(Lift(j, action, mod))
+  def lift[Op[_], A, J](j: J, action: F[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): BlobIO[A] =
+    F.liftF(Lift(j, action, mod))
 
   /** 
    * Lift a BlobIO[A] into an exception-capturing BlobIO[Throwable \/ A].
    * @group Constructors (Lifting)
    */
   def attempt[A](a: BlobIO[A]): BlobIO[Throwable \/ A] =
-    F.liftFC[BlobOp, Throwable \/ A](Attempt(a))
+    F.liftF[BlobOp, Throwable \/ A](Attempt(a))
  
   /**
    * Non-strict unit for capturing effects.
    * @group Constructors (Lifting)
    */
   def delay[A](a: => A): BlobIO[A] =
-    F.liftFC(Pure(a _))
+    F.liftF(Pure(a _))
 
   /**
    * Backdoor for arbitrary computations on the underlying Blob.
    * @group Constructors (Lifting)
    */
   def raw[A](f: Blob => A): BlobIO[A] =
-    F.liftFC(Raw(f))
+    F.liftF(Raw(f))
 
   /** 
    * @group Constructors (Primitives)
    */
   val free: BlobIO[Unit] =
-    F.liftFC(Free)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getBinaryStream(a: Long, b: Long): BlobIO[InputStream] =
-    F.liftFC(GetBinaryStream(a, b))
+    F.liftF(Free)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getBinaryStream: BlobIO[InputStream] =
-    F.liftFC(GetBinaryStream1)
+    F.liftF(GetBinaryStream)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getBinaryStream(a: Long, b: Long): BlobIO[InputStream] =
+    F.liftF(GetBinaryStream1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getBytes(a: Long, b: Int): BlobIO[Array[Byte]] =
-    F.liftFC(GetBytes(a, b))
+    F.liftF(GetBytes(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   val length: BlobIO[Long] =
-    F.liftFC(Length)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def position(a: Array[Byte], b: Long): BlobIO[Long] =
-    F.liftFC(Position(a, b))
+    F.liftF(Length)
 
   /** 
    * @group Constructors (Primitives)
    */
   def position(a: Blob, b: Long): BlobIO[Long] =
-    F.liftFC(Position1(a, b))
+    F.liftF(Position(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def position(a: Array[Byte], b: Long): BlobIO[Long] =
+    F.liftF(Position1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBinaryStream(a: Long): BlobIO[OutputStream] =
-    F.liftFC(SetBinaryStream(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setBytes(a: Long, b: Array[Byte]): BlobIO[Int] =
-    F.liftFC(SetBytes(a, b))
+    F.liftF(SetBinaryStream(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBytes(a: Long, b: Array[Byte], c: Int, d: Int): BlobIO[Int] =
-    F.liftFC(SetBytes1(a, b, c, d))
+    F.liftF(SetBytes(a, b, c, d))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setBytes(a: Long, b: Array[Byte]): BlobIO[Int] =
+    F.liftF(SetBytes1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def truncate(a: Long): BlobIO[Unit] =
-    F.liftFC(Truncate(a))
+    F.liftF(Truncate(a))
 
  /** 
   * Natural transformation from `BlobOp` to `Kleisli` for the given `M`, consuming a `java.sql.Blob`. 

--- a/core/src/main/scala/doobie/free/callablestatement.scala
+++ b/core/src/main/scala/doobie/free/callablestatement.scala
@@ -1,6 +1,6 @@
 package doobie.free
 
-import scalaz.{ Catchable, Coyoneda, Free => F, Kleisli, Monad, ~>, \/ }
+import scalaz.{ Catchable, Free => F, Kleisli, Monad, ~>, \/ }
 import scalaz.concurrent.Task
 
 import doobie.util.capture._
@@ -30,6 +30,7 @@ import java.sql.RowId
 import java.sql.SQLData
 import java.sql.SQLInput
 import java.sql.SQLOutput
+import java.sql.SQLType
 import java.sql.SQLWarning
 import java.sql.SQLXML
 import java.sql.Statement
@@ -112,7 +113,7 @@ object callablestatement {
       }
 
     // Lifting
-    case class Lift[Op[_], A, J](j: J, action: F.FreeC[Op, A], mod: KleisliTrans.Aux[Op, J]) extends CallableStatementOp[A] {
+    case class Lift[Op[_], A, J](j: J, action: F[Op, A], mod: KleisliTrans.Aux[Op, J]) extends CallableStatementOp[A] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => mod.transK[M].apply(action).run(j))
     }
 
@@ -157,20 +158,38 @@ object callablestatement {
     case object Execute extends CallableStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute())
     }
-    case class  Execute1(a: String, b: Array[Int]) extends CallableStatementOp[Boolean] {
+    case class  Execute1(a: String, b: Array[String]) extends CallableStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
     }
-    case class  Execute2(a: String, b: Int) extends CallableStatementOp[Boolean] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
-    }
-    case class  Execute3(a: String) extends CallableStatementOp[Boolean] {
+    case class  Execute2(a: String) extends CallableStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a))
     }
-    case class  Execute4(a: String, b: Array[String]) extends CallableStatementOp[Boolean] {
+    case class  Execute3(a: String, b: Array[Int]) extends CallableStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
+    }
+    case class  Execute4(a: String, b: Int) extends CallableStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
     }
     case object ExecuteBatch extends CallableStatementOp[Array[Int]] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeBatch())
+    }
+    case object ExecuteLargeBatch extends CallableStatementOp[Array[Long]] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeBatch())
+    }
+    case object ExecuteLargeUpdate extends CallableStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate())
+    }
+    case class  ExecuteLargeUpdate1(a: String, b: Int) extends CallableStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
+    }
+    case class  ExecuteLargeUpdate2(a: String, b: Array[Int]) extends CallableStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
+    }
+    case class  ExecuteLargeUpdate3(a: String) extends CallableStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a))
+    }
+    case class  ExecuteLargeUpdate4(a: String, b: Array[String]) extends CallableStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
     }
     case object ExecuteQuery extends CallableStatementOp[ResultSet] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeQuery())
@@ -181,10 +200,10 @@ object callablestatement {
     case object ExecuteUpdate extends CallableStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate())
     }
-    case class  ExecuteUpdate1(a: String, b: Array[String]) extends CallableStatementOp[Int] {
+    case class  ExecuteUpdate1(a: String, b: Int) extends CallableStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
     }
-    case class  ExecuteUpdate2(a: String, b: Int) extends CallableStatementOp[Int] {
+    case class  ExecuteUpdate2(a: String, b: Array[String]) extends CallableStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
     }
     case class  ExecuteUpdate3(a: String, b: Array[Int]) extends CallableStatementOp[Int] {
@@ -193,20 +212,20 @@ object callablestatement {
     case class  ExecuteUpdate4(a: String) extends CallableStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a))
     }
-    case class  GetArray(a: String) extends CallableStatementOp[SqlArray] {
+    case class  GetArray(a: Int) extends CallableStatementOp[SqlArray] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getArray(a))
     }
-    case class  GetArray1(a: Int) extends CallableStatementOp[SqlArray] {
+    case class  GetArray1(a: String) extends CallableStatementOp[SqlArray] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getArray(a))
     }
     case class  GetBigDecimal(a: String) extends CallableStatementOp[BigDecimal] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a))
     }
-    case class  GetBigDecimal1(a: Int, b: Int) extends CallableStatementOp[BigDecimal] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a, b))
-    }
-    case class  GetBigDecimal2(a: Int) extends CallableStatementOp[BigDecimal] {
+    case class  GetBigDecimal1(a: Int) extends CallableStatementOp[BigDecimal] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a))
+    }
+    case class  GetBigDecimal2(a: Int, b: Int) extends CallableStatementOp[BigDecimal] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a, b))
     }
     case class  GetBlob(a: String) extends CallableStatementOp[Blob] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBlob(a))
@@ -220,38 +239,38 @@ object callablestatement {
     case class  GetBoolean1(a: Int) extends CallableStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBoolean(a))
     }
-    case class  GetByte(a: Int) extends CallableStatementOp[Byte] {
+    case class  GetByte(a: String) extends CallableStatementOp[Byte] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getByte(a))
     }
-    case class  GetByte1(a: String) extends CallableStatementOp[Byte] {
+    case class  GetByte1(a: Int) extends CallableStatementOp[Byte] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getByte(a))
     }
-    case class  GetBytes(a: Int) extends CallableStatementOp[Array[Byte]] {
+    case class  GetBytes(a: String) extends CallableStatementOp[Array[Byte]] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBytes(a))
     }
-    case class  GetBytes1(a: String) extends CallableStatementOp[Array[Byte]] {
+    case class  GetBytes1(a: Int) extends CallableStatementOp[Array[Byte]] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBytes(a))
     }
-    case class  GetCharacterStream(a: String) extends CallableStatementOp[Reader] {
+    case class  GetCharacterStream(a: Int) extends CallableStatementOp[Reader] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getCharacterStream(a))
     }
-    case class  GetCharacterStream1(a: Int) extends CallableStatementOp[Reader] {
+    case class  GetCharacterStream1(a: String) extends CallableStatementOp[Reader] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getCharacterStream(a))
     }
-    case class  GetClob(a: Int) extends CallableStatementOp[Clob] {
+    case class  GetClob(a: String) extends CallableStatementOp[Clob] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getClob(a))
     }
-    case class  GetClob1(a: String) extends CallableStatementOp[Clob] {
+    case class  GetClob1(a: Int) extends CallableStatementOp[Clob] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getClob(a))
     }
     case object GetConnection extends CallableStatementOp[Connection] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getConnection())
     }
-    case class  GetDate(a: Int) extends CallableStatementOp[Date] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a))
-    }
-    case class  GetDate1(a: String, b: Calendar) extends CallableStatementOp[Date] {
+    case class  GetDate(a: String, b: Calendar) extends CallableStatementOp[Date] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a, b))
+    }
+    case class  GetDate1(a: Int) extends CallableStatementOp[Date] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a))
     }
     case class  GetDate2(a: Int, b: Calendar) extends CallableStatementOp[Date] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a, b))
@@ -259,10 +278,10 @@ object callablestatement {
     case class  GetDate3(a: String) extends CallableStatementOp[Date] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a))
     }
-    case class  GetDouble(a: String) extends CallableStatementOp[Double] {
+    case class  GetDouble(a: Int) extends CallableStatementOp[Double] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDouble(a))
     }
-    case class  GetDouble1(a: Int) extends CallableStatementOp[Double] {
+    case class  GetDouble1(a: String) extends CallableStatementOp[Double] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDouble(a))
     }
     case object GetFetchDirection extends CallableStatementOp[Int] {
@@ -286,10 +305,16 @@ object callablestatement {
     case class  GetInt1(a: String) extends CallableStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getInt(a))
     }
-    case class  GetLong(a: String) extends CallableStatementOp[Long] {
+    case object GetLargeMaxRows extends CallableStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeMaxRows())
+    }
+    case object GetLargeUpdateCount extends CallableStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeUpdateCount())
+    }
+    case class  GetLong(a: Int) extends CallableStatementOp[Long] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLong(a))
     }
-    case class  GetLong1(a: Int) extends CallableStatementOp[Long] {
+    case class  GetLong1(a: String) extends CallableStatementOp[Long] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLong(a))
     }
     case object GetMaxFieldSize extends CallableStatementOp[Int] {
@@ -307,40 +332,40 @@ object callablestatement {
     case object GetMoreResults1 extends CallableStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMoreResults())
     }
-    case class  GetNCharacterStream(a: String) extends CallableStatementOp[Reader] {
+    case class  GetNCharacterStream(a: Int) extends CallableStatementOp[Reader] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNCharacterStream(a))
     }
-    case class  GetNCharacterStream1(a: Int) extends CallableStatementOp[Reader] {
+    case class  GetNCharacterStream1(a: String) extends CallableStatementOp[Reader] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNCharacterStream(a))
     }
-    case class  GetNClob(a: Int) extends CallableStatementOp[NClob] {
+    case class  GetNClob(a: String) extends CallableStatementOp[NClob] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNClob(a))
     }
-    case class  GetNClob1(a: String) extends CallableStatementOp[NClob] {
+    case class  GetNClob1(a: Int) extends CallableStatementOp[NClob] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNClob(a))
     }
-    case class  GetNString(a: String) extends CallableStatementOp[String] {
+    case class  GetNString(a: Int) extends CallableStatementOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNString(a))
     }
-    case class  GetNString1(a: Int) extends CallableStatementOp[String] {
+    case class  GetNString1(a: String) extends CallableStatementOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNString(a))
     }
     case class  GetObject(a: String) extends CallableStatementOp[Object] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a))
     }
-    case class  GetObject1(a: Int, b: Map[String, Class[_]]) extends CallableStatementOp[Object] {
+    case class  GetObject1[T](a: String, b: Class[T]) extends CallableStatementOp[T] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
     }
-    case class  GetObject2(a: Int) extends CallableStatementOp[Object] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a))
+    case class  GetObject2[T](a: Int, b: Class[T]) extends CallableStatementOp[T] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
     }
     case class  GetObject3(a: String, b: Map[String, Class[_]]) extends CallableStatementOp[Object] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
     }
-    case class  GetObject4[T](a: String, b: Class[T]) extends CallableStatementOp[T] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
+    case class  GetObject4(a: Int) extends CallableStatementOp[Object] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a))
     }
-    case class  GetObject5[T](a: Int, b: Class[T]) extends CallableStatementOp[T] {
+    case class  GetObject5(a: Int, b: Map[String, Class[_]]) extends CallableStatementOp[Object] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
     }
     case object GetParameterMetaData extends CallableStatementOp[ParameterMetaData] {
@@ -349,10 +374,10 @@ object callablestatement {
     case object GetQueryTimeout extends CallableStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getQueryTimeout())
     }
-    case class  GetRef(a: String) extends CallableStatementOp[Ref] {
+    case class  GetRef(a: Int) extends CallableStatementOp[Ref] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getRef(a))
     }
-    case class  GetRef1(a: Int) extends CallableStatementOp[Ref] {
+    case class  GetRef1(a: String) extends CallableStatementOp[Ref] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getRef(a))
     }
     case object GetResultSet extends CallableStatementOp[ResultSet] {
@@ -373,10 +398,10 @@ object callablestatement {
     case class  GetRowId1(a: Int) extends CallableStatementOp[RowId] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getRowId(a))
     }
-    case class  GetSQLXML(a: Int) extends CallableStatementOp[SQLXML] {
+    case class  GetSQLXML(a: String) extends CallableStatementOp[SQLXML] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSQLXML(a))
     }
-    case class  GetSQLXML1(a: String) extends CallableStatementOp[SQLXML] {
+    case class  GetSQLXML1(a: Int) extends CallableStatementOp[SQLXML] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSQLXML(a))
     }
     case class  GetShort(a: String) extends CallableStatementOp[Short] {
@@ -391,34 +416,34 @@ object callablestatement {
     case class  GetString1(a: Int) extends CallableStatementOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getString(a))
     }
-    case class  GetTime(a: Int, b: Calendar) extends CallableStatementOp[Time] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a, b))
+    case class  GetTime(a: String) extends CallableStatementOp[Time] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a))
     }
     case class  GetTime1(a: String, b: Calendar) extends CallableStatementOp[Time] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a, b))
     }
-    case class  GetTime2(a: Int) extends CallableStatementOp[Time] {
+    case class  GetTime2(a: Int, b: Calendar) extends CallableStatementOp[Time] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a, b))
+    }
+    case class  GetTime3(a: Int) extends CallableStatementOp[Time] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a))
     }
-    case class  GetTime3(a: String) extends CallableStatementOp[Time] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a))
-    }
-    case class  GetTimestamp(a: String, b: Calendar) extends CallableStatementOp[Timestamp] {
+    case class  GetTimestamp(a: Int, b: Calendar) extends CallableStatementOp[Timestamp] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a, b))
     }
-    case class  GetTimestamp1(a: String) extends CallableStatementOp[Timestamp] {
+    case class  GetTimestamp1(a: Int) extends CallableStatementOp[Timestamp] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a))
     }
-    case class  GetTimestamp2(a: Int) extends CallableStatementOp[Timestamp] {
+    case class  GetTimestamp2(a: String) extends CallableStatementOp[Timestamp] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a))
     }
-    case class  GetTimestamp3(a: Int, b: Calendar) extends CallableStatementOp[Timestamp] {
+    case class  GetTimestamp3(a: String, b: Calendar) extends CallableStatementOp[Timestamp] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a, b))
     }
-    case class  GetURL(a: String) extends CallableStatementOp[URL] {
+    case class  GetURL(a: Int) extends CallableStatementOp[URL] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getURL(a))
     }
-    case class  GetURL1(a: Int) extends CallableStatementOp[URL] {
+    case class  GetURL1(a: String) extends CallableStatementOp[URL] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getURL(a))
     }
     case object GetUpdateCount extends CallableStatementOp[Int] {
@@ -439,23 +464,41 @@ object callablestatement {
     case class  IsWrapperFor(a: Class[_]) extends CallableStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.isWrapperFor(a))
     }
-    case class  RegisterOutParameter(a: String, b: Int) extends CallableStatementOp[Unit] {
+    case class  RegisterOutParameter(a: Int, b: SQLType, c: String) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
+    }
+    case class  RegisterOutParameter1(a: String, b: SQLType) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b))
     }
-    case class  RegisterOutParameter1(a: String, b: Int, c: String) extends CallableStatementOp[Unit] {
+    case class  RegisterOutParameter10(a: Int, b: Int, c: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
     }
-    case class  RegisterOutParameter2(a: Int, b: Int, c: String) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
-    }
-    case class  RegisterOutParameter3(a: String, b: Int, c: Int) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
-    }
-    case class  RegisterOutParameter4(a: Int, b: Int, c: Int) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
-    }
-    case class  RegisterOutParameter5(a: Int, b: Int) extends CallableStatementOp[Unit] {
+    case class  RegisterOutParameter11(a: Int, b: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b))
+    }
+    case class  RegisterOutParameter2(a: String, b: SQLType, c: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
+    }
+    case class  RegisterOutParameter3(a: Int, b: SQLType, c: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
+    }
+    case class  RegisterOutParameter4(a: Int, b: SQLType) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b))
+    }
+    case class  RegisterOutParameter5(a: String, b: SQLType, c: String) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
+    }
+    case class  RegisterOutParameter6(a: String, b: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b))
+    }
+    case class  RegisterOutParameter7(a: String, b: Int, c: String) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
+    }
+    case class  RegisterOutParameter8(a: String, b: Int, c: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
+    }
+    case class  RegisterOutParameter9(a: Int, b: Int, c: String) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
     }
     case class  SetArray(a: Int, b: SqlArray) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setArray(a, b))
@@ -463,20 +506,20 @@ object callablestatement {
     case class  SetAsciiStream(a: String, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
     }
-    case class  SetAsciiStream1(a: String, b: InputStream) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b))
-    }
-    case class  SetAsciiStream2(a: String, b: InputStream, c: Int) extends CallableStatementOp[Unit] {
+    case class  SetAsciiStream1(a: String, b: InputStream, c: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
     }
-    case class  SetAsciiStream3(a: Int, b: InputStream) extends CallableStatementOp[Unit] {
+    case class  SetAsciiStream2(a: String, b: InputStream) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b))
+    }
+    case class  SetAsciiStream3(a: Int, b: InputStream, c: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
     }
     case class  SetAsciiStream4(a: Int, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
     }
-    case class  SetAsciiStream5(a: Int, b: InputStream, c: Int) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
+    case class  SetAsciiStream5(a: Int, b: InputStream) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b))
     }
     case class  SetBigDecimal(a: String, b: BigDecimal) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBigDecimal(a, b))
@@ -484,14 +527,14 @@ object callablestatement {
     case class  SetBigDecimal1(a: Int, b: BigDecimal) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBigDecimal(a, b))
     }
-    case class  SetBinaryStream(a: String, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
+    case class  SetBinaryStream(a: String, b: InputStream, c: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b, c))
     }
-    case class  SetBinaryStream1(a: String, b: InputStream, c: Int) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b, c))
-    }
-    case class  SetBinaryStream2(a: String, b: InputStream) extends CallableStatementOp[Unit] {
+    case class  SetBinaryStream1(a: String, b: InputStream) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b))
+    }
+    case class  SetBinaryStream2(a: String, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b, c))
     }
     case class  SetBinaryStream3(a: Int, b: InputStream, c: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b, c))
@@ -502,11 +545,11 @@ object callablestatement {
     case class  SetBinaryStream5(a: Int, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b, c))
     }
-    case class  SetBlob(a: String, b: Blob) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b))
-    }
-    case class  SetBlob1(a: String, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
+    case class  SetBlob(a: String, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b, c))
+    }
+    case class  SetBlob1(a: String, b: Blob) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b))
     }
     case class  SetBlob2(a: String, b: InputStream) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b))
@@ -538,50 +581,50 @@ object callablestatement {
     case class  SetBytes1(a: Int, b: Array[Byte]) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBytes(a, b))
     }
-    case class  SetCharacterStream(a: String, b: Reader, c: Long) extends CallableStatementOp[Unit] {
+    case class  SetCharacterStream(a: String, b: Reader, c: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b, c))
     }
-    case class  SetCharacterStream1(a: String, b: Reader, c: Int) extends CallableStatementOp[Unit] {
+    case class  SetCharacterStream1(a: String, b: Reader, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b, c))
     }
     case class  SetCharacterStream2(a: String, b: Reader) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b))
     }
-    case class  SetCharacterStream3(a: Int, b: Reader, c: Int) extends CallableStatementOp[Unit] {
+    case class  SetCharacterStream3(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b, c))
     }
     case class  SetCharacterStream4(a: Int, b: Reader) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b))
     }
-    case class  SetCharacterStream5(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit] {
+    case class  SetCharacterStream5(a: Int, b: Reader, c: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b, c))
     }
-    case class  SetClob(a: String, b: Reader) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
-    }
-    case class  SetClob1(a: String, b: Clob) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
-    }
-    case class  SetClob2(a: String, b: Reader, c: Long) extends CallableStatementOp[Unit] {
+    case class  SetClob(a: String, b: Reader, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b, c))
     }
-    case class  SetClob3(a: Int, b: Reader) extends CallableStatementOp[Unit] {
+    case class  SetClob1(a: String, b: Reader) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
     }
-    case class  SetClob4(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit] {
+    case class  SetClob2(a: String, b: Clob) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
+    }
+    case class  SetClob3(a: Int, b: Clob) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
+    }
+    case class  SetClob4(a: Int, b: Reader) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
+    }
+    case class  SetClob5(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b, c))
-    }
-    case class  SetClob5(a: Int, b: Clob) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
     }
     case class  SetCursorName(a: String) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCursorName(a))
     }
-    case class  SetDate(a: String, b: Date) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b))
-    }
-    case class  SetDate1(a: String, b: Date, c: Calendar) extends CallableStatementOp[Unit] {
+    case class  SetDate(a: String, b: Date, c: Calendar) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b, c))
+    }
+    case class  SetDate1(a: String, b: Date) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b))
     }
     case class  SetDate2(a: Int, b: Date, c: Calendar) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b, c))
@@ -616,6 +659,9 @@ object callablestatement {
     case class  SetInt1(a: Int, b: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setInt(a, b))
     }
+    case class  SetLargeMaxRows(a: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setLargeMaxRows(a))
+    }
     case class  SetLong(a: String, b: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setLong(a, b))
     }
@@ -649,11 +695,11 @@ object callablestatement {
     case class  SetNClob2(a: String, b: Reader) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
     }
-    case class  SetNClob3(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b, c))
-    }
-    case class  SetNClob4(a: Int, b: NClob) extends CallableStatementOp[Unit] {
+    case class  SetNClob3(a: Int, b: NClob) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
+    }
+    case class  SetNClob4(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b, c))
     }
     case class  SetNClob5(a: Int, b: Reader) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
@@ -679,19 +725,31 @@ object callablestatement {
     case class  SetObject(a: String, b: Object) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b))
     }
-    case class  SetObject1(a: String, b: Object, c: Int, d: Int) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
-    }
-    case class  SetObject2(a: String, b: Object, c: Int) extends CallableStatementOp[Unit] {
+    case class  SetObject1(a: String, b: Object, c: SQLType) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
     }
-    case class  SetObject3(a: Int, b: Object, c: Int, d: Int) extends CallableStatementOp[Unit] {
+    case class  SetObject2(a: String, b: Object, c: SQLType, d: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
     }
-    case class  SetObject4(a: Int, b: Object, c: Int) extends CallableStatementOp[Unit] {
+    case class  SetObject3(a: String, b: Object, c: Int, d: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
+    }
+    case class  SetObject4(a: String, b: Object, c: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
     }
-    case class  SetObject5(a: Int, b: Object) extends CallableStatementOp[Unit] {
+    case class  SetObject5(a: Int, b: Object, c: SQLType, d: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
+    }
+    case class  SetObject6(a: Int, b: Object, c: SQLType) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
+    }
+    case class  SetObject7(a: Int, b: Object, c: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
+    }
+    case class  SetObject8(a: Int, b: Object, c: Int, d: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
+    }
+    case class  SetObject9(a: Int, b: Object) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b))
     }
     case class  SetPoolable(a: Boolean) extends CallableStatementOp[Unit] {
@@ -733,11 +791,11 @@ object callablestatement {
     case class  SetTime1(a: String, b: Time) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTime(a, b))
     }
-    case class  SetTime2(a: Int, b: Time) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTime(a, b))
-    }
-    case class  SetTime3(a: Int, b: Time, c: Calendar) extends CallableStatementOp[Unit] {
+    case class  SetTime2(a: Int, b: Time, c: Calendar) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTime(a, b, c))
+    }
+    case class  SetTime3(a: Int, b: Time) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTime(a, b))
     }
     case class  SetTimestamp(a: String, b: Timestamp) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b))
@@ -745,11 +803,11 @@ object callablestatement {
     case class  SetTimestamp1(a: String, b: Timestamp, c: Calendar) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b, c))
     }
-    case class  SetTimestamp2(a: Int, b: Timestamp, c: Calendar) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b, c))
-    }
-    case class  SetTimestamp3(a: Int, b: Timestamp) extends CallableStatementOp[Unit] {
+    case class  SetTimestamp2(a: Int, b: Timestamp) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b))
+    }
+    case class  SetTimestamp3(a: Int, b: Timestamp, c: Calendar) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b, c))
     }
     case class  SetURL(a: String, b: URL) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setURL(a, b))
@@ -775,14 +833,7 @@ object callablestatement {
    * a `java.sql.CallableStatement` and produces a value of type `A`. 
    * @group Algebra 
    */
-  type CallableStatementIO[A] = F.FreeC[CallableStatementOp, A]
-
-  /**
-   * Monad instance for [[CallableStatementIO]] (can't be inferred).
-   * @group Typeclass Instances 
-   */
-  implicit val MonadCallableStatementIO: Monad[CallableStatementIO] = 
-    F.freeMonad[({type λ[α] = Coyoneda[CallableStatementOp, α]})#λ]
+  type CallableStatementIO[A] = F[CallableStatementOp, A]
 
   /**
    * Catchable instance for [[CallableStatementIO]].
@@ -807,1301 +858,1415 @@ object callablestatement {
    * Lift a different type of program that has a default Kleisli interpreter.
    * @group Constructors (Lifting)
    */
-  def lift[Op[_], A, J](j: J, action: F.FreeC[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): CallableStatementIO[A] =
-    F.liftFC(Lift(j, action, mod))
+  def lift[Op[_], A, J](j: J, action: F[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): CallableStatementIO[A] =
+    F.liftF(Lift(j, action, mod))
 
   /** 
    * Lift a CallableStatementIO[A] into an exception-capturing CallableStatementIO[Throwable \/ A].
    * @group Constructors (Lifting)
    */
   def attempt[A](a: CallableStatementIO[A]): CallableStatementIO[Throwable \/ A] =
-    F.liftFC[CallableStatementOp, Throwable \/ A](Attempt(a))
+    F.liftF[CallableStatementOp, Throwable \/ A](Attempt(a))
  
   /**
    * Non-strict unit for capturing effects.
    * @group Constructors (Lifting)
    */
   def delay[A](a: => A): CallableStatementIO[A] =
-    F.liftFC(Pure(a _))
+    F.liftF(Pure(a _))
 
   /**
    * Backdoor for arbitrary computations on the underlying CallableStatement.
    * @group Constructors (Lifting)
    */
   def raw[A](f: CallableStatement => A): CallableStatementIO[A] =
-    F.liftFC(Raw(f))
+    F.liftF(Raw(f))
 
   /** 
    * @group Constructors (Primitives)
    */
   val addBatch: CallableStatementIO[Unit] =
-    F.liftFC(AddBatch)
+    F.liftF(AddBatch)
 
   /** 
    * @group Constructors (Primitives)
    */
   def addBatch(a: String): CallableStatementIO[Unit] =
-    F.liftFC(AddBatch1(a))
+    F.liftF(AddBatch1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val cancel: CallableStatementIO[Unit] =
-    F.liftFC(Cancel)
+    F.liftF(Cancel)
 
   /** 
    * @group Constructors (Primitives)
    */
   val clearBatch: CallableStatementIO[Unit] =
-    F.liftFC(ClearBatch)
+    F.liftF(ClearBatch)
 
   /** 
    * @group Constructors (Primitives)
    */
   val clearParameters: CallableStatementIO[Unit] =
-    F.liftFC(ClearParameters)
+    F.liftF(ClearParameters)
 
   /** 
    * @group Constructors (Primitives)
    */
   val clearWarnings: CallableStatementIO[Unit] =
-    F.liftFC(ClearWarnings)
+    F.liftF(ClearWarnings)
 
   /** 
    * @group Constructors (Primitives)
    */
   val close: CallableStatementIO[Unit] =
-    F.liftFC(Close)
+    F.liftF(Close)
 
   /** 
    * @group Constructors (Primitives)
    */
   val closeOnCompletion: CallableStatementIO[Unit] =
-    F.liftFC(CloseOnCompletion)
+    F.liftF(CloseOnCompletion)
 
   /** 
    * @group Constructors (Primitives)
    */
   val execute: CallableStatementIO[Boolean] =
-    F.liftFC(Execute)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def execute(a: String, b: Array[Int]): CallableStatementIO[Boolean] =
-    F.liftFC(Execute1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def execute(a: String, b: Int): CallableStatementIO[Boolean] =
-    F.liftFC(Execute2(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def execute(a: String): CallableStatementIO[Boolean] =
-    F.liftFC(Execute3(a))
+    F.liftF(Execute)
 
   /** 
    * @group Constructors (Primitives)
    */
   def execute(a: String, b: Array[String]): CallableStatementIO[Boolean] =
-    F.liftFC(Execute4(a, b))
+    F.liftF(Execute1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def execute(a: String): CallableStatementIO[Boolean] =
+    F.liftF(Execute2(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def execute(a: String, b: Array[Int]): CallableStatementIO[Boolean] =
+    F.liftF(Execute3(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def execute(a: String, b: Int): CallableStatementIO[Boolean] =
+    F.liftF(Execute4(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   val executeBatch: CallableStatementIO[Array[Int]] =
-    F.liftFC(ExecuteBatch)
+    F.liftF(ExecuteBatch)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val executeLargeBatch: CallableStatementIO[Array[Long]] =
+    F.liftF(ExecuteLargeBatch)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val executeLargeUpdate: CallableStatementIO[Long] =
+    F.liftF(ExecuteLargeUpdate)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String, b: Int): CallableStatementIO[Long] =
+    F.liftF(ExecuteLargeUpdate1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String, b: Array[Int]): CallableStatementIO[Long] =
+    F.liftF(ExecuteLargeUpdate2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String): CallableStatementIO[Long] =
+    F.liftF(ExecuteLargeUpdate3(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String, b: Array[String]): CallableStatementIO[Long] =
+    F.liftF(ExecuteLargeUpdate4(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   val executeQuery: CallableStatementIO[ResultSet] =
-    F.liftFC(ExecuteQuery)
+    F.liftF(ExecuteQuery)
 
   /** 
    * @group Constructors (Primitives)
    */
   def executeQuery(a: String): CallableStatementIO[ResultSet] =
-    F.liftFC(ExecuteQuery1(a))
+    F.liftF(ExecuteQuery1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val executeUpdate: CallableStatementIO[Int] =
-    F.liftFC(ExecuteUpdate)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeUpdate(a: String, b: Array[String]): CallableStatementIO[Int] =
-    F.liftFC(ExecuteUpdate1(a, b))
+    F.liftF(ExecuteUpdate)
 
   /** 
    * @group Constructors (Primitives)
    */
   def executeUpdate(a: String, b: Int): CallableStatementIO[Int] =
-    F.liftFC(ExecuteUpdate2(a, b))
+    F.liftF(ExecuteUpdate1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeUpdate(a: String, b: Array[String]): CallableStatementIO[Int] =
+    F.liftF(ExecuteUpdate2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def executeUpdate(a: String, b: Array[Int]): CallableStatementIO[Int] =
-    F.liftFC(ExecuteUpdate3(a, b))
+    F.liftF(ExecuteUpdate3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def executeUpdate(a: String): CallableStatementIO[Int] =
-    F.liftFC(ExecuteUpdate4(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getArray(a: String): CallableStatementIO[SqlArray] =
-    F.liftFC(GetArray(a))
+    F.liftF(ExecuteUpdate4(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getArray(a: Int): CallableStatementIO[SqlArray] =
-    F.liftFC(GetArray1(a))
+    F.liftF(GetArray(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getArray(a: String): CallableStatementIO[SqlArray] =
+    F.liftF(GetArray1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getBigDecimal(a: String): CallableStatementIO[BigDecimal] =
-    F.liftFC(GetBigDecimal(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getBigDecimal(a: Int, b: Int): CallableStatementIO[BigDecimal] =
-    F.liftFC(GetBigDecimal1(a, b))
+    F.liftF(GetBigDecimal(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getBigDecimal(a: Int): CallableStatementIO[BigDecimal] =
-    F.liftFC(GetBigDecimal2(a))
+    F.liftF(GetBigDecimal1(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getBigDecimal(a: Int, b: Int): CallableStatementIO[BigDecimal] =
+    F.liftF(GetBigDecimal2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getBlob(a: String): CallableStatementIO[Blob] =
-    F.liftFC(GetBlob(a))
+    F.liftF(GetBlob(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getBlob(a: Int): CallableStatementIO[Blob] =
-    F.liftFC(GetBlob1(a))
+    F.liftF(GetBlob1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getBoolean(a: String): CallableStatementIO[Boolean] =
-    F.liftFC(GetBoolean(a))
+    F.liftF(GetBoolean(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getBoolean(a: Int): CallableStatementIO[Boolean] =
-    F.liftFC(GetBoolean1(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getByte(a: Int): CallableStatementIO[Byte] =
-    F.liftFC(GetByte(a))
+    F.liftF(GetBoolean1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getByte(a: String): CallableStatementIO[Byte] =
-    F.liftFC(GetByte1(a))
+    F.liftF(GetByte(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getBytes(a: Int): CallableStatementIO[Array[Byte]] =
-    F.liftFC(GetBytes(a))
+  def getByte(a: Int): CallableStatementIO[Byte] =
+    F.liftF(GetByte1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getBytes(a: String): CallableStatementIO[Array[Byte]] =
-    F.liftFC(GetBytes1(a))
+    F.liftF(GetBytes(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getCharacterStream(a: String): CallableStatementIO[Reader] =
-    F.liftFC(GetCharacterStream(a))
+  def getBytes(a: Int): CallableStatementIO[Array[Byte]] =
+    F.liftF(GetBytes1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getCharacterStream(a: Int): CallableStatementIO[Reader] =
-    F.liftFC(GetCharacterStream1(a))
+    F.liftF(GetCharacterStream(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getClob(a: Int): CallableStatementIO[Clob] =
-    F.liftFC(GetClob(a))
+  def getCharacterStream(a: String): CallableStatementIO[Reader] =
+    F.liftF(GetCharacterStream1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getClob(a: String): CallableStatementIO[Clob] =
-    F.liftFC(GetClob1(a))
+    F.liftF(GetClob(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getClob(a: Int): CallableStatementIO[Clob] =
+    F.liftF(GetClob1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getConnection: CallableStatementIO[Connection] =
-    F.liftFC(GetConnection)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getDate(a: Int): CallableStatementIO[Date] =
-    F.liftFC(GetDate(a))
+    F.liftF(GetConnection)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getDate(a: String, b: Calendar): CallableStatementIO[Date] =
-    F.liftFC(GetDate1(a, b))
+    F.liftF(GetDate(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getDate(a: Int): CallableStatementIO[Date] =
+    F.liftF(GetDate1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getDate(a: Int, b: Calendar): CallableStatementIO[Date] =
-    F.liftFC(GetDate2(a, b))
+    F.liftF(GetDate2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getDate(a: String): CallableStatementIO[Date] =
-    F.liftFC(GetDate3(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getDouble(a: String): CallableStatementIO[Double] =
-    F.liftFC(GetDouble(a))
+    F.liftF(GetDate3(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getDouble(a: Int): CallableStatementIO[Double] =
-    F.liftFC(GetDouble1(a))
+    F.liftF(GetDouble(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getDouble(a: String): CallableStatementIO[Double] =
+    F.liftF(GetDouble1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getFetchDirection: CallableStatementIO[Int] =
-    F.liftFC(GetFetchDirection)
+    F.liftF(GetFetchDirection)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getFetchSize: CallableStatementIO[Int] =
-    F.liftFC(GetFetchSize)
+    F.liftF(GetFetchSize)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getFloat(a: Int): CallableStatementIO[Float] =
-    F.liftFC(GetFloat(a))
+    F.liftF(GetFloat(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getFloat(a: String): CallableStatementIO[Float] =
-    F.liftFC(GetFloat1(a))
+    F.liftF(GetFloat1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getGeneratedKeys: CallableStatementIO[ResultSet] =
-    F.liftFC(GetGeneratedKeys)
+    F.liftF(GetGeneratedKeys)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getInt(a: Int): CallableStatementIO[Int] =
-    F.liftFC(GetInt(a))
+    F.liftF(GetInt(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getInt(a: String): CallableStatementIO[Int] =
-    F.liftFC(GetInt1(a))
+    F.liftF(GetInt1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getLong(a: String): CallableStatementIO[Long] =
-    F.liftFC(GetLong(a))
+  val getLargeMaxRows: CallableStatementIO[Long] =
+    F.liftF(GetLargeMaxRows)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val getLargeUpdateCount: CallableStatementIO[Long] =
+    F.liftF(GetLargeUpdateCount)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getLong(a: Int): CallableStatementIO[Long] =
-    F.liftFC(GetLong1(a))
+    F.liftF(GetLong(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getLong(a: String): CallableStatementIO[Long] =
+    F.liftF(GetLong1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxFieldSize: CallableStatementIO[Int] =
-    F.liftFC(GetMaxFieldSize)
+    F.liftF(GetMaxFieldSize)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxRows: CallableStatementIO[Int] =
-    F.liftFC(GetMaxRows)
+    F.liftF(GetMaxRows)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMetaData: CallableStatementIO[ResultSetMetaData] =
-    F.liftFC(GetMetaData)
+    F.liftF(GetMetaData)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getMoreResults(a: Int): CallableStatementIO[Boolean] =
-    F.liftFC(GetMoreResults(a))
+    F.liftF(GetMoreResults(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMoreResults: CallableStatementIO[Boolean] =
-    F.liftFC(GetMoreResults1)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getNCharacterStream(a: String): CallableStatementIO[Reader] =
-    F.liftFC(GetNCharacterStream(a))
+    F.liftF(GetMoreResults1)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getNCharacterStream(a: Int): CallableStatementIO[Reader] =
-    F.liftFC(GetNCharacterStream1(a))
+    F.liftF(GetNCharacterStream(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getNClob(a: Int): CallableStatementIO[NClob] =
-    F.liftFC(GetNClob(a))
+  def getNCharacterStream(a: String): CallableStatementIO[Reader] =
+    F.liftF(GetNCharacterStream1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getNClob(a: String): CallableStatementIO[NClob] =
-    F.liftFC(GetNClob1(a))
+    F.liftF(GetNClob(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getNString(a: String): CallableStatementIO[String] =
-    F.liftFC(GetNString(a))
+  def getNClob(a: Int): CallableStatementIO[NClob] =
+    F.liftF(GetNClob1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getNString(a: Int): CallableStatementIO[String] =
-    F.liftFC(GetNString1(a))
+    F.liftF(GetNString(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getNString(a: String): CallableStatementIO[String] =
+    F.liftF(GetNString1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getObject(a: String): CallableStatementIO[Object] =
-    F.liftFC(GetObject(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getObject(a: Int, b: Map[String, Class[_]]): CallableStatementIO[Object] =
-    F.liftFC(GetObject1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getObject(a: Int): CallableStatementIO[Object] =
-    F.liftFC(GetObject2(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getObject(a: String, b: Map[String, Class[_]]): CallableStatementIO[Object] =
-    F.liftFC(GetObject3(a, b))
+    F.liftF(GetObject(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getObject[T](a: String, b: Class[T]): CallableStatementIO[T] =
-    F.liftFC(GetObject4(a, b))
+    F.liftF(GetObject1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getObject[T](a: Int, b: Class[T]): CallableStatementIO[T] =
-    F.liftFC(GetObject5(a, b))
+    F.liftF(GetObject2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getObject(a: String, b: Map[String, Class[_]]): CallableStatementIO[Object] =
+    F.liftF(GetObject3(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getObject(a: Int): CallableStatementIO[Object] =
+    F.liftF(GetObject4(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getObject(a: Int, b: Map[String, Class[_]]): CallableStatementIO[Object] =
+    F.liftF(GetObject5(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getParameterMetaData: CallableStatementIO[ParameterMetaData] =
-    F.liftFC(GetParameterMetaData)
+    F.liftF(GetParameterMetaData)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getQueryTimeout: CallableStatementIO[Int] =
-    F.liftFC(GetQueryTimeout)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getRef(a: String): CallableStatementIO[Ref] =
-    F.liftFC(GetRef(a))
+    F.liftF(GetQueryTimeout)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getRef(a: Int): CallableStatementIO[Ref] =
-    F.liftFC(GetRef1(a))
+    F.liftF(GetRef(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getRef(a: String): CallableStatementIO[Ref] =
+    F.liftF(GetRef1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getResultSet: CallableStatementIO[ResultSet] =
-    F.liftFC(GetResultSet)
+    F.liftF(GetResultSet)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getResultSetConcurrency: CallableStatementIO[Int] =
-    F.liftFC(GetResultSetConcurrency)
+    F.liftF(GetResultSetConcurrency)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getResultSetHoldability: CallableStatementIO[Int] =
-    F.liftFC(GetResultSetHoldability)
+    F.liftF(GetResultSetHoldability)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getResultSetType: CallableStatementIO[Int] =
-    F.liftFC(GetResultSetType)
+    F.liftF(GetResultSetType)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getRowId(a: String): CallableStatementIO[RowId] =
-    F.liftFC(GetRowId(a))
+    F.liftF(GetRowId(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getRowId(a: Int): CallableStatementIO[RowId] =
-    F.liftFC(GetRowId1(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getSQLXML(a: Int): CallableStatementIO[SQLXML] =
-    F.liftFC(GetSQLXML(a))
+    F.liftF(GetRowId1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getSQLXML(a: String): CallableStatementIO[SQLXML] =
-    F.liftFC(GetSQLXML1(a))
+    F.liftF(GetSQLXML(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getSQLXML(a: Int): CallableStatementIO[SQLXML] =
+    F.liftF(GetSQLXML1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getShort(a: String): CallableStatementIO[Short] =
-    F.liftFC(GetShort(a))
+    F.liftF(GetShort(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getShort(a: Int): CallableStatementIO[Short] =
-    F.liftFC(GetShort1(a))
+    F.liftF(GetShort1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getString(a: String): CallableStatementIO[String] =
-    F.liftFC(GetString(a))
+    F.liftF(GetString(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getString(a: Int): CallableStatementIO[String] =
-    F.liftFC(GetString1(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getTime(a: Int, b: Calendar): CallableStatementIO[Time] =
-    F.liftFC(GetTime(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getTime(a: String, b: Calendar): CallableStatementIO[Time] =
-    F.liftFC(GetTime1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getTime(a: Int): CallableStatementIO[Time] =
-    F.liftFC(GetTime2(a))
+    F.liftF(GetString1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getTime(a: String): CallableStatementIO[Time] =
-    F.liftFC(GetTime3(a))
+    F.liftF(GetTime(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getTimestamp(a: String, b: Calendar): CallableStatementIO[Timestamp] =
-    F.liftFC(GetTimestamp(a, b))
+  def getTime(a: String, b: Calendar): CallableStatementIO[Time] =
+    F.liftF(GetTime1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getTimestamp(a: String): CallableStatementIO[Timestamp] =
-    F.liftFC(GetTimestamp1(a))
+  def getTime(a: Int, b: Calendar): CallableStatementIO[Time] =
+    F.liftF(GetTime2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getTimestamp(a: Int): CallableStatementIO[Timestamp] =
-    F.liftFC(GetTimestamp2(a))
+  def getTime(a: Int): CallableStatementIO[Time] =
+    F.liftF(GetTime3(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getTimestamp(a: Int, b: Calendar): CallableStatementIO[Timestamp] =
-    F.liftFC(GetTimestamp3(a, b))
+    F.liftF(GetTimestamp(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getURL(a: String): CallableStatementIO[URL] =
-    F.liftFC(GetURL(a))
+  def getTimestamp(a: Int): CallableStatementIO[Timestamp] =
+    F.liftF(GetTimestamp1(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getTimestamp(a: String): CallableStatementIO[Timestamp] =
+    F.liftF(GetTimestamp2(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getTimestamp(a: String, b: Calendar): CallableStatementIO[Timestamp] =
+    F.liftF(GetTimestamp3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getURL(a: Int): CallableStatementIO[URL] =
-    F.liftFC(GetURL1(a))
+    F.liftF(GetURL(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getURL(a: String): CallableStatementIO[URL] =
+    F.liftF(GetURL1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getUpdateCount: CallableStatementIO[Int] =
-    F.liftFC(GetUpdateCount)
+    F.liftF(GetUpdateCount)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getWarnings: CallableStatementIO[SQLWarning] =
-    F.liftFC(GetWarnings)
+    F.liftF(GetWarnings)
 
   /** 
    * @group Constructors (Primitives)
    */
   val isCloseOnCompletion: CallableStatementIO[Boolean] =
-    F.liftFC(IsCloseOnCompletion)
+    F.liftF(IsCloseOnCompletion)
 
   /** 
    * @group Constructors (Primitives)
    */
   val isClosed: CallableStatementIO[Boolean] =
-    F.liftFC(IsClosed)
+    F.liftF(IsClosed)
 
   /** 
    * @group Constructors (Primitives)
    */
   val isPoolable: CallableStatementIO[Boolean] =
-    F.liftFC(IsPoolable)
+    F.liftF(IsPoolable)
 
   /** 
    * @group Constructors (Primitives)
    */
   def isWrapperFor(a: Class[_]): CallableStatementIO[Boolean] =
-    F.liftFC(IsWrapperFor(a))
+    F.liftF(IsWrapperFor(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def registerOutParameter(a: String, b: Int): CallableStatementIO[Unit] =
-    F.liftFC(RegisterOutParameter(a, b))
+  def registerOutParameter(a: Int, b: SQLType, c: String): CallableStatementIO[Unit] =
+    F.liftF(RegisterOutParameter(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def registerOutParameter(a: String, b: Int, c: String): CallableStatementIO[Unit] =
-    F.liftFC(RegisterOutParameter1(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def registerOutParameter(a: Int, b: Int, c: String): CallableStatementIO[Unit] =
-    F.liftFC(RegisterOutParameter2(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def registerOutParameter(a: String, b: Int, c: Int): CallableStatementIO[Unit] =
-    F.liftFC(RegisterOutParameter3(a, b, c))
+  def registerOutParameter(a: String, b: SQLType): CallableStatementIO[Unit] =
+    F.liftF(RegisterOutParameter1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def registerOutParameter(a: Int, b: Int, c: Int): CallableStatementIO[Unit] =
-    F.liftFC(RegisterOutParameter4(a, b, c))
+    F.liftF(RegisterOutParameter10(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def registerOutParameter(a: Int, b: Int): CallableStatementIO[Unit] =
-    F.liftFC(RegisterOutParameter5(a, b))
+    F.liftF(RegisterOutParameter11(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def registerOutParameter(a: String, b: SQLType, c: Int): CallableStatementIO[Unit] =
+    F.liftF(RegisterOutParameter2(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def registerOutParameter(a: Int, b: SQLType, c: Int): CallableStatementIO[Unit] =
+    F.liftF(RegisterOutParameter3(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def registerOutParameter(a: Int, b: SQLType): CallableStatementIO[Unit] =
+    F.liftF(RegisterOutParameter4(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def registerOutParameter(a: String, b: SQLType, c: String): CallableStatementIO[Unit] =
+    F.liftF(RegisterOutParameter5(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def registerOutParameter(a: String, b: Int): CallableStatementIO[Unit] =
+    F.liftF(RegisterOutParameter6(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def registerOutParameter(a: String, b: Int, c: String): CallableStatementIO[Unit] =
+    F.liftF(RegisterOutParameter7(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def registerOutParameter(a: String, b: Int, c: Int): CallableStatementIO[Unit] =
+    F.liftF(RegisterOutParameter8(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def registerOutParameter(a: Int, b: Int, c: String): CallableStatementIO[Unit] =
+    F.liftF(RegisterOutParameter9(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setArray(a: Int, b: SqlArray): CallableStatementIO[Unit] =
-    F.liftFC(SetArray(a, b))
+    F.liftF(SetArray(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setAsciiStream(a: String, b: InputStream, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetAsciiStream(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setAsciiStream(a: String, b: InputStream): CallableStatementIO[Unit] =
-    F.liftFC(SetAsciiStream1(a, b))
+    F.liftF(SetAsciiStream(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setAsciiStream(a: String, b: InputStream, c: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetAsciiStream2(a, b, c))
+    F.liftF(SetAsciiStream1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setAsciiStream(a: Int, b: InputStream): CallableStatementIO[Unit] =
-    F.liftFC(SetAsciiStream3(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setAsciiStream(a: Int, b: InputStream, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetAsciiStream4(a, b, c))
+  def setAsciiStream(a: String, b: InputStream): CallableStatementIO[Unit] =
+    F.liftF(SetAsciiStream2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setAsciiStream(a: Int, b: InputStream, c: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetAsciiStream5(a, b, c))
+    F.liftF(SetAsciiStream3(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setAsciiStream(a: Int, b: InputStream, c: Long): CallableStatementIO[Unit] =
+    F.liftF(SetAsciiStream4(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setAsciiStream(a: Int, b: InputStream): CallableStatementIO[Unit] =
+    F.liftF(SetAsciiStream5(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBigDecimal(a: String, b: BigDecimal): CallableStatementIO[Unit] =
-    F.liftFC(SetBigDecimal(a, b))
+    F.liftF(SetBigDecimal(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBigDecimal(a: Int, b: BigDecimal): CallableStatementIO[Unit] =
-    F.liftFC(SetBigDecimal1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setBinaryStream(a: String, b: InputStream, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetBinaryStream(a, b, c))
+    F.liftF(SetBigDecimal1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBinaryStream(a: String, b: InputStream, c: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetBinaryStream1(a, b, c))
+    F.liftF(SetBinaryStream(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBinaryStream(a: String, b: InputStream): CallableStatementIO[Unit] =
-    F.liftFC(SetBinaryStream2(a, b))
+    F.liftF(SetBinaryStream1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setBinaryStream(a: String, b: InputStream, c: Long): CallableStatementIO[Unit] =
+    F.liftF(SetBinaryStream2(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBinaryStream(a: Int, b: InputStream, c: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetBinaryStream3(a, b, c))
+    F.liftF(SetBinaryStream3(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBinaryStream(a: Int, b: InputStream): CallableStatementIO[Unit] =
-    F.liftFC(SetBinaryStream4(a, b))
+    F.liftF(SetBinaryStream4(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBinaryStream(a: Int, b: InputStream, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetBinaryStream5(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setBlob(a: String, b: Blob): CallableStatementIO[Unit] =
-    F.liftFC(SetBlob(a, b))
+    F.liftF(SetBinaryStream5(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBlob(a: String, b: InputStream, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetBlob1(a, b, c))
+    F.liftF(SetBlob(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setBlob(a: String, b: Blob): CallableStatementIO[Unit] =
+    F.liftF(SetBlob1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBlob(a: String, b: InputStream): CallableStatementIO[Unit] =
-    F.liftFC(SetBlob2(a, b))
+    F.liftF(SetBlob2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBlob(a: Int, b: InputStream, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetBlob3(a, b, c))
+    F.liftF(SetBlob3(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBlob(a: Int, b: Blob): CallableStatementIO[Unit] =
-    F.liftFC(SetBlob4(a, b))
+    F.liftF(SetBlob4(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBlob(a: Int, b: InputStream): CallableStatementIO[Unit] =
-    F.liftFC(SetBlob5(a, b))
+    F.liftF(SetBlob5(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBoolean(a: String, b: Boolean): CallableStatementIO[Unit] =
-    F.liftFC(SetBoolean(a, b))
+    F.liftF(SetBoolean(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBoolean(a: Int, b: Boolean): CallableStatementIO[Unit] =
-    F.liftFC(SetBoolean1(a, b))
+    F.liftF(SetBoolean1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setByte(a: String, b: Byte): CallableStatementIO[Unit] =
-    F.liftFC(SetByte(a, b))
+    F.liftF(SetByte(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setByte(a: Int, b: Byte): CallableStatementIO[Unit] =
-    F.liftFC(SetByte1(a, b))
+    F.liftF(SetByte1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBytes(a: String, b: Array[Byte]): CallableStatementIO[Unit] =
-    F.liftFC(SetBytes(a, b))
+    F.liftF(SetBytes(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBytes(a: Int, b: Array[Byte]): CallableStatementIO[Unit] =
-    F.liftFC(SetBytes1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setCharacterStream(a: String, b: Reader, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetCharacterStream(a, b, c))
+    F.liftF(SetBytes1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setCharacterStream(a: String, b: Reader, c: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetCharacterStream1(a, b, c))
+    F.liftF(SetCharacterStream(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setCharacterStream(a: String, b: Reader, c: Long): CallableStatementIO[Unit] =
+    F.liftF(SetCharacterStream1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setCharacterStream(a: String, b: Reader): CallableStatementIO[Unit] =
-    F.liftFC(SetCharacterStream2(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setCharacterStream(a: Int, b: Reader, c: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetCharacterStream3(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setCharacterStream(a: Int, b: Reader): CallableStatementIO[Unit] =
-    F.liftFC(SetCharacterStream4(a, b))
+    F.liftF(SetCharacterStream2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setCharacterStream(a: Int, b: Reader, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetCharacterStream5(a, b, c))
+    F.liftF(SetCharacterStream3(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setClob(a: String, b: Reader): CallableStatementIO[Unit] =
-    F.liftFC(SetClob(a, b))
+  def setCharacterStream(a: Int, b: Reader): CallableStatementIO[Unit] =
+    F.liftF(SetCharacterStream4(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setClob(a: String, b: Clob): CallableStatementIO[Unit] =
-    F.liftFC(SetClob1(a, b))
+  def setCharacterStream(a: Int, b: Reader, c: Int): CallableStatementIO[Unit] =
+    F.liftF(SetCharacterStream5(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setClob(a: String, b: Reader, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetClob2(a, b, c))
+    F.liftF(SetClob(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setClob(a: Int, b: Reader): CallableStatementIO[Unit] =
-    F.liftFC(SetClob3(a, b))
+  def setClob(a: String, b: Reader): CallableStatementIO[Unit] =
+    F.liftF(SetClob1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setClob(a: Int, b: Reader, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetClob4(a, b, c))
+  def setClob(a: String, b: Clob): CallableStatementIO[Unit] =
+    F.liftF(SetClob2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setClob(a: Int, b: Clob): CallableStatementIO[Unit] =
-    F.liftFC(SetClob5(a, b))
+    F.liftF(SetClob3(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setClob(a: Int, b: Reader): CallableStatementIO[Unit] =
+    F.liftF(SetClob4(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setClob(a: Int, b: Reader, c: Long): CallableStatementIO[Unit] =
+    F.liftF(SetClob5(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setCursorName(a: String): CallableStatementIO[Unit] =
-    F.liftFC(SetCursorName(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setDate(a: String, b: Date): CallableStatementIO[Unit] =
-    F.liftFC(SetDate(a, b))
+    F.liftF(SetCursorName(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setDate(a: String, b: Date, c: Calendar): CallableStatementIO[Unit] =
-    F.liftFC(SetDate1(a, b, c))
+    F.liftF(SetDate(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setDate(a: String, b: Date): CallableStatementIO[Unit] =
+    F.liftF(SetDate1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setDate(a: Int, b: Date, c: Calendar): CallableStatementIO[Unit] =
-    F.liftFC(SetDate2(a, b, c))
+    F.liftF(SetDate2(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setDate(a: Int, b: Date): CallableStatementIO[Unit] =
-    F.liftFC(SetDate3(a, b))
+    F.liftF(SetDate3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setDouble(a: String, b: Double): CallableStatementIO[Unit] =
-    F.liftFC(SetDouble(a, b))
+    F.liftF(SetDouble(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setDouble(a: Int, b: Double): CallableStatementIO[Unit] =
-    F.liftFC(SetDouble1(a, b))
+    F.liftF(SetDouble1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setEscapeProcessing(a: Boolean): CallableStatementIO[Unit] =
-    F.liftFC(SetEscapeProcessing(a))
+    F.liftF(SetEscapeProcessing(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setFetchDirection(a: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetFetchDirection(a))
+    F.liftF(SetFetchDirection(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setFetchSize(a: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetFetchSize(a))
+    F.liftF(SetFetchSize(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setFloat(a: String, b: Float): CallableStatementIO[Unit] =
-    F.liftFC(SetFloat(a, b))
+    F.liftF(SetFloat(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setFloat(a: Int, b: Float): CallableStatementIO[Unit] =
-    F.liftFC(SetFloat1(a, b))
+    F.liftF(SetFloat1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setInt(a: String, b: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetInt(a, b))
+    F.liftF(SetInt(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setInt(a: Int, b: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetInt1(a, b))
+    F.liftF(SetInt1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setLargeMaxRows(a: Long): CallableStatementIO[Unit] =
+    F.liftF(SetLargeMaxRows(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setLong(a: String, b: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetLong(a, b))
+    F.liftF(SetLong(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setLong(a: Int, b: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetLong1(a, b))
+    F.liftF(SetLong1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setMaxFieldSize(a: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetMaxFieldSize(a))
+    F.liftF(SetMaxFieldSize(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setMaxRows(a: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetMaxRows(a))
+    F.liftF(SetMaxRows(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNCharacterStream(a: String, b: Reader): CallableStatementIO[Unit] =
-    F.liftFC(SetNCharacterStream(a, b))
+    F.liftF(SetNCharacterStream(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNCharacterStream(a: String, b: Reader, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetNCharacterStream1(a, b, c))
+    F.liftF(SetNCharacterStream1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNCharacterStream(a: Int, b: Reader): CallableStatementIO[Unit] =
-    F.liftFC(SetNCharacterStream2(a, b))
+    F.liftF(SetNCharacterStream2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNCharacterStream(a: Int, b: Reader, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetNCharacterStream3(a, b, c))
+    F.liftF(SetNCharacterStream3(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNClob(a: String, b: Reader, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetNClob(a, b, c))
+    F.liftF(SetNClob(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNClob(a: String, b: NClob): CallableStatementIO[Unit] =
-    F.liftFC(SetNClob1(a, b))
+    F.liftF(SetNClob1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNClob(a: String, b: Reader): CallableStatementIO[Unit] =
-    F.liftFC(SetNClob2(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setNClob(a: Int, b: Reader, c: Long): CallableStatementIO[Unit] =
-    F.liftFC(SetNClob3(a, b, c))
+    F.liftF(SetNClob2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNClob(a: Int, b: NClob): CallableStatementIO[Unit] =
-    F.liftFC(SetNClob4(a, b))
+    F.liftF(SetNClob3(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setNClob(a: Int, b: Reader, c: Long): CallableStatementIO[Unit] =
+    F.liftF(SetNClob4(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNClob(a: Int, b: Reader): CallableStatementIO[Unit] =
-    F.liftFC(SetNClob5(a, b))
+    F.liftF(SetNClob5(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNString(a: String, b: String): CallableStatementIO[Unit] =
-    F.liftFC(SetNString(a, b))
+    F.liftF(SetNString(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNString(a: Int, b: String): CallableStatementIO[Unit] =
-    F.liftFC(SetNString1(a, b))
+    F.liftF(SetNString1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNull(a: String, b: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetNull(a, b))
+    F.liftF(SetNull(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNull(a: String, b: Int, c: String): CallableStatementIO[Unit] =
-    F.liftFC(SetNull1(a, b, c))
+    F.liftF(SetNull1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNull(a: Int, b: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetNull2(a, b))
+    F.liftF(SetNull2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNull(a: Int, b: Int, c: String): CallableStatementIO[Unit] =
-    F.liftFC(SetNull3(a, b, c))
+    F.liftF(SetNull3(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setObject(a: String, b: Object): CallableStatementIO[Unit] =
-    F.liftFC(SetObject(a, b))
+    F.liftF(SetObject(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setObject(a: String, b: Object, c: SQLType): CallableStatementIO[Unit] =
+    F.liftF(SetObject1(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setObject(a: String, b: Object, c: SQLType, d: Int): CallableStatementIO[Unit] =
+    F.liftF(SetObject2(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setObject(a: String, b: Object, c: Int, d: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetObject1(a, b, c, d))
+    F.liftF(SetObject3(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setObject(a: String, b: Object, c: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetObject2(a, b, c))
+    F.liftF(SetObject4(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setObject(a: Int, b: Object, c: Int, d: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetObject3(a, b, c, d))
+  def setObject(a: Int, b: Object, c: SQLType, d: Int): CallableStatementIO[Unit] =
+    F.liftF(SetObject5(a, b, c, d))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setObject(a: Int, b: Object, c: SQLType): CallableStatementIO[Unit] =
+    F.liftF(SetObject6(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setObject(a: Int, b: Object, c: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetObject4(a, b, c))
+    F.liftF(SetObject7(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setObject(a: Int, b: Object, c: Int, d: Int): CallableStatementIO[Unit] =
+    F.liftF(SetObject8(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setObject(a: Int, b: Object): CallableStatementIO[Unit] =
-    F.liftFC(SetObject5(a, b))
+    F.liftF(SetObject9(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setPoolable(a: Boolean): CallableStatementIO[Unit] =
-    F.liftFC(SetPoolable(a))
+    F.liftF(SetPoolable(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setQueryTimeout(a: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetQueryTimeout(a))
+    F.liftF(SetQueryTimeout(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setRef(a: Int, b: Ref): CallableStatementIO[Unit] =
-    F.liftFC(SetRef(a, b))
+    F.liftF(SetRef(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setRowId(a: String, b: RowId): CallableStatementIO[Unit] =
-    F.liftFC(SetRowId(a, b))
+    F.liftF(SetRowId(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setRowId(a: Int, b: RowId): CallableStatementIO[Unit] =
-    F.liftFC(SetRowId1(a, b))
+    F.liftF(SetRowId1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setSQLXML(a: String, b: SQLXML): CallableStatementIO[Unit] =
-    F.liftFC(SetSQLXML(a, b))
+    F.liftF(SetSQLXML(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setSQLXML(a: Int, b: SQLXML): CallableStatementIO[Unit] =
-    F.liftFC(SetSQLXML1(a, b))
+    F.liftF(SetSQLXML1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setShort(a: String, b: Short): CallableStatementIO[Unit] =
-    F.liftFC(SetShort(a, b))
+    F.liftF(SetShort(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setShort(a: Int, b: Short): CallableStatementIO[Unit] =
-    F.liftFC(SetShort1(a, b))
+    F.liftF(SetShort1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setString(a: String, b: String): CallableStatementIO[Unit] =
-    F.liftFC(SetString(a, b))
+    F.liftF(SetString(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setString(a: Int, b: String): CallableStatementIO[Unit] =
-    F.liftFC(SetString1(a, b))
+    F.liftF(SetString1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setTime(a: String, b: Time, c: Calendar): CallableStatementIO[Unit] =
-    F.liftFC(SetTime(a, b, c))
+    F.liftF(SetTime(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setTime(a: String, b: Time): CallableStatementIO[Unit] =
-    F.liftFC(SetTime1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setTime(a: Int, b: Time): CallableStatementIO[Unit] =
-    F.liftFC(SetTime2(a, b))
+    F.liftF(SetTime1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setTime(a: Int, b: Time, c: Calendar): CallableStatementIO[Unit] =
-    F.liftFC(SetTime3(a, b, c))
+    F.liftF(SetTime2(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setTime(a: Int, b: Time): CallableStatementIO[Unit] =
+    F.liftF(SetTime3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setTimestamp(a: String, b: Timestamp): CallableStatementIO[Unit] =
-    F.liftFC(SetTimestamp(a, b))
+    F.liftF(SetTimestamp(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setTimestamp(a: String, b: Timestamp, c: Calendar): CallableStatementIO[Unit] =
-    F.liftFC(SetTimestamp1(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setTimestamp(a: Int, b: Timestamp, c: Calendar): CallableStatementIO[Unit] =
-    F.liftFC(SetTimestamp2(a, b, c))
+    F.liftF(SetTimestamp1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setTimestamp(a: Int, b: Timestamp): CallableStatementIO[Unit] =
-    F.liftFC(SetTimestamp3(a, b))
+    F.liftF(SetTimestamp2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setTimestamp(a: Int, b: Timestamp, c: Calendar): CallableStatementIO[Unit] =
+    F.liftF(SetTimestamp3(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setURL(a: String, b: URL): CallableStatementIO[Unit] =
-    F.liftFC(SetURL(a, b))
+    F.liftF(SetURL(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setURL(a: Int, b: URL): CallableStatementIO[Unit] =
-    F.liftFC(SetURL1(a, b))
+    F.liftF(SetURL1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setUnicodeStream(a: Int, b: InputStream, c: Int): CallableStatementIO[Unit] =
-    F.liftFC(SetUnicodeStream(a, b, c))
+    F.liftF(SetUnicodeStream(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def unwrap[T](a: Class[T]): CallableStatementIO[T] =
-    F.liftFC(Unwrap(a))
+    F.liftF(Unwrap(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val wasNull: CallableStatementIO[Boolean] =
-    F.liftFC(WasNull)
+    F.liftF(WasNull)
 
  /** 
   * Natural transformation from `CallableStatementOp` to `Kleisli` for the given `M`, consuming a `java.sql.CallableStatement`. 

--- a/core/src/main/scala/doobie/free/callablestatement.scala
+++ b/core/src/main/scala/doobie/free/callablestatement.scala
@@ -30,7 +30,6 @@ import java.sql.RowId
 import java.sql.SQLData
 import java.sql.SQLInput
 import java.sql.SQLOutput
-import java.sql.SQLType
 import java.sql.SQLWarning
 import java.sql.SQLXML
 import java.sql.Statement
@@ -63,7 +62,7 @@ import resultset.ResultSetIO
  *
  * `CallableStatementIO` is a free monad that must be run via an interpreter, most commonly via
  * natural transformation of its underlying algebra `CallableStatementOp` to another monad via
- * `Free.runFC`. 
+ * `Free#foldMap`.
  *
  * The library provides a natural transformation to `Kleisli[M, CallableStatement, A]` for any
  * exception-trapping (`Catchable`) and effect-capturing (`Capture`) monad `M`. Such evidence is 
@@ -158,38 +157,20 @@ object callablestatement {
     case object Execute extends CallableStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute())
     }
-    case class  Execute1(a: String, b: Array[String]) extends CallableStatementOp[Boolean] {
+    case class  Execute1(a: String, b: Array[Int]) extends CallableStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
     }
-    case class  Execute2(a: String) extends CallableStatementOp[Boolean] {
+    case class  Execute2(a: String, b: Int) extends CallableStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
+    }
+    case class  Execute3(a: String) extends CallableStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a))
     }
-    case class  Execute3(a: String, b: Array[Int]) extends CallableStatementOp[Boolean] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
-    }
-    case class  Execute4(a: String, b: Int) extends CallableStatementOp[Boolean] {
+    case class  Execute4(a: String, b: Array[String]) extends CallableStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
     }
     case object ExecuteBatch extends CallableStatementOp[Array[Int]] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeBatch())
-    }
-    case object ExecuteLargeBatch extends CallableStatementOp[Array[Long]] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeBatch())
-    }
-    case object ExecuteLargeUpdate extends CallableStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate())
-    }
-    case class  ExecuteLargeUpdate1(a: String, b: Int) extends CallableStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
-    }
-    case class  ExecuteLargeUpdate2(a: String, b: Array[Int]) extends CallableStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
-    }
-    case class  ExecuteLargeUpdate3(a: String) extends CallableStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a))
-    }
-    case class  ExecuteLargeUpdate4(a: String, b: Array[String]) extends CallableStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
     }
     case object ExecuteQuery extends CallableStatementOp[ResultSet] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeQuery())
@@ -200,8 +181,8 @@ object callablestatement {
     case object ExecuteUpdate extends CallableStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate())
     }
-    case class  ExecuteUpdate1(a: String, b: Int) extends CallableStatementOp[Int] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
+    case class  ExecuteUpdate1(a: String) extends CallableStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a))
     }
     case class  ExecuteUpdate2(a: String, b: Array[String]) extends CallableStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
@@ -209,8 +190,8 @@ object callablestatement {
     case class  ExecuteUpdate3(a: String, b: Array[Int]) extends CallableStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
     }
-    case class  ExecuteUpdate4(a: String) extends CallableStatementOp[Int] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a))
+    case class  ExecuteUpdate4(a: String, b: Int) extends CallableStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
     }
     case class  GetArray(a: Int) extends CallableStatementOp[SqlArray] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getArray(a))
@@ -218,19 +199,19 @@ object callablestatement {
     case class  GetArray1(a: String) extends CallableStatementOp[SqlArray] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getArray(a))
     }
-    case class  GetBigDecimal(a: String) extends CallableStatementOp[BigDecimal] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a))
-    }
-    case class  GetBigDecimal1(a: Int) extends CallableStatementOp[BigDecimal] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a))
-    }
-    case class  GetBigDecimal2(a: Int, b: Int) extends CallableStatementOp[BigDecimal] {
+    case class  GetBigDecimal(a: Int, b: Int) extends CallableStatementOp[BigDecimal] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a, b))
     }
-    case class  GetBlob(a: String) extends CallableStatementOp[Blob] {
+    case class  GetBigDecimal1(a: String) extends CallableStatementOp[BigDecimal] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a))
+    }
+    case class  GetBigDecimal2(a: Int) extends CallableStatementOp[BigDecimal] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a))
+    }
+    case class  GetBlob(a: Int) extends CallableStatementOp[Blob] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBlob(a))
     }
-    case class  GetBlob1(a: Int) extends CallableStatementOp[Blob] {
+    case class  GetBlob1(a: String) extends CallableStatementOp[Blob] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBlob(a))
     }
     case class  GetBoolean(a: String) extends CallableStatementOp[Boolean] {
@@ -239,10 +220,10 @@ object callablestatement {
     case class  GetBoolean1(a: Int) extends CallableStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBoolean(a))
     }
-    case class  GetByte(a: String) extends CallableStatementOp[Byte] {
+    case class  GetByte(a: Int) extends CallableStatementOp[Byte] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getByte(a))
     }
-    case class  GetByte1(a: Int) extends CallableStatementOp[Byte] {
+    case class  GetByte1(a: String) extends CallableStatementOp[Byte] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getByte(a))
     }
     case class  GetBytes(a: String) extends CallableStatementOp[Array[Byte]] {
@@ -251,10 +232,10 @@ object callablestatement {
     case class  GetBytes1(a: Int) extends CallableStatementOp[Array[Byte]] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBytes(a))
     }
-    case class  GetCharacterStream(a: Int) extends CallableStatementOp[Reader] {
+    case class  GetCharacterStream(a: String) extends CallableStatementOp[Reader] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getCharacterStream(a))
     }
-    case class  GetCharacterStream1(a: String) extends CallableStatementOp[Reader] {
+    case class  GetCharacterStream1(a: Int) extends CallableStatementOp[Reader] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getCharacterStream(a))
     }
     case class  GetClob(a: String) extends CallableStatementOp[Clob] {
@@ -266,17 +247,17 @@ object callablestatement {
     case object GetConnection extends CallableStatementOp[Connection] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getConnection())
     }
-    case class  GetDate(a: String, b: Calendar) extends CallableStatementOp[Date] {
+    case class  GetDate(a: Int, b: Calendar) extends CallableStatementOp[Date] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a, b))
     }
     case class  GetDate1(a: Int) extends CallableStatementOp[Date] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a))
     }
-    case class  GetDate2(a: Int, b: Calendar) extends CallableStatementOp[Date] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a, b))
-    }
-    case class  GetDate3(a: String) extends CallableStatementOp[Date] {
+    case class  GetDate2(a: String) extends CallableStatementOp[Date] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a))
+    }
+    case class  GetDate3(a: String, b: Calendar) extends CallableStatementOp[Date] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a, b))
     }
     case class  GetDouble(a: Int) extends CallableStatementOp[Double] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDouble(a))
@@ -290,10 +271,10 @@ object callablestatement {
     case object GetFetchSize extends CallableStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getFetchSize())
     }
-    case class  GetFloat(a: Int) extends CallableStatementOp[Float] {
+    case class  GetFloat(a: String) extends CallableStatementOp[Float] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getFloat(a))
     }
-    case class  GetFloat1(a: String) extends CallableStatementOp[Float] {
+    case class  GetFloat1(a: Int) extends CallableStatementOp[Float] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getFloat(a))
     }
     case object GetGeneratedKeys extends CallableStatementOp[ResultSet] {
@@ -304,12 +285,6 @@ object callablestatement {
     }
     case class  GetInt1(a: String) extends CallableStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getInt(a))
-    }
-    case object GetLargeMaxRows extends CallableStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeMaxRows())
-    }
-    case object GetLargeUpdateCount extends CallableStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeUpdateCount())
     }
     case class  GetLong(a: Int) extends CallableStatementOp[Long] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLong(a))
@@ -338,10 +313,10 @@ object callablestatement {
     case class  GetNCharacterStream1(a: String) extends CallableStatementOp[Reader] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNCharacterStream(a))
     }
-    case class  GetNClob(a: String) extends CallableStatementOp[NClob] {
+    case class  GetNClob(a: Int) extends CallableStatementOp[NClob] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNClob(a))
     }
-    case class  GetNClob1(a: Int) extends CallableStatementOp[NClob] {
+    case class  GetNClob1(a: String) extends CallableStatementOp[NClob] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNClob(a))
     }
     case class  GetNString(a: Int) extends CallableStatementOp[String] {
@@ -350,22 +325,22 @@ object callablestatement {
     case class  GetNString1(a: String) extends CallableStatementOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNString(a))
     }
-    case class  GetObject(a: String) extends CallableStatementOp[Object] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a))
+    case class  GetObject[T](a: Int, b: Class[T]) extends CallableStatementOp[T] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
     }
     case class  GetObject1[T](a: String, b: Class[T]) extends CallableStatementOp[T] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
     }
-    case class  GetObject2[T](a: Int, b: Class[T]) extends CallableStatementOp[T] {
+    case class  GetObject2(a: Int, b: Map[String, Class[_]]) extends CallableStatementOp[Object] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
     }
-    case class  GetObject3(a: String, b: Map[String, Class[_]]) extends CallableStatementOp[Object] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
+    case class  GetObject3(a: String) extends CallableStatementOp[Object] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a))
     }
     case class  GetObject4(a: Int) extends CallableStatementOp[Object] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a))
     }
-    case class  GetObject5(a: Int, b: Map[String, Class[_]]) extends CallableStatementOp[Object] {
+    case class  GetObject5(a: String, b: Map[String, Class[_]]) extends CallableStatementOp[Object] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
     }
     case object GetParameterMetaData extends CallableStatementOp[ParameterMetaData] {
@@ -374,10 +349,10 @@ object callablestatement {
     case object GetQueryTimeout extends CallableStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getQueryTimeout())
     }
-    case class  GetRef(a: Int) extends CallableStatementOp[Ref] {
+    case class  GetRef(a: String) extends CallableStatementOp[Ref] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getRef(a))
     }
-    case class  GetRef1(a: String) extends CallableStatementOp[Ref] {
+    case class  GetRef1(a: Int) extends CallableStatementOp[Ref] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getRef(a))
     }
     case object GetResultSet extends CallableStatementOp[ResultSet] {
@@ -398,16 +373,16 @@ object callablestatement {
     case class  GetRowId1(a: Int) extends CallableStatementOp[RowId] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getRowId(a))
     }
-    case class  GetSQLXML(a: String) extends CallableStatementOp[SQLXML] {
+    case class  GetSQLXML(a: Int) extends CallableStatementOp[SQLXML] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSQLXML(a))
     }
-    case class  GetSQLXML1(a: Int) extends CallableStatementOp[SQLXML] {
+    case class  GetSQLXML1(a: String) extends CallableStatementOp[SQLXML] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSQLXML(a))
     }
-    case class  GetShort(a: String) extends CallableStatementOp[Short] {
+    case class  GetShort(a: Int) extends CallableStatementOp[Short] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getShort(a))
     }
-    case class  GetShort1(a: Int) extends CallableStatementOp[Short] {
+    case class  GetShort1(a: String) extends CallableStatementOp[Short] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getShort(a))
     }
     case class  GetString(a: String) extends CallableStatementOp[String] {
@@ -419,31 +394,31 @@ object callablestatement {
     case class  GetTime(a: String) extends CallableStatementOp[Time] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a))
     }
-    case class  GetTime1(a: String, b: Calendar) extends CallableStatementOp[Time] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a, b))
-    }
-    case class  GetTime2(a: Int, b: Calendar) extends CallableStatementOp[Time] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a, b))
-    }
-    case class  GetTime3(a: Int) extends CallableStatementOp[Time] {
+    case class  GetTime1(a: Int) extends CallableStatementOp[Time] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a))
     }
-    case class  GetTimestamp(a: Int, b: Calendar) extends CallableStatementOp[Timestamp] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a, b))
+    case class  GetTime2(a: String, b: Calendar) extends CallableStatementOp[Time] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a, b))
+    }
+    case class  GetTime3(a: Int, b: Calendar) extends CallableStatementOp[Time] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a, b))
+    }
+    case class  GetTimestamp(a: String) extends CallableStatementOp[Timestamp] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a))
     }
     case class  GetTimestamp1(a: Int) extends CallableStatementOp[Timestamp] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a))
     }
-    case class  GetTimestamp2(a: String) extends CallableStatementOp[Timestamp] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a))
+    case class  GetTimestamp2(a: Int, b: Calendar) extends CallableStatementOp[Timestamp] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a, b))
     }
     case class  GetTimestamp3(a: String, b: Calendar) extends CallableStatementOp[Timestamp] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a, b))
     }
-    case class  GetURL(a: Int) extends CallableStatementOp[URL] {
+    case class  GetURL(a: String) extends CallableStatementOp[URL] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getURL(a))
     }
-    case class  GetURL1(a: String) extends CallableStatementOp[URL] {
+    case class  GetURL1(a: Int) extends CallableStatementOp[URL] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getURL(a))
     }
     case object GetUpdateCount extends CallableStatementOp[Int] {
@@ -464,41 +439,23 @@ object callablestatement {
     case class  IsWrapperFor(a: Class[_]) extends CallableStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.isWrapperFor(a))
     }
-    case class  RegisterOutParameter(a: Int, b: SQLType, c: String) extends CallableStatementOp[Unit] {
+    case class  RegisterOutParameter(a: Int, b: Int, c: String) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
     }
-    case class  RegisterOutParameter1(a: String, b: SQLType) extends CallableStatementOp[Unit] {
+    case class  RegisterOutParameter1(a: String, b: Int, c: String) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
+    }
+    case class  RegisterOutParameter2(a: String, b: Int, c: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
+    }
+    case class  RegisterOutParameter3(a: String, b: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b))
     }
-    case class  RegisterOutParameter10(a: Int, b: Int, c: Int) extends CallableStatementOp[Unit] {
+    case class  RegisterOutParameter4(a: Int, b: Int, c: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
     }
-    case class  RegisterOutParameter11(a: Int, b: Int) extends CallableStatementOp[Unit] {
+    case class  RegisterOutParameter5(a: Int, b: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b))
-    }
-    case class  RegisterOutParameter2(a: String, b: SQLType, c: Int) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
-    }
-    case class  RegisterOutParameter3(a: Int, b: SQLType, c: Int) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
-    }
-    case class  RegisterOutParameter4(a: Int, b: SQLType) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b))
-    }
-    case class  RegisterOutParameter5(a: String, b: SQLType, c: String) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
-    }
-    case class  RegisterOutParameter6(a: String, b: Int) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b))
-    }
-    case class  RegisterOutParameter7(a: String, b: Int, c: String) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
-    }
-    case class  RegisterOutParameter8(a: String, b: Int, c: Int) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
-    }
-    case class  RegisterOutParameter9(a: Int, b: Int, c: String) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.registerOutParameter(a, b, c))
     }
     case class  SetArray(a: Int, b: SqlArray) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setArray(a, b))
@@ -512,10 +469,10 @@ object callablestatement {
     case class  SetAsciiStream2(a: String, b: InputStream) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b))
     }
-    case class  SetAsciiStream3(a: Int, b: InputStream, c: Int) extends CallableStatementOp[Unit] {
+    case class  SetAsciiStream3(a: Int, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
     }
-    case class  SetAsciiStream4(a: Int, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
+    case class  SetAsciiStream4(a: Int, b: InputStream, c: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
     }
     case class  SetAsciiStream5(a: Int, b: InputStream) extends CallableStatementOp[Unit] {
@@ -527,14 +484,14 @@ object callablestatement {
     case class  SetBigDecimal1(a: Int, b: BigDecimal) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBigDecimal(a, b))
     }
-    case class  SetBinaryStream(a: String, b: InputStream, c: Int) extends CallableStatementOp[Unit] {
+    case class  SetBinaryStream(a: String, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b, c))
     }
-    case class  SetBinaryStream1(a: String, b: InputStream) extends CallableStatementOp[Unit] {
+    case class  SetBinaryStream1(a: String, b: InputStream, c: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b, c))
+    }
+    case class  SetBinaryStream2(a: String, b: InputStream) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b))
-    }
-    case class  SetBinaryStream2(a: String, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b, c))
     }
     case class  SetBinaryStream3(a: Int, b: InputStream, c: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b, c))
@@ -545,20 +502,20 @@ object callablestatement {
     case class  SetBinaryStream5(a: Int, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b, c))
     }
-    case class  SetBlob(a: String, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b, c))
-    }
-    case class  SetBlob1(a: String, b: Blob) extends CallableStatementOp[Unit] {
+    case class  SetBlob(a: String, b: Blob) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b))
+    }
+    case class  SetBlob1(a: String, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b, c))
     }
     case class  SetBlob2(a: String, b: InputStream) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b))
     }
-    case class  SetBlob3(a: Int, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b, c))
-    }
-    case class  SetBlob4(a: Int, b: Blob) extends CallableStatementOp[Unit] {
+    case class  SetBlob3(a: Int, b: Blob) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b))
+    }
+    case class  SetBlob4(a: Int, b: InputStream, c: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b, c))
     }
     case class  SetBlob5(a: Int, b: InputStream) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b))
@@ -581,31 +538,31 @@ object callablestatement {
     case class  SetBytes1(a: Int, b: Array[Byte]) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBytes(a, b))
     }
-    case class  SetCharacterStream(a: String, b: Reader, c: Int) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b, c))
+    case class  SetCharacterStream(a: String, b: Reader) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b))
     }
     case class  SetCharacterStream1(a: String, b: Reader, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b, c))
     }
-    case class  SetCharacterStream2(a: String, b: Reader) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b))
-    }
-    case class  SetCharacterStream3(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit] {
+    case class  SetCharacterStream2(a: String, b: Reader, c: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b, c))
     }
-    case class  SetCharacterStream4(a: Int, b: Reader) extends CallableStatementOp[Unit] {
+    case class  SetCharacterStream3(a: Int, b: Reader) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b))
     }
-    case class  SetCharacterStream5(a: Int, b: Reader, c: Int) extends CallableStatementOp[Unit] {
+    case class  SetCharacterStream4(a: Int, b: Reader, c: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b, c))
+    }
+    case class  SetCharacterStream5(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b, c))
     }
     case class  SetClob(a: String, b: Reader, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b, c))
     }
-    case class  SetClob1(a: String, b: Reader) extends CallableStatementOp[Unit] {
+    case class  SetClob1(a: String, b: Clob) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
     }
-    case class  SetClob2(a: String, b: Clob) extends CallableStatementOp[Unit] {
+    case class  SetClob2(a: String, b: Reader) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
     }
     case class  SetClob3(a: Int, b: Clob) extends CallableStatementOp[Unit] {
@@ -620,17 +577,17 @@ object callablestatement {
     case class  SetCursorName(a: String) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCursorName(a))
     }
-    case class  SetDate(a: String, b: Date, c: Calendar) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b, c))
-    }
-    case class  SetDate1(a: String, b: Date) extends CallableStatementOp[Unit] {
+    case class  SetDate(a: String, b: Date) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b))
     }
-    case class  SetDate2(a: Int, b: Date, c: Calendar) extends CallableStatementOp[Unit] {
+    case class  SetDate1(a: String, b: Date, c: Calendar) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b, c))
     }
-    case class  SetDate3(a: Int, b: Date) extends CallableStatementOp[Unit] {
+    case class  SetDate2(a: Int, b: Date) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b))
+    }
+    case class  SetDate3(a: Int, b: Date, c: Calendar) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b, c))
     }
     case class  SetDouble(a: String, b: Double) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDouble(a, b))
@@ -659,9 +616,6 @@ object callablestatement {
     case class  SetInt1(a: Int, b: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setInt(a, b))
     }
-    case class  SetLargeMaxRows(a: Long) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setLargeMaxRows(a))
-    }
     case class  SetLong(a: String, b: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setLong(a, b))
     }
@@ -686,20 +640,20 @@ object callablestatement {
     case class  SetNCharacterStream3(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNCharacterStream(a, b, c))
     }
-    case class  SetNClob(a: String, b: Reader, c: Long) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b, c))
+    case class  SetNClob(a: String, b: Reader) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
     }
     case class  SetNClob1(a: String, b: NClob) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
     }
-    case class  SetNClob2(a: String, b: Reader) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
-    }
-    case class  SetNClob3(a: Int, b: NClob) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
-    }
-    case class  SetNClob4(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit] {
+    case class  SetNClob2(a: String, b: Reader, c: Long) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b, c))
+    }
+    case class  SetNClob3(a: Int, b: Reader, c: Long) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b, c))
+    }
+    case class  SetNClob4(a: Int, b: NClob) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
     }
     case class  SetNClob5(a: Int, b: Reader) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
@@ -710,11 +664,11 @@ object callablestatement {
     case class  SetNString1(a: Int, b: String) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNString(a, b))
     }
-    case class  SetNull(a: String, b: Int) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNull(a, b))
-    }
-    case class  SetNull1(a: String, b: Int, c: String) extends CallableStatementOp[Unit] {
+    case class  SetNull(a: String, b: Int, c: String) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNull(a, b, c))
+    }
+    case class  SetNull1(a: String, b: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNull(a, b))
     }
     case class  SetNull2(a: Int, b: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNull(a, b))
@@ -722,34 +676,22 @@ object callablestatement {
     case class  SetNull3(a: Int, b: Int, c: String) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNull(a, b, c))
     }
-    case class  SetObject(a: String, b: Object) extends CallableStatementOp[Unit] {
+    case class  SetObject(a: String, b: Object, c: Int) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
+    }
+    case class  SetObject1(a: String, b: Object) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b))
     }
-    case class  SetObject1(a: String, b: Object, c: SQLType) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
-    }
-    case class  SetObject2(a: String, b: Object, c: SQLType, d: Int) extends CallableStatementOp[Unit] {
+    case class  SetObject2(a: String, b: Object, c: Int, d: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
     }
-    case class  SetObject3(a: String, b: Object, c: Int, d: Int) extends CallableStatementOp[Unit] {
+    case class  SetObject3(a: Int, b: Object, c: Int, d: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
     }
-    case class  SetObject4(a: String, b: Object, c: Int) extends CallableStatementOp[Unit] {
+    case class  SetObject4(a: Int, b: Object, c: Int) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
     }
-    case class  SetObject5(a: Int, b: Object, c: SQLType, d: Int) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
-    }
-    case class  SetObject6(a: Int, b: Object, c: SQLType) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
-    }
-    case class  SetObject7(a: Int, b: Object, c: Int) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
-    }
-    case class  SetObject8(a: Int, b: Object, c: Int, d: Int) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
-    }
-    case class  SetObject9(a: Int, b: Object) extends CallableStatementOp[Unit] {
+    case class  SetObject5(a: Int, b: Object) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b))
     }
     case class  SetPoolable(a: Boolean) extends CallableStatementOp[Unit] {
@@ -785,11 +727,11 @@ object callablestatement {
     case class  SetString1(a: Int, b: String) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setString(a, b))
     }
-    case class  SetTime(a: String, b: Time, c: Calendar) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTime(a, b, c))
-    }
-    case class  SetTime1(a: String, b: Time) extends CallableStatementOp[Unit] {
+    case class  SetTime(a: String, b: Time) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTime(a, b))
+    }
+    case class  SetTime1(a: String, b: Time, c: Calendar) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTime(a, b, c))
     }
     case class  SetTime2(a: Int, b: Time, c: Calendar) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTime(a, b, c))
@@ -797,11 +739,11 @@ object callablestatement {
     case class  SetTime3(a: Int, b: Time) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTime(a, b))
     }
-    case class  SetTimestamp(a: String, b: Timestamp) extends CallableStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b))
-    }
-    case class  SetTimestamp1(a: String, b: Timestamp, c: Calendar) extends CallableStatementOp[Unit] {
+    case class  SetTimestamp(a: String, b: Timestamp, c: Calendar) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b, c))
+    }
+    case class  SetTimestamp1(a: String, b: Timestamp) extends CallableStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b))
     }
     case class  SetTimestamp2(a: Int, b: Timestamp) extends CallableStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b))
@@ -939,25 +881,25 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def execute(a: String, b: Array[String]): CallableStatementIO[Boolean] =
+  def execute(a: String, b: Array[Int]): CallableStatementIO[Boolean] =
     F.liftF(Execute1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def execute(a: String): CallableStatementIO[Boolean] =
-    F.liftF(Execute2(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def execute(a: String, b: Array[Int]): CallableStatementIO[Boolean] =
-    F.liftF(Execute3(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def execute(a: String, b: Int): CallableStatementIO[Boolean] =
+    F.liftF(Execute2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def execute(a: String): CallableStatementIO[Boolean] =
+    F.liftF(Execute3(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def execute(a: String, b: Array[String]): CallableStatementIO[Boolean] =
     F.liftF(Execute4(a, b))
 
   /** 
@@ -965,42 +907,6 @@ object callablestatement {
    */
   val executeBatch: CallableStatementIO[Array[Int]] =
     F.liftF(ExecuteBatch)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val executeLargeBatch: CallableStatementIO[Array[Long]] =
-    F.liftF(ExecuteLargeBatch)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val executeLargeUpdate: CallableStatementIO[Long] =
-    F.liftF(ExecuteLargeUpdate)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String, b: Int): CallableStatementIO[Long] =
-    F.liftF(ExecuteLargeUpdate1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String, b: Array[Int]): CallableStatementIO[Long] =
-    F.liftF(ExecuteLargeUpdate2(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String): CallableStatementIO[Long] =
-    F.liftF(ExecuteLargeUpdate3(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String, b: Array[String]): CallableStatementIO[Long] =
-    F.liftF(ExecuteLargeUpdate4(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1023,8 +929,8 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def executeUpdate(a: String, b: Int): CallableStatementIO[Int] =
-    F.liftF(ExecuteUpdate1(a, b))
+  def executeUpdate(a: String): CallableStatementIO[Int] =
+    F.liftF(ExecuteUpdate1(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -1041,8 +947,8 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def executeUpdate(a: String): CallableStatementIO[Int] =
-    F.liftF(ExecuteUpdate4(a))
+  def executeUpdate(a: String, b: Int): CallableStatementIO[Int] =
+    F.liftF(ExecuteUpdate4(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1059,31 +965,31 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getBigDecimal(a: String): CallableStatementIO[BigDecimal] =
-    F.liftF(GetBigDecimal(a))
+  def getBigDecimal(a: Int, b: Int): CallableStatementIO[BigDecimal] =
+    F.liftF(GetBigDecimal(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getBigDecimal(a: Int): CallableStatementIO[BigDecimal] =
+  def getBigDecimal(a: String): CallableStatementIO[BigDecimal] =
     F.liftF(GetBigDecimal1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getBigDecimal(a: Int, b: Int): CallableStatementIO[BigDecimal] =
-    F.liftF(GetBigDecimal2(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getBlob(a: String): CallableStatementIO[Blob] =
-    F.liftF(GetBlob(a))
+  def getBigDecimal(a: Int): CallableStatementIO[BigDecimal] =
+    F.liftF(GetBigDecimal2(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getBlob(a: Int): CallableStatementIO[Blob] =
+    F.liftF(GetBlob(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getBlob(a: String): CallableStatementIO[Blob] =
     F.liftF(GetBlob1(a))
 
   /** 
@@ -1101,13 +1007,13 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getByte(a: String): CallableStatementIO[Byte] =
+  def getByte(a: Int): CallableStatementIO[Byte] =
     F.liftF(GetByte(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getByte(a: Int): CallableStatementIO[Byte] =
+  def getByte(a: String): CallableStatementIO[Byte] =
     F.liftF(GetByte1(a))
 
   /** 
@@ -1125,13 +1031,13 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getCharacterStream(a: Int): CallableStatementIO[Reader] =
+  def getCharacterStream(a: String): CallableStatementIO[Reader] =
     F.liftF(GetCharacterStream(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getCharacterStream(a: String): CallableStatementIO[Reader] =
+  def getCharacterStream(a: Int): CallableStatementIO[Reader] =
     F.liftF(GetCharacterStream1(a))
 
   /** 
@@ -1155,7 +1061,7 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getDate(a: String, b: Calendar): CallableStatementIO[Date] =
+  def getDate(a: Int, b: Calendar): CallableStatementIO[Date] =
     F.liftF(GetDate(a, b))
 
   /** 
@@ -1167,14 +1073,14 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getDate(a: Int, b: Calendar): CallableStatementIO[Date] =
-    F.liftF(GetDate2(a, b))
+  def getDate(a: String): CallableStatementIO[Date] =
+    F.liftF(GetDate2(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getDate(a: String): CallableStatementIO[Date] =
-    F.liftF(GetDate3(a))
+  def getDate(a: String, b: Calendar): CallableStatementIO[Date] =
+    F.liftF(GetDate3(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1203,13 +1109,13 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getFloat(a: Int): CallableStatementIO[Float] =
+  def getFloat(a: String): CallableStatementIO[Float] =
     F.liftF(GetFloat(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getFloat(a: String): CallableStatementIO[Float] =
+  def getFloat(a: Int): CallableStatementIO[Float] =
     F.liftF(GetFloat1(a))
 
   /** 
@@ -1229,18 +1135,6 @@ object callablestatement {
    */
   def getInt(a: String): CallableStatementIO[Int] =
     F.liftF(GetInt1(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val getLargeMaxRows: CallableStatementIO[Long] =
-    F.liftF(GetLargeMaxRows)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val getLargeUpdateCount: CallableStatementIO[Long] =
-    F.liftF(GetLargeUpdateCount)
 
   /** 
    * @group Constructors (Primitives)
@@ -1299,13 +1193,13 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getNClob(a: String): CallableStatementIO[NClob] =
+  def getNClob(a: Int): CallableStatementIO[NClob] =
     F.liftF(GetNClob(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getNClob(a: Int): CallableStatementIO[NClob] =
+  def getNClob(a: String): CallableStatementIO[NClob] =
     F.liftF(GetNClob1(a))
 
   /** 
@@ -1323,8 +1217,8 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getObject(a: String): CallableStatementIO[Object] =
-    F.liftF(GetObject(a))
+  def getObject[T](a: Int, b: Class[T]): CallableStatementIO[T] =
+    F.liftF(GetObject(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1335,14 +1229,14 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getObject[T](a: Int, b: Class[T]): CallableStatementIO[T] =
+  def getObject(a: Int, b: Map[String, Class[_]]): CallableStatementIO[Object] =
     F.liftF(GetObject2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getObject(a: String, b: Map[String, Class[_]]): CallableStatementIO[Object] =
-    F.liftF(GetObject3(a, b))
+  def getObject(a: String): CallableStatementIO[Object] =
+    F.liftF(GetObject3(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -1353,7 +1247,7 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getObject(a: Int, b: Map[String, Class[_]]): CallableStatementIO[Object] =
+  def getObject(a: String, b: Map[String, Class[_]]): CallableStatementIO[Object] =
     F.liftF(GetObject5(a, b))
 
   /** 
@@ -1371,13 +1265,13 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getRef(a: Int): CallableStatementIO[Ref] =
+  def getRef(a: String): CallableStatementIO[Ref] =
     F.liftF(GetRef(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getRef(a: String): CallableStatementIO[Ref] =
+  def getRef(a: Int): CallableStatementIO[Ref] =
     F.liftF(GetRef1(a))
 
   /** 
@@ -1419,25 +1313,25 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getSQLXML(a: String): CallableStatementIO[SQLXML] =
+  def getSQLXML(a: Int): CallableStatementIO[SQLXML] =
     F.liftF(GetSQLXML(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getSQLXML(a: Int): CallableStatementIO[SQLXML] =
+  def getSQLXML(a: String): CallableStatementIO[SQLXML] =
     F.liftF(GetSQLXML1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getShort(a: String): CallableStatementIO[Short] =
+  def getShort(a: Int): CallableStatementIO[Short] =
     F.liftF(GetShort(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getShort(a: Int): CallableStatementIO[Short] =
+  def getShort(a: String): CallableStatementIO[Short] =
     F.liftF(GetShort1(a))
 
   /** 
@@ -1461,26 +1355,26 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getTime(a: String, b: Calendar): CallableStatementIO[Time] =
-    F.liftF(GetTime1(a, b))
+  def getTime(a: Int): CallableStatementIO[Time] =
+    F.liftF(GetTime1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getTime(a: Int, b: Calendar): CallableStatementIO[Time] =
+  def getTime(a: String, b: Calendar): CallableStatementIO[Time] =
     F.liftF(GetTime2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getTime(a: Int): CallableStatementIO[Time] =
-    F.liftF(GetTime3(a))
+  def getTime(a: Int, b: Calendar): CallableStatementIO[Time] =
+    F.liftF(GetTime3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getTimestamp(a: Int, b: Calendar): CallableStatementIO[Timestamp] =
-    F.liftF(GetTimestamp(a, b))
+  def getTimestamp(a: String): CallableStatementIO[Timestamp] =
+    F.liftF(GetTimestamp(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -1491,8 +1385,8 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getTimestamp(a: String): CallableStatementIO[Timestamp] =
-    F.liftF(GetTimestamp2(a))
+  def getTimestamp(a: Int, b: Calendar): CallableStatementIO[Timestamp] =
+    F.liftF(GetTimestamp2(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1503,13 +1397,13 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def getURL(a: Int): CallableStatementIO[URL] =
+  def getURL(a: String): CallableStatementIO[URL] =
     F.liftF(GetURL(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getURL(a: String): CallableStatementIO[URL] =
+  def getURL(a: Int): CallableStatementIO[URL] =
     F.liftF(GetURL1(a))
 
   /** 
@@ -1551,74 +1445,38 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def registerOutParameter(a: Int, b: SQLType, c: String): CallableStatementIO[Unit] =
+  def registerOutParameter(a: Int, b: Int, c: String): CallableStatementIO[Unit] =
     F.liftF(RegisterOutParameter(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def registerOutParameter(a: String, b: SQLType): CallableStatementIO[Unit] =
-    F.liftF(RegisterOutParameter1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def registerOutParameter(a: Int, b: Int, c: Int): CallableStatementIO[Unit] =
-    F.liftF(RegisterOutParameter10(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def registerOutParameter(a: Int, b: Int): CallableStatementIO[Unit] =
-    F.liftF(RegisterOutParameter11(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def registerOutParameter(a: String, b: SQLType, c: Int): CallableStatementIO[Unit] =
-    F.liftF(RegisterOutParameter2(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def registerOutParameter(a: Int, b: SQLType, c: Int): CallableStatementIO[Unit] =
-    F.liftF(RegisterOutParameter3(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def registerOutParameter(a: Int, b: SQLType): CallableStatementIO[Unit] =
-    F.liftF(RegisterOutParameter4(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def registerOutParameter(a: String, b: SQLType, c: String): CallableStatementIO[Unit] =
-    F.liftF(RegisterOutParameter5(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def registerOutParameter(a: String, b: Int): CallableStatementIO[Unit] =
-    F.liftF(RegisterOutParameter6(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def registerOutParameter(a: String, b: Int, c: String): CallableStatementIO[Unit] =
-    F.liftF(RegisterOutParameter7(a, b, c))
+    F.liftF(RegisterOutParameter1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def registerOutParameter(a: String, b: Int, c: Int): CallableStatementIO[Unit] =
-    F.liftF(RegisterOutParameter8(a, b, c))
+    F.liftF(RegisterOutParameter2(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def registerOutParameter(a: Int, b: Int, c: String): CallableStatementIO[Unit] =
-    F.liftF(RegisterOutParameter9(a, b, c))
+  def registerOutParameter(a: String, b: Int): CallableStatementIO[Unit] =
+    F.liftF(RegisterOutParameter3(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def registerOutParameter(a: Int, b: Int, c: Int): CallableStatementIO[Unit] =
+    F.liftF(RegisterOutParameter4(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def registerOutParameter(a: Int, b: Int): CallableStatementIO[Unit] =
+    F.liftF(RegisterOutParameter5(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1647,13 +1505,13 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setAsciiStream(a: Int, b: InputStream, c: Int): CallableStatementIO[Unit] =
+  def setAsciiStream(a: Int, b: InputStream, c: Long): CallableStatementIO[Unit] =
     F.liftF(SetAsciiStream3(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setAsciiStream(a: Int, b: InputStream, c: Long): CallableStatementIO[Unit] =
+  def setAsciiStream(a: Int, b: InputStream, c: Int): CallableStatementIO[Unit] =
     F.liftF(SetAsciiStream4(a, b, c))
 
   /** 
@@ -1677,20 +1535,20 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setBinaryStream(a: String, b: InputStream, c: Int): CallableStatementIO[Unit] =
+  def setBinaryStream(a: String, b: InputStream, c: Long): CallableStatementIO[Unit] =
     F.liftF(SetBinaryStream(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setBinaryStream(a: String, b: InputStream): CallableStatementIO[Unit] =
-    F.liftF(SetBinaryStream1(a, b))
+  def setBinaryStream(a: String, b: InputStream, c: Int): CallableStatementIO[Unit] =
+    F.liftF(SetBinaryStream1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setBinaryStream(a: String, b: InputStream, c: Long): CallableStatementIO[Unit] =
-    F.liftF(SetBinaryStream2(a, b, c))
+  def setBinaryStream(a: String, b: InputStream): CallableStatementIO[Unit] =
+    F.liftF(SetBinaryStream2(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1713,14 +1571,14 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setBlob(a: String, b: InputStream, c: Long): CallableStatementIO[Unit] =
-    F.liftF(SetBlob(a, b, c))
+  def setBlob(a: String, b: Blob): CallableStatementIO[Unit] =
+    F.liftF(SetBlob(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setBlob(a: String, b: Blob): CallableStatementIO[Unit] =
-    F.liftF(SetBlob1(a, b))
+  def setBlob(a: String, b: InputStream, c: Long): CallableStatementIO[Unit] =
+    F.liftF(SetBlob1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -1731,14 +1589,14 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setBlob(a: Int, b: InputStream, c: Long): CallableStatementIO[Unit] =
-    F.liftF(SetBlob3(a, b, c))
+  def setBlob(a: Int, b: Blob): CallableStatementIO[Unit] =
+    F.liftF(SetBlob3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setBlob(a: Int, b: Blob): CallableStatementIO[Unit] =
-    F.liftF(SetBlob4(a, b))
+  def setBlob(a: Int, b: InputStream, c: Long): CallableStatementIO[Unit] =
+    F.liftF(SetBlob4(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -1785,8 +1643,8 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setCharacterStream(a: String, b: Reader, c: Int): CallableStatementIO[Unit] =
-    F.liftF(SetCharacterStream(a, b, c))
+  def setCharacterStream(a: String, b: Reader): CallableStatementIO[Unit] =
+    F.liftF(SetCharacterStream(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1797,25 +1655,25 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setCharacterStream(a: String, b: Reader): CallableStatementIO[Unit] =
-    F.liftF(SetCharacterStream2(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setCharacterStream(a: Int, b: Reader, c: Long): CallableStatementIO[Unit] =
-    F.liftF(SetCharacterStream3(a, b, c))
+  def setCharacterStream(a: String, b: Reader, c: Int): CallableStatementIO[Unit] =
+    F.liftF(SetCharacterStream2(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setCharacterStream(a: Int, b: Reader): CallableStatementIO[Unit] =
-    F.liftF(SetCharacterStream4(a, b))
+    F.liftF(SetCharacterStream3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setCharacterStream(a: Int, b: Reader, c: Int): CallableStatementIO[Unit] =
+    F.liftF(SetCharacterStream4(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setCharacterStream(a: Int, b: Reader, c: Long): CallableStatementIO[Unit] =
     F.liftF(SetCharacterStream5(a, b, c))
 
   /** 
@@ -1827,13 +1685,13 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setClob(a: String, b: Reader): CallableStatementIO[Unit] =
+  def setClob(a: String, b: Clob): CallableStatementIO[Unit] =
     F.liftF(SetClob1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setClob(a: String, b: Clob): CallableStatementIO[Unit] =
+  def setClob(a: String, b: Reader): CallableStatementIO[Unit] =
     F.liftF(SetClob2(a, b))
 
   /** 
@@ -1863,26 +1721,26 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setDate(a: String, b: Date, c: Calendar): CallableStatementIO[Unit] =
-    F.liftF(SetDate(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def setDate(a: String, b: Date): CallableStatementIO[Unit] =
-    F.liftF(SetDate1(a, b))
+    F.liftF(SetDate(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setDate(a: Int, b: Date, c: Calendar): CallableStatementIO[Unit] =
-    F.liftF(SetDate2(a, b, c))
+  def setDate(a: String, b: Date, c: Calendar): CallableStatementIO[Unit] =
+    F.liftF(SetDate1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setDate(a: Int, b: Date): CallableStatementIO[Unit] =
-    F.liftF(SetDate3(a, b))
+    F.liftF(SetDate2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setDate(a: Int, b: Date, c: Calendar): CallableStatementIO[Unit] =
+    F.liftF(SetDate3(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -1941,12 +1799,6 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setLargeMaxRows(a: Long): CallableStatementIO[Unit] =
-    F.liftF(SetLargeMaxRows(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def setLong(a: String, b: Long): CallableStatementIO[Unit] =
     F.liftF(SetLong(a, b))
 
@@ -1995,8 +1847,8 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setNClob(a: String, b: Reader, c: Long): CallableStatementIO[Unit] =
-    F.liftF(SetNClob(a, b, c))
+  def setNClob(a: String, b: Reader): CallableStatementIO[Unit] =
+    F.liftF(SetNClob(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -2007,20 +1859,20 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setNClob(a: String, b: Reader): CallableStatementIO[Unit] =
-    F.liftF(SetNClob2(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setNClob(a: Int, b: NClob): CallableStatementIO[Unit] =
-    F.liftF(SetNClob3(a, b))
+  def setNClob(a: String, b: Reader, c: Long): CallableStatementIO[Unit] =
+    F.liftF(SetNClob2(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNClob(a: Int, b: Reader, c: Long): CallableStatementIO[Unit] =
-    F.liftF(SetNClob4(a, b, c))
+    F.liftF(SetNClob3(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setNClob(a: Int, b: NClob): CallableStatementIO[Unit] =
+    F.liftF(SetNClob4(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -2043,14 +1895,14 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setNull(a: String, b: Int): CallableStatementIO[Unit] =
-    F.liftF(SetNull(a, b))
+  def setNull(a: String, b: Int, c: String): CallableStatementIO[Unit] =
+    F.liftF(SetNull(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setNull(a: String, b: Int, c: String): CallableStatementIO[Unit] =
-    F.liftF(SetNull1(a, b, c))
+  def setNull(a: String, b: Int): CallableStatementIO[Unit] =
+    F.liftF(SetNull1(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -2067,62 +1919,38 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
+  def setObject(a: String, b: Object, c: Int): CallableStatementIO[Unit] =
+    F.liftF(SetObject(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
   def setObject(a: String, b: Object): CallableStatementIO[Unit] =
-    F.liftF(SetObject(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setObject(a: String, b: Object, c: SQLType): CallableStatementIO[Unit] =
-    F.liftF(SetObject1(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setObject(a: String, b: Object, c: SQLType, d: Int): CallableStatementIO[Unit] =
-    F.liftF(SetObject2(a, b, c, d))
+    F.liftF(SetObject1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setObject(a: String, b: Object, c: Int, d: Int): CallableStatementIO[Unit] =
-    F.liftF(SetObject3(a, b, c, d))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setObject(a: String, b: Object, c: Int): CallableStatementIO[Unit] =
-    F.liftF(SetObject4(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setObject(a: Int, b: Object, c: SQLType, d: Int): CallableStatementIO[Unit] =
-    F.liftF(SetObject5(a, b, c, d))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setObject(a: Int, b: Object, c: SQLType): CallableStatementIO[Unit] =
-    F.liftF(SetObject6(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setObject(a: Int, b: Object, c: Int): CallableStatementIO[Unit] =
-    F.liftF(SetObject7(a, b, c))
+    F.liftF(SetObject2(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setObject(a: Int, b: Object, c: Int, d: Int): CallableStatementIO[Unit] =
-    F.liftF(SetObject8(a, b, c, d))
+    F.liftF(SetObject3(a, b, c, d))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setObject(a: Int, b: Object, c: Int): CallableStatementIO[Unit] =
+    F.liftF(SetObject4(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setObject(a: Int, b: Object): CallableStatementIO[Unit] =
-    F.liftF(SetObject9(a, b))
+    F.liftF(SetObject5(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -2193,14 +2021,14 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setTime(a: String, b: Time, c: Calendar): CallableStatementIO[Unit] =
-    F.liftF(SetTime(a, b, c))
+  def setTime(a: String, b: Time): CallableStatementIO[Unit] =
+    F.liftF(SetTime(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setTime(a: String, b: Time): CallableStatementIO[Unit] =
-    F.liftF(SetTime1(a, b))
+  def setTime(a: String, b: Time, c: Calendar): CallableStatementIO[Unit] =
+    F.liftF(SetTime1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -2217,14 +2045,14 @@ object callablestatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setTimestamp(a: String, b: Timestamp): CallableStatementIO[Unit] =
-    F.liftF(SetTimestamp(a, b))
+  def setTimestamp(a: String, b: Timestamp, c: Calendar): CallableStatementIO[Unit] =
+    F.liftF(SetTimestamp(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setTimestamp(a: String, b: Timestamp, c: Calendar): CallableStatementIO[Unit] =
-    F.liftF(SetTimestamp1(a, b, c))
+  def setTimestamp(a: String, b: Timestamp): CallableStatementIO[Unit] =
+    F.liftF(SetTimestamp1(a, b))
 
   /** 
    * @group Constructors (Primitives)

--- a/core/src/main/scala/doobie/free/clob.scala
+++ b/core/src/main/scala/doobie/free/clob.scala
@@ -49,7 +49,7 @@ import resultset.ResultSetIO
  *
  * `ClobIO` is a free monad that must be run via an interpreter, most commonly via
  * natural transformation of its underlying algebra `ClobOp` to another monad via
- * `Free.runFC`. 
+ * `Free#foldMap`.
  *
  * The library provides a natural transformation to `Kleisli[M, Clob, A]` for any
  * exception-trapping (`Catchable`) and effect-capturing (`Capture`) monad `M`. Such evidence is 
@@ -123,11 +123,11 @@ object clob {
     case object GetAsciiStream extends ClobOp[InputStream] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getAsciiStream())
     }
-    case class  GetCharacterStream(a: Long, b: Long) extends ClobOp[Reader] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getCharacterStream(a, b))
-    }
-    case object GetCharacterStream1 extends ClobOp[Reader] {
+    case object GetCharacterStream extends ClobOp[Reader] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getCharacterStream())
+    }
+    case class  GetCharacterStream1(a: Long, b: Long) extends ClobOp[Reader] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getCharacterStream(a, b))
     }
     case class  GetSubString(a: Long, b: Int) extends ClobOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSubString(a, b))
@@ -147,11 +147,11 @@ object clob {
     case class  SetCharacterStream(a: Long) extends ClobOp[Writer] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a))
     }
-    case class  SetString(a: Long, b: String) extends ClobOp[Int] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setString(a, b))
-    }
-    case class  SetString1(a: Long, b: String, c: Int, d: Int) extends ClobOp[Int] {
+    case class  SetString(a: Long, b: String, c: Int, d: Int) extends ClobOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setString(a, b, c, d))
+    }
+    case class  SetString1(a: Long, b: String) extends ClobOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setString(a, b))
     }
     case class  Truncate(a: Long) extends ClobOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.truncate(a))
@@ -229,14 +229,14 @@ object clob {
   /** 
    * @group Constructors (Primitives)
    */
-  def getCharacterStream(a: Long, b: Long): ClobIO[Reader] =
-    F.liftF(GetCharacterStream(a, b))
+  val getCharacterStream: ClobIO[Reader] =
+    F.liftF(GetCharacterStream)
 
   /** 
    * @group Constructors (Primitives)
    */
-  val getCharacterStream: ClobIO[Reader] =
-    F.liftF(GetCharacterStream1)
+  def getCharacterStream(a: Long, b: Long): ClobIO[Reader] =
+    F.liftF(GetCharacterStream1(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -277,14 +277,14 @@ object clob {
   /** 
    * @group Constructors (Primitives)
    */
-  def setString(a: Long, b: String): ClobIO[Int] =
-    F.liftF(SetString(a, b))
+  def setString(a: Long, b: String, c: Int, d: Int): ClobIO[Int] =
+    F.liftF(SetString(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setString(a: Long, b: String, c: Int, d: Int): ClobIO[Int] =
-    F.liftF(SetString1(a, b, c, d))
+  def setString(a: Long, b: String): ClobIO[Int] =
+    F.liftF(SetString1(a, b))
 
   /** 
    * @group Constructors (Primitives)

--- a/core/src/main/scala/doobie/free/clob.scala
+++ b/core/src/main/scala/doobie/free/clob.scala
@@ -1,6 +1,6 @@
 package doobie.free
 
-import scalaz.{ Catchable, Coyoneda, Free => F, Kleisli, Monad, ~>, \/ }
+import scalaz.{ Catchable, Free => F, Kleisli, Monad, ~>, \/ }
 import scalaz.concurrent.Task
 
 import doobie.util.capture._
@@ -99,7 +99,7 @@ object clob {
       }
 
     // Lifting
-    case class Lift[Op[_], A, J](j: J, action: F.FreeC[Op, A], mod: KleisliTrans.Aux[Op, J]) extends ClobOp[A] {
+    case class Lift[Op[_], A, J](j: J, action: F[Op, A], mod: KleisliTrans.Aux[Op, J]) extends ClobOp[A] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => mod.transK[M].apply(action).run(j))
     }
 
@@ -165,14 +165,7 @@ object clob {
    * a `java.sql.Clob` and produces a value of type `A`. 
    * @group Algebra 
    */
-  type ClobIO[A] = F.FreeC[ClobOp, A]
-
-  /**
-   * Monad instance for [[ClobIO]] (can't be inferred).
-   * @group Typeclass Instances 
-   */
-  implicit val MonadClobIO: Monad[ClobIO] = 
-    F.freeMonad[({type λ[α] = Coyoneda[ClobOp, α]})#λ]
+  type ClobIO[A] = F[ClobOp, A]
 
   /**
    * Catchable instance for [[ClobIO]].
@@ -197,107 +190,107 @@ object clob {
    * Lift a different type of program that has a default Kleisli interpreter.
    * @group Constructors (Lifting)
    */
-  def lift[Op[_], A, J](j: J, action: F.FreeC[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): ClobIO[A] =
-    F.liftFC(Lift(j, action, mod))
+  def lift[Op[_], A, J](j: J, action: F[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): ClobIO[A] =
+    F.liftF(Lift(j, action, mod))
 
   /** 
    * Lift a ClobIO[A] into an exception-capturing ClobIO[Throwable \/ A].
    * @group Constructors (Lifting)
    */
   def attempt[A](a: ClobIO[A]): ClobIO[Throwable \/ A] =
-    F.liftFC[ClobOp, Throwable \/ A](Attempt(a))
+    F.liftF[ClobOp, Throwable \/ A](Attempt(a))
  
   /**
    * Non-strict unit for capturing effects.
    * @group Constructors (Lifting)
    */
   def delay[A](a: => A): ClobIO[A] =
-    F.liftFC(Pure(a _))
+    F.liftF(Pure(a _))
 
   /**
    * Backdoor for arbitrary computations on the underlying Clob.
    * @group Constructors (Lifting)
    */
   def raw[A](f: Clob => A): ClobIO[A] =
-    F.liftFC(Raw(f))
+    F.liftF(Raw(f))
 
   /** 
    * @group Constructors (Primitives)
    */
   val free: ClobIO[Unit] =
-    F.liftFC(Free)
+    F.liftF(Free)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getAsciiStream: ClobIO[InputStream] =
-    F.liftFC(GetAsciiStream)
+    F.liftF(GetAsciiStream)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getCharacterStream(a: Long, b: Long): ClobIO[Reader] =
-    F.liftFC(GetCharacterStream(a, b))
+    F.liftF(GetCharacterStream(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getCharacterStream: ClobIO[Reader] =
-    F.liftFC(GetCharacterStream1)
+    F.liftF(GetCharacterStream1)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getSubString(a: Long, b: Int): ClobIO[String] =
-    F.liftFC(GetSubString(a, b))
+    F.liftF(GetSubString(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   val length: ClobIO[Long] =
-    F.liftFC(Length)
+    F.liftF(Length)
 
   /** 
    * @group Constructors (Primitives)
    */
   def position(a: Clob, b: Long): ClobIO[Long] =
-    F.liftFC(Position(a, b))
+    F.liftF(Position(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def position(a: String, b: Long): ClobIO[Long] =
-    F.liftFC(Position1(a, b))
+    F.liftF(Position1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setAsciiStream(a: Long): ClobIO[OutputStream] =
-    F.liftFC(SetAsciiStream(a))
+    F.liftF(SetAsciiStream(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setCharacterStream(a: Long): ClobIO[Writer] =
-    F.liftFC(SetCharacterStream(a))
+    F.liftF(SetCharacterStream(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setString(a: Long, b: String): ClobIO[Int] =
-    F.liftFC(SetString(a, b))
+    F.liftF(SetString(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setString(a: Long, b: String, c: Int, d: Int): ClobIO[Int] =
-    F.liftFC(SetString1(a, b, c, d))
+    F.liftF(SetString1(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
   def truncate(a: Long): ClobIO[Unit] =
-    F.liftFC(Truncate(a))
+    F.liftF(Truncate(a))
 
  /** 
   * Natural transformation from `ClobOp` to `Kleisli` for the given `M`, consuming a `java.sql.Clob`. 

--- a/core/src/main/scala/doobie/free/connection.scala
+++ b/core/src/main/scala/doobie/free/connection.scala
@@ -55,7 +55,7 @@ import resultset.ResultSetIO
  *
  * `ConnectionIO` is a free monad that must be run via an interpreter, most commonly via
  * natural transformation of its underlying algebra `ConnectionOp` to another monad via
- * `Free.runFC`. 
+ * `Free#foldMap`.
  *
  * The library provides a natural transformation to `Kleisli[M, Connection, A]` for any
  * exception-trapping (`Catchable`) and effect-capturing (`Capture`) monad `M`. Such evidence is 
@@ -153,11 +153,11 @@ object connection {
     case class  CreateStatement(a: Int, b: Int) extends ConnectionOp[Statement] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.createStatement(a, b))
     }
-    case class  CreateStatement1(a: Int, b: Int, c: Int) extends ConnectionOp[Statement] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.createStatement(a, b, c))
-    }
-    case object CreateStatement2 extends ConnectionOp[Statement] {
+    case object CreateStatement1 extends ConnectionOp[Statement] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.createStatement())
+    }
+    case class  CreateStatement2(a: Int, b: Int, c: Int) extends ConnectionOp[Statement] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.createStatement(a, b, c))
     }
     case class  CreateStruct(a: String, b: Array[Object]) extends ConnectionOp[Struct] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.createStruct(a, b))
@@ -210,41 +210,41 @@ object connection {
     case class  NativeSQL(a: String) extends ConnectionOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.nativeSQL(a))
     }
-    case class  PrepareCall(a: String) extends ConnectionOp[CallableStatement] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareCall(a))
-    }
-    case class  PrepareCall1(a: String, b: Int, c: Int, d: Int) extends ConnectionOp[CallableStatement] {
+    case class  PrepareCall(a: String, b: Int, c: Int, d: Int) extends ConnectionOp[CallableStatement] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareCall(a, b, c, d))
     }
-    case class  PrepareCall2(a: String, b: Int, c: Int) extends ConnectionOp[CallableStatement] {
+    case class  PrepareCall1(a: String, b: Int, c: Int) extends ConnectionOp[CallableStatement] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareCall(a, b, c))
+    }
+    case class  PrepareCall2(a: String) extends ConnectionOp[CallableStatement] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareCall(a))
     }
     case class  PrepareStatement(a: String, b: Int) extends ConnectionOp[PreparedStatement] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a, b))
     }
-    case class  PrepareStatement1(a: String, b: Array[Int]) extends ConnectionOp[PreparedStatement] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a, b))
-    }
-    case class  PrepareStatement2(a: String) extends ConnectionOp[PreparedStatement] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a))
-    }
-    case class  PrepareStatement3(a: String, b: Int, c: Int, d: Int) extends ConnectionOp[PreparedStatement] {
+    case class  PrepareStatement1(a: String, b: Int, c: Int, d: Int) extends ConnectionOp[PreparedStatement] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a, b, c, d))
     }
-    case class  PrepareStatement4(a: String, b: Int, c: Int) extends ConnectionOp[PreparedStatement] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a, b, c))
-    }
-    case class  PrepareStatement5(a: String, b: Array[String]) extends ConnectionOp[PreparedStatement] {
+    case class  PrepareStatement2(a: String, b: Array[Int]) extends ConnectionOp[PreparedStatement] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a, b))
+    }
+    case class  PrepareStatement3(a: String, b: Array[String]) extends ConnectionOp[PreparedStatement] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a, b))
+    }
+    case class  PrepareStatement4(a: String) extends ConnectionOp[PreparedStatement] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a))
+    }
+    case class  PrepareStatement5(a: String, b: Int, c: Int) extends ConnectionOp[PreparedStatement] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a, b, c))
     }
     case class  ReleaseSavepoint(a: Savepoint) extends ConnectionOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.releaseSavepoint(a))
     }
-    case class  Rollback(a: Savepoint) extends ConnectionOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.rollback(a))
-    }
-    case object Rollback1 extends ConnectionOp[Unit] {
+    case object Rollback extends ConnectionOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.rollback())
+    }
+    case class  Rollback1(a: Savepoint) extends ConnectionOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.rollback(a))
     }
     case class  SetAutoCommit(a: Boolean) extends ConnectionOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAutoCommit(a))
@@ -267,11 +267,11 @@ object connection {
     case class  SetReadOnly(a: Boolean) extends ConnectionOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setReadOnly(a))
     }
-    case object SetSavepoint extends ConnectionOp[Savepoint] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setSavepoint())
-    }
-    case class  SetSavepoint1(a: String) extends ConnectionOp[Savepoint] {
+    case class  SetSavepoint(a: String) extends ConnectionOp[Savepoint] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setSavepoint(a))
+    }
+    case object SetSavepoint1 extends ConnectionOp[Savepoint] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setSavepoint())
     }
     case class  SetSchema(a: String) extends ConnectionOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setSchema(a))
@@ -406,14 +406,14 @@ object connection {
   /** 
    * @group Constructors (Primitives)
    */
-  def createStatement(a: Int, b: Int, c: Int): ConnectionIO[Statement] =
-    F.liftF(CreateStatement1(a, b, c))
+  val createStatement: ConnectionIO[Statement] =
+    F.liftF(CreateStatement1)
 
   /** 
    * @group Constructors (Primitives)
    */
-  val createStatement: ConnectionIO[Statement] =
-    F.liftF(CreateStatement2)
+  def createStatement(a: Int, b: Int, c: Int): ConnectionIO[Statement] =
+    F.liftF(CreateStatement2(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -520,20 +520,20 @@ object connection {
   /** 
    * @group Constructors (Primitives)
    */
-  def prepareCall(a: String): ConnectionIO[CallableStatement] =
-    F.liftF(PrepareCall(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def prepareCall(a: String, b: Int, c: Int, d: Int): ConnectionIO[CallableStatement] =
-    F.liftF(PrepareCall1(a, b, c, d))
+    F.liftF(PrepareCall(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
   def prepareCall(a: String, b: Int, c: Int): ConnectionIO[CallableStatement] =
-    F.liftF(PrepareCall2(a, b, c))
+    F.liftF(PrepareCall1(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def prepareCall(a: String): ConnectionIO[CallableStatement] =
+    F.liftF(PrepareCall2(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -544,32 +544,32 @@ object connection {
   /** 
    * @group Constructors (Primitives)
    */
-  def prepareStatement(a: String, b: Array[Int]): ConnectionIO[PreparedStatement] =
-    F.liftF(PrepareStatement1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def prepareStatement(a: String): ConnectionIO[PreparedStatement] =
-    F.liftF(PrepareStatement2(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def prepareStatement(a: String, b: Int, c: Int, d: Int): ConnectionIO[PreparedStatement] =
-    F.liftF(PrepareStatement3(a, b, c, d))
+    F.liftF(PrepareStatement1(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def prepareStatement(a: String, b: Int, c: Int): ConnectionIO[PreparedStatement] =
-    F.liftF(PrepareStatement4(a, b, c))
+  def prepareStatement(a: String, b: Array[Int]): ConnectionIO[PreparedStatement] =
+    F.liftF(PrepareStatement2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def prepareStatement(a: String, b: Array[String]): ConnectionIO[PreparedStatement] =
-    F.liftF(PrepareStatement5(a, b))
+    F.liftF(PrepareStatement3(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def prepareStatement(a: String): ConnectionIO[PreparedStatement] =
+    F.liftF(PrepareStatement4(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def prepareStatement(a: String, b: Int, c: Int): ConnectionIO[PreparedStatement] =
+    F.liftF(PrepareStatement5(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -580,14 +580,14 @@ object connection {
   /** 
    * @group Constructors (Primitives)
    */
-  def rollback(a: Savepoint): ConnectionIO[Unit] =
-    F.liftF(Rollback(a))
+  val rollback: ConnectionIO[Unit] =
+    F.liftF(Rollback)
 
   /** 
    * @group Constructors (Primitives)
    */
-  val rollback: ConnectionIO[Unit] =
-    F.liftF(Rollback1)
+  def rollback(a: Savepoint): ConnectionIO[Unit] =
+    F.liftF(Rollback1(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -634,14 +634,14 @@ object connection {
   /** 
    * @group Constructors (Primitives)
    */
-  val setSavepoint: ConnectionIO[Savepoint] =
-    F.liftF(SetSavepoint)
+  def setSavepoint(a: String): ConnectionIO[Savepoint] =
+    F.liftF(SetSavepoint(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setSavepoint(a: String): ConnectionIO[Savepoint] =
-    F.liftF(SetSavepoint1(a))
+  val setSavepoint: ConnectionIO[Savepoint] =
+    F.liftF(SetSavepoint1)
 
   /** 
    * @group Constructors (Primitives)

--- a/core/src/main/scala/doobie/free/connection.scala
+++ b/core/src/main/scala/doobie/free/connection.scala
@@ -1,6 +1,6 @@
 package doobie.free
 
-import scalaz.{ Catchable, Coyoneda, Free => F, Kleisli, Monad, ~>, \/ }
+import scalaz.{ Catchable, Free => F, Kleisli, Monad, ~>, \/ }
 import scalaz.concurrent.Task
 
 import doobie.util.capture._
@@ -105,7 +105,7 @@ object connection {
       }
 
     // Lifting
-    case class Lift[Op[_], A, J](j: J, action: F.FreeC[Op, A], mod: KleisliTrans.Aux[Op, J]) extends ConnectionOp[A] {
+    case class Lift[Op[_], A, J](j: J, action: F[Op, A], mod: KleisliTrans.Aux[Op, J]) extends ConnectionOp[A] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => mod.transK[M].apply(action).run(j))
     }
 
@@ -150,14 +150,14 @@ object connection {
     case object CreateSQLXML extends ConnectionOp[SQLXML] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.createSQLXML())
     }
-    case object CreateStatement extends ConnectionOp[Statement] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.createStatement())
-    }
-    case class  CreateStatement1(a: Int, b: Int) extends ConnectionOp[Statement] {
+    case class  CreateStatement(a: Int, b: Int) extends ConnectionOp[Statement] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.createStatement(a, b))
     }
-    case class  CreateStatement2(a: Int, b: Int, c: Int) extends ConnectionOp[Statement] {
+    case class  CreateStatement1(a: Int, b: Int, c: Int) extends ConnectionOp[Statement] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.createStatement(a, b, c))
+    }
+    case object CreateStatement2 extends ConnectionOp[Statement] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.createStatement())
     }
     case class  CreateStruct(a: String, b: Array[Object]) extends ConnectionOp[Struct] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.createStruct(a, b))
@@ -168,11 +168,11 @@ object connection {
     case object GetCatalog extends ConnectionOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getCatalog())
     }
-    case object GetClientInfo extends ConnectionOp[Properties] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getClientInfo())
-    }
-    case class  GetClientInfo1(a: String) extends ConnectionOp[String] {
+    case class  GetClientInfo(a: String) extends ConnectionOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getClientInfo(a))
+    }
+    case object GetClientInfo1 extends ConnectionOp[Properties] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getClientInfo())
     }
     case object GetHoldability extends ConnectionOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getHoldability())
@@ -210,31 +210,31 @@ object connection {
     case class  NativeSQL(a: String) extends ConnectionOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.nativeSQL(a))
     }
-    case class  PrepareCall(a: String, b: Int, c: Int, d: Int) extends ConnectionOp[CallableStatement] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareCall(a, b, c, d))
-    }
-    case class  PrepareCall1(a: String, b: Int, c: Int) extends ConnectionOp[CallableStatement] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareCall(a, b, c))
-    }
-    case class  PrepareCall2(a: String) extends ConnectionOp[CallableStatement] {
+    case class  PrepareCall(a: String) extends ConnectionOp[CallableStatement] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareCall(a))
     }
-    case class  PrepareStatement(a: String, b: Array[String]) extends ConnectionOp[PreparedStatement] {
+    case class  PrepareCall1(a: String, b: Int, c: Int, d: Int) extends ConnectionOp[CallableStatement] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareCall(a, b, c, d))
+    }
+    case class  PrepareCall2(a: String, b: Int, c: Int) extends ConnectionOp[CallableStatement] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareCall(a, b, c))
+    }
+    case class  PrepareStatement(a: String, b: Int) extends ConnectionOp[PreparedStatement] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a, b))
     }
-    case class  PrepareStatement1(a: String, b: Int, c: Int, d: Int) extends ConnectionOp[PreparedStatement] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a, b, c, d))
+    case class  PrepareStatement1(a: String, b: Array[Int]) extends ConnectionOp[PreparedStatement] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a, b))
     }
-    case class  PrepareStatement2(a: String, b: Int, c: Int) extends ConnectionOp[PreparedStatement] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a, b, c))
-    }
-    case class  PrepareStatement3(a: String) extends ConnectionOp[PreparedStatement] {
+    case class  PrepareStatement2(a: String) extends ConnectionOp[PreparedStatement] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a))
     }
-    case class  PrepareStatement4(a: String, b: Array[Int]) extends ConnectionOp[PreparedStatement] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a, b))
+    case class  PrepareStatement3(a: String, b: Int, c: Int, d: Int) extends ConnectionOp[PreparedStatement] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a, b, c, d))
     }
-    case class  PrepareStatement5(a: String, b: Int) extends ConnectionOp[PreparedStatement] {
+    case class  PrepareStatement4(a: String, b: Int, c: Int) extends ConnectionOp[PreparedStatement] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a, b, c))
+    }
+    case class  PrepareStatement5(a: String, b: Array[String]) extends ConnectionOp[PreparedStatement] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.prepareStatement(a, b))
     }
     case class  ReleaseSavepoint(a: Savepoint) extends ConnectionOp[Unit] {
@@ -252,11 +252,11 @@ object connection {
     case class  SetCatalog(a: String) extends ConnectionOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCatalog(a))
     }
-    case class  SetClientInfo(a: String, b: String) extends ConnectionOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClientInfo(a, b))
-    }
-    case class  SetClientInfo1(a: Properties) extends ConnectionOp[Unit] {
+    case class  SetClientInfo(a: Properties) extends ConnectionOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClientInfo(a))
+    }
+    case class  SetClientInfo1(a: String, b: String) extends ConnectionOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClientInfo(a, b))
     }
     case class  SetHoldability(a: Int) extends ConnectionOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setHoldability(a))
@@ -294,14 +294,7 @@ object connection {
    * a `java.sql.Connection` and produces a value of type `A`. 
    * @group Algebra 
    */
-  type ConnectionIO[A] = F.FreeC[ConnectionOp, A]
-
-  /**
-   * Monad instance for [[ConnectionIO]] (can't be inferred).
-   * @group Typeclass Instances 
-   */
-  implicit val MonadConnectionIO: Monad[ConnectionIO] = 
-    F.freeMonad[({type λ[α] = Coyoneda[ConnectionOp, α]})#λ]
+  type ConnectionIO[A] = F[ConnectionOp, A]
 
   /**
    * Catchable instance for [[ConnectionIO]].
@@ -326,353 +319,353 @@ object connection {
    * Lift a different type of program that has a default Kleisli interpreter.
    * @group Constructors (Lifting)
    */
-  def lift[Op[_], A, J](j: J, action: F.FreeC[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): ConnectionIO[A] =
-    F.liftFC(Lift(j, action, mod))
+  def lift[Op[_], A, J](j: J, action: F[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): ConnectionIO[A] =
+    F.liftF(Lift(j, action, mod))
 
   /** 
    * Lift a ConnectionIO[A] into an exception-capturing ConnectionIO[Throwable \/ A].
    * @group Constructors (Lifting)
    */
   def attempt[A](a: ConnectionIO[A]): ConnectionIO[Throwable \/ A] =
-    F.liftFC[ConnectionOp, Throwable \/ A](Attempt(a))
+    F.liftF[ConnectionOp, Throwable \/ A](Attempt(a))
  
   /**
    * Non-strict unit for capturing effects.
    * @group Constructors (Lifting)
    */
   def delay[A](a: => A): ConnectionIO[A] =
-    F.liftFC(Pure(a _))
+    F.liftF(Pure(a _))
 
   /**
    * Backdoor for arbitrary computations on the underlying Connection.
    * @group Constructors (Lifting)
    */
   def raw[A](f: Connection => A): ConnectionIO[A] =
-    F.liftFC(Raw(f))
+    F.liftF(Raw(f))
 
   /** 
    * @group Constructors (Primitives)
    */
   def abort(a: Executor): ConnectionIO[Unit] =
-    F.liftFC(Abort(a))
+    F.liftF(Abort(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val clearWarnings: ConnectionIO[Unit] =
-    F.liftFC(ClearWarnings)
+    F.liftF(ClearWarnings)
 
   /** 
    * @group Constructors (Primitives)
    */
   val close: ConnectionIO[Unit] =
-    F.liftFC(Close)
+    F.liftF(Close)
 
   /** 
    * @group Constructors (Primitives)
    */
   val commit: ConnectionIO[Unit] =
-    F.liftFC(Commit)
+    F.liftF(Commit)
 
   /** 
    * @group Constructors (Primitives)
    */
   def createArrayOf(a: String, b: Array[Object]): ConnectionIO[SqlArray] =
-    F.liftFC(CreateArrayOf(a, b))
+    F.liftF(CreateArrayOf(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   val createBlob: ConnectionIO[Blob] =
-    F.liftFC(CreateBlob)
+    F.liftF(CreateBlob)
 
   /** 
    * @group Constructors (Primitives)
    */
   val createClob: ConnectionIO[Clob] =
-    F.liftFC(CreateClob)
+    F.liftF(CreateClob)
 
   /** 
    * @group Constructors (Primitives)
    */
   val createNClob: ConnectionIO[NClob] =
-    F.liftFC(CreateNClob)
+    F.liftF(CreateNClob)
 
   /** 
    * @group Constructors (Primitives)
    */
   val createSQLXML: ConnectionIO[SQLXML] =
-    F.liftFC(CreateSQLXML)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val createStatement: ConnectionIO[Statement] =
-    F.liftFC(CreateStatement)
+    F.liftF(CreateSQLXML)
 
   /** 
    * @group Constructors (Primitives)
    */
   def createStatement(a: Int, b: Int): ConnectionIO[Statement] =
-    F.liftFC(CreateStatement1(a, b))
+    F.liftF(CreateStatement(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def createStatement(a: Int, b: Int, c: Int): ConnectionIO[Statement] =
-    F.liftFC(CreateStatement2(a, b, c))
+    F.liftF(CreateStatement1(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val createStatement: ConnectionIO[Statement] =
+    F.liftF(CreateStatement2)
 
   /** 
    * @group Constructors (Primitives)
    */
   def createStruct(a: String, b: Array[Object]): ConnectionIO[Struct] =
-    F.liftFC(CreateStruct(a, b))
+    F.liftF(CreateStruct(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getAutoCommit: ConnectionIO[Boolean] =
-    F.liftFC(GetAutoCommit)
+    F.liftF(GetAutoCommit)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getCatalog: ConnectionIO[String] =
-    F.liftFC(GetCatalog)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val getClientInfo: ConnectionIO[Properties] =
-    F.liftFC(GetClientInfo)
+    F.liftF(GetCatalog)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getClientInfo(a: String): ConnectionIO[String] =
-    F.liftFC(GetClientInfo1(a))
+    F.liftF(GetClientInfo(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val getClientInfo: ConnectionIO[Properties] =
+    F.liftF(GetClientInfo1)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getHoldability: ConnectionIO[Int] =
-    F.liftFC(GetHoldability)
+    F.liftF(GetHoldability)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMetaData: ConnectionIO[DatabaseMetaData] =
-    F.liftFC(GetMetaData)
+    F.liftF(GetMetaData)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getNetworkTimeout: ConnectionIO[Int] =
-    F.liftFC(GetNetworkTimeout)
+    F.liftF(GetNetworkTimeout)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getSchema: ConnectionIO[String] =
-    F.liftFC(GetSchema)
+    F.liftF(GetSchema)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getTransactionIsolation: ConnectionIO[Int] =
-    F.liftFC(GetTransactionIsolation)
+    F.liftF(GetTransactionIsolation)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getTypeMap: ConnectionIO[Map[String, Class[_]]] =
-    F.liftFC(GetTypeMap)
+    F.liftF(GetTypeMap)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getWarnings: ConnectionIO[SQLWarning] =
-    F.liftFC(GetWarnings)
+    F.liftF(GetWarnings)
 
   /** 
    * @group Constructors (Primitives)
    */
   val isClosed: ConnectionIO[Boolean] =
-    F.liftFC(IsClosed)
+    F.liftF(IsClosed)
 
   /** 
    * @group Constructors (Primitives)
    */
   val isReadOnly: ConnectionIO[Boolean] =
-    F.liftFC(IsReadOnly)
+    F.liftF(IsReadOnly)
 
   /** 
    * @group Constructors (Primitives)
    */
   def isValid(a: Int): ConnectionIO[Boolean] =
-    F.liftFC(IsValid(a))
+    F.liftF(IsValid(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def isWrapperFor(a: Class[_]): ConnectionIO[Boolean] =
-    F.liftFC(IsWrapperFor(a))
+    F.liftF(IsWrapperFor(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def nativeSQL(a: String): ConnectionIO[String] =
-    F.liftFC(NativeSQL(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def prepareCall(a: String, b: Int, c: Int, d: Int): ConnectionIO[CallableStatement] =
-    F.liftFC(PrepareCall(a, b, c, d))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def prepareCall(a: String, b: Int, c: Int): ConnectionIO[CallableStatement] =
-    F.liftFC(PrepareCall1(a, b, c))
+    F.liftF(NativeSQL(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def prepareCall(a: String): ConnectionIO[CallableStatement] =
-    F.liftFC(PrepareCall2(a))
+    F.liftF(PrepareCall(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def prepareStatement(a: String, b: Array[String]): ConnectionIO[PreparedStatement] =
-    F.liftFC(PrepareStatement(a, b))
+  def prepareCall(a: String, b: Int, c: Int, d: Int): ConnectionIO[CallableStatement] =
+    F.liftF(PrepareCall1(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def prepareStatement(a: String, b: Int, c: Int, d: Int): ConnectionIO[PreparedStatement] =
-    F.liftFC(PrepareStatement1(a, b, c, d))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def prepareStatement(a: String, b: Int, c: Int): ConnectionIO[PreparedStatement] =
-    F.liftFC(PrepareStatement2(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def prepareStatement(a: String): ConnectionIO[PreparedStatement] =
-    F.liftFC(PrepareStatement3(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def prepareStatement(a: String, b: Array[Int]): ConnectionIO[PreparedStatement] =
-    F.liftFC(PrepareStatement4(a, b))
+  def prepareCall(a: String, b: Int, c: Int): ConnectionIO[CallableStatement] =
+    F.liftF(PrepareCall2(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def prepareStatement(a: String, b: Int): ConnectionIO[PreparedStatement] =
-    F.liftFC(PrepareStatement5(a, b))
+    F.liftF(PrepareStatement(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def prepareStatement(a: String, b: Array[Int]): ConnectionIO[PreparedStatement] =
+    F.liftF(PrepareStatement1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def prepareStatement(a: String): ConnectionIO[PreparedStatement] =
+    F.liftF(PrepareStatement2(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def prepareStatement(a: String, b: Int, c: Int, d: Int): ConnectionIO[PreparedStatement] =
+    F.liftF(PrepareStatement3(a, b, c, d))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def prepareStatement(a: String, b: Int, c: Int): ConnectionIO[PreparedStatement] =
+    F.liftF(PrepareStatement4(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def prepareStatement(a: String, b: Array[String]): ConnectionIO[PreparedStatement] =
+    F.liftF(PrepareStatement5(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def releaseSavepoint(a: Savepoint): ConnectionIO[Unit] =
-    F.liftFC(ReleaseSavepoint(a))
+    F.liftF(ReleaseSavepoint(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def rollback(a: Savepoint): ConnectionIO[Unit] =
-    F.liftFC(Rollback(a))
+    F.liftF(Rollback(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val rollback: ConnectionIO[Unit] =
-    F.liftFC(Rollback1)
+    F.liftF(Rollback1)
 
   /** 
    * @group Constructors (Primitives)
    */
   def setAutoCommit(a: Boolean): ConnectionIO[Unit] =
-    F.liftFC(SetAutoCommit(a))
+    F.liftF(SetAutoCommit(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setCatalog(a: String): ConnectionIO[Unit] =
-    F.liftFC(SetCatalog(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setClientInfo(a: String, b: String): ConnectionIO[Unit] =
-    F.liftFC(SetClientInfo(a, b))
+    F.liftF(SetCatalog(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setClientInfo(a: Properties): ConnectionIO[Unit] =
-    F.liftFC(SetClientInfo1(a))
+    F.liftF(SetClientInfo(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setClientInfo(a: String, b: String): ConnectionIO[Unit] =
+    F.liftF(SetClientInfo1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setHoldability(a: Int): ConnectionIO[Unit] =
-    F.liftFC(SetHoldability(a))
+    F.liftF(SetHoldability(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNetworkTimeout(a: Executor, b: Int): ConnectionIO[Unit] =
-    F.liftFC(SetNetworkTimeout(a, b))
+    F.liftF(SetNetworkTimeout(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setReadOnly(a: Boolean): ConnectionIO[Unit] =
-    F.liftFC(SetReadOnly(a))
+    F.liftF(SetReadOnly(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val setSavepoint: ConnectionIO[Savepoint] =
-    F.liftFC(SetSavepoint)
+    F.liftF(SetSavepoint)
 
   /** 
    * @group Constructors (Primitives)
    */
   def setSavepoint(a: String): ConnectionIO[Savepoint] =
-    F.liftFC(SetSavepoint1(a))
+    F.liftF(SetSavepoint1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setSchema(a: String): ConnectionIO[Unit] =
-    F.liftFC(SetSchema(a))
+    F.liftF(SetSchema(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setTransactionIsolation(a: Int): ConnectionIO[Unit] =
-    F.liftFC(SetTransactionIsolation(a))
+    F.liftF(SetTransactionIsolation(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setTypeMap(a: Map[String, Class[_]]): ConnectionIO[Unit] =
-    F.liftFC(SetTypeMap(a))
+    F.liftF(SetTypeMap(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def unwrap[T](a: Class[T]): ConnectionIO[T] =
-    F.liftFC(Unwrap(a))
+    F.liftF(Unwrap(a))
 
  /** 
   * Natural transformation from `ConnectionOp` to `Kleisli` for the given `M`, consuming a `java.sql.Connection`. 

--- a/core/src/main/scala/doobie/free/databasemetadata.scala
+++ b/core/src/main/scala/doobie/free/databasemetadata.scala
@@ -1,6 +1,6 @@
 package doobie.free
 
-import scalaz.{ Catchable, Coyoneda, Free => F, Kleisli, Monad, ~>, \/ }
+import scalaz.{ Catchable, Free => F, Kleisli, Monad, ~>, \/ }
 import scalaz.concurrent.Task
 
 import doobie.util.capture._
@@ -98,7 +98,7 @@ object databasemetadata {
       }
 
     // Lifting
-    case class Lift[Op[_], A, J](j: J, action: F.FreeC[Op, A], mod: KleisliTrans.Aux[Op, J]) extends DatabaseMetaDataOp[A] {
+    case class Lift[Op[_], A, J](j: J, action: F[Op, A], mod: KleisliTrans.Aux[Op, J]) extends DatabaseMetaDataOp[A] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => mod.transK[M].apply(action).run(j))
     }
 
@@ -260,6 +260,9 @@ object databasemetadata {
     case object GetMaxIndexLength extends DatabaseMetaDataOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMaxIndexLength())
     }
+    case object GetMaxLogicalLobSize extends DatabaseMetaDataOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMaxLogicalLobSize())
+    }
     case object GetMaxProcedureNameLength extends DatabaseMetaDataOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMaxProcedureNameLength())
     }
@@ -317,11 +320,11 @@ object databasemetadata {
     case object GetSchemaTerm extends DatabaseMetaDataOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSchemaTerm())
     }
-    case object GetSchemas extends DatabaseMetaDataOp[ResultSet] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSchemas())
-    }
-    case class  GetSchemas1(a: String, b: String) extends DatabaseMetaDataOp[ResultSet] {
+    case class  GetSchemas(a: String, b: String) extends DatabaseMetaDataOp[ResultSet] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSchemas(a, b))
+    }
+    case object GetSchemas1 extends DatabaseMetaDataOp[ResultSet] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSchemas())
     }
     case object GetSearchStringEscape extends DatabaseMetaDataOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSearchStringEscape())
@@ -467,11 +470,11 @@ object databasemetadata {
     case object SupportsColumnAliasing extends DatabaseMetaDataOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.supportsColumnAliasing())
     }
-    case object SupportsConvert extends DatabaseMetaDataOp[Boolean] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.supportsConvert())
-    }
-    case class  SupportsConvert1(a: Int, b: Int) extends DatabaseMetaDataOp[Boolean] {
+    case class  SupportsConvert(a: Int, b: Int) extends DatabaseMetaDataOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.supportsConvert(a, b))
+    }
+    case object SupportsConvert1 extends DatabaseMetaDataOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.supportsConvert())
     }
     case object SupportsCoreSQLGrammar extends DatabaseMetaDataOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.supportsCoreSQLGrammar())
@@ -566,6 +569,9 @@ object databasemetadata {
     case object SupportsPositionedUpdate extends DatabaseMetaDataOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.supportsPositionedUpdate())
     }
+    case object SupportsRefCursors extends DatabaseMetaDataOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.supportsRefCursors())
+    }
     case class  SupportsResultSetConcurrency(a: Int, b: Int) extends DatabaseMetaDataOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.supportsResultSetConcurrency(a, b))
     }
@@ -653,14 +659,7 @@ object databasemetadata {
    * a `java.sql.DatabaseMetaData` and produces a value of type `A`. 
    * @group Algebra 
    */
-  type DatabaseMetaDataIO[A] = F.FreeC[DatabaseMetaDataOp, A]
-
-  /**
-   * Monad instance for [[DatabaseMetaDataIO]] (can't be inferred).
-   * @group Typeclass Instances 
-   */
-  implicit val MonadDatabaseMetaDataIO: Monad[DatabaseMetaDataIO] = 
-    F.freeMonad[({type λ[α] = Coyoneda[DatabaseMetaDataOp, α]})#λ]
+  type DatabaseMetaDataIO[A] = F[DatabaseMetaDataOp, A]
 
   /**
    * Catchable instance for [[DatabaseMetaDataIO]].
@@ -685,1085 +684,1097 @@ object databasemetadata {
    * Lift a different type of program that has a default Kleisli interpreter.
    * @group Constructors (Lifting)
    */
-  def lift[Op[_], A, J](j: J, action: F.FreeC[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): DatabaseMetaDataIO[A] =
-    F.liftFC(Lift(j, action, mod))
+  def lift[Op[_], A, J](j: J, action: F[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): DatabaseMetaDataIO[A] =
+    F.liftF(Lift(j, action, mod))
 
   /** 
    * Lift a DatabaseMetaDataIO[A] into an exception-capturing DatabaseMetaDataIO[Throwable \/ A].
    * @group Constructors (Lifting)
    */
   def attempt[A](a: DatabaseMetaDataIO[A]): DatabaseMetaDataIO[Throwable \/ A] =
-    F.liftFC[DatabaseMetaDataOp, Throwable \/ A](Attempt(a))
+    F.liftF[DatabaseMetaDataOp, Throwable \/ A](Attempt(a))
  
   /**
    * Non-strict unit for capturing effects.
    * @group Constructors (Lifting)
    */
   def delay[A](a: => A): DatabaseMetaDataIO[A] =
-    F.liftFC(Pure(a _))
+    F.liftF(Pure(a _))
 
   /**
    * Backdoor for arbitrary computations on the underlying DatabaseMetaData.
    * @group Constructors (Lifting)
    */
   def raw[A](f: DatabaseMetaData => A): DatabaseMetaDataIO[A] =
-    F.liftFC(Raw(f))
+    F.liftF(Raw(f))
 
   /** 
    * @group Constructors (Primitives)
    */
   val allProceduresAreCallable: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(AllProceduresAreCallable)
+    F.liftF(AllProceduresAreCallable)
 
   /** 
    * @group Constructors (Primitives)
    */
   val allTablesAreSelectable: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(AllTablesAreSelectable)
+    F.liftF(AllTablesAreSelectable)
 
   /** 
    * @group Constructors (Primitives)
    */
   val autoCommitFailureClosesAllResultSets: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(AutoCommitFailureClosesAllResultSets)
+    F.liftF(AutoCommitFailureClosesAllResultSets)
 
   /** 
    * @group Constructors (Primitives)
    */
   val dataDefinitionCausesTransactionCommit: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(DataDefinitionCausesTransactionCommit)
+    F.liftF(DataDefinitionCausesTransactionCommit)
 
   /** 
    * @group Constructors (Primitives)
    */
   val dataDefinitionIgnoredInTransactions: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(DataDefinitionIgnoredInTransactions)
+    F.liftF(DataDefinitionIgnoredInTransactions)
 
   /** 
    * @group Constructors (Primitives)
    */
   def deletesAreDetected(a: Int): DatabaseMetaDataIO[Boolean] =
-    F.liftFC(DeletesAreDetected(a))
+    F.liftF(DeletesAreDetected(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val doesMaxRowSizeIncludeBlobs: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(DoesMaxRowSizeIncludeBlobs)
+    F.liftF(DoesMaxRowSizeIncludeBlobs)
 
   /** 
    * @group Constructors (Primitives)
    */
   val generatedKeyAlwaysReturned: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(GeneratedKeyAlwaysReturned)
+    F.liftF(GeneratedKeyAlwaysReturned)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getAttributes(a: String, b: String, c: String, d: String): DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetAttributes(a, b, c, d))
+    F.liftF(GetAttributes(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getBestRowIdentifier(a: String, b: String, c: String, d: Int, e: Boolean): DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetBestRowIdentifier(a, b, c, d, e))
+    F.liftF(GetBestRowIdentifier(a, b, c, d, e))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getCatalogSeparator: DatabaseMetaDataIO[String] =
-    F.liftFC(GetCatalogSeparator)
+    F.liftF(GetCatalogSeparator)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getCatalogTerm: DatabaseMetaDataIO[String] =
-    F.liftFC(GetCatalogTerm)
+    F.liftF(GetCatalogTerm)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getCatalogs: DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetCatalogs)
+    F.liftF(GetCatalogs)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getClientInfoProperties: DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetClientInfoProperties)
+    F.liftF(GetClientInfoProperties)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getColumnPrivileges(a: String, b: String, c: String, d: String): DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetColumnPrivileges(a, b, c, d))
+    F.liftF(GetColumnPrivileges(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getColumns(a: String, b: String, c: String, d: String): DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetColumns(a, b, c, d))
+    F.liftF(GetColumns(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getConnection: DatabaseMetaDataIO[Connection] =
-    F.liftFC(GetConnection)
+    F.liftF(GetConnection)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getCrossReference(a: String, b: String, c: String, d: String, e: String, f: String): DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetCrossReference(a, b, c, d, e, f))
+    F.liftF(GetCrossReference(a, b, c, d, e, f))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getDatabaseMajorVersion: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetDatabaseMajorVersion)
+    F.liftF(GetDatabaseMajorVersion)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getDatabaseMinorVersion: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetDatabaseMinorVersion)
+    F.liftF(GetDatabaseMinorVersion)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getDatabaseProductName: DatabaseMetaDataIO[String] =
-    F.liftFC(GetDatabaseProductName)
+    F.liftF(GetDatabaseProductName)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getDatabaseProductVersion: DatabaseMetaDataIO[String] =
-    F.liftFC(GetDatabaseProductVersion)
+    F.liftF(GetDatabaseProductVersion)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getDefaultTransactionIsolation: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetDefaultTransactionIsolation)
+    F.liftF(GetDefaultTransactionIsolation)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getDriverMajorVersion: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetDriverMajorVersion)
+    F.liftF(GetDriverMajorVersion)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getDriverMinorVersion: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetDriverMinorVersion)
+    F.liftF(GetDriverMinorVersion)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getDriverName: DatabaseMetaDataIO[String] =
-    F.liftFC(GetDriverName)
+    F.liftF(GetDriverName)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getDriverVersion: DatabaseMetaDataIO[String] =
-    F.liftFC(GetDriverVersion)
+    F.liftF(GetDriverVersion)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getExportedKeys(a: String, b: String, c: String): DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetExportedKeys(a, b, c))
+    F.liftF(GetExportedKeys(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getExtraNameCharacters: DatabaseMetaDataIO[String] =
-    F.liftFC(GetExtraNameCharacters)
+    F.liftF(GetExtraNameCharacters)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getFunctionColumns(a: String, b: String, c: String, d: String): DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetFunctionColumns(a, b, c, d))
+    F.liftF(GetFunctionColumns(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getFunctions(a: String, b: String, c: String): DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetFunctions(a, b, c))
+    F.liftF(GetFunctions(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getIdentifierQuoteString: DatabaseMetaDataIO[String] =
-    F.liftFC(GetIdentifierQuoteString)
+    F.liftF(GetIdentifierQuoteString)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getImportedKeys(a: String, b: String, c: String): DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetImportedKeys(a, b, c))
+    F.liftF(GetImportedKeys(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getIndexInfo(a: String, b: String, c: String, d: Boolean, e: Boolean): DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetIndexInfo(a, b, c, d, e))
+    F.liftF(GetIndexInfo(a, b, c, d, e))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getJDBCMajorVersion: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetJDBCMajorVersion)
+    F.liftF(GetJDBCMajorVersion)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getJDBCMinorVersion: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetJDBCMinorVersion)
+    F.liftF(GetJDBCMinorVersion)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxBinaryLiteralLength: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetMaxBinaryLiteralLength)
+    F.liftF(GetMaxBinaryLiteralLength)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxCatalogNameLength: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetMaxCatalogNameLength)
+    F.liftF(GetMaxCatalogNameLength)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxCharLiteralLength: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetMaxCharLiteralLength)
+    F.liftF(GetMaxCharLiteralLength)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxColumnNameLength: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetMaxColumnNameLength)
+    F.liftF(GetMaxColumnNameLength)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxColumnsInGroupBy: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetMaxColumnsInGroupBy)
+    F.liftF(GetMaxColumnsInGroupBy)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxColumnsInIndex: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetMaxColumnsInIndex)
+    F.liftF(GetMaxColumnsInIndex)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxColumnsInOrderBy: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetMaxColumnsInOrderBy)
+    F.liftF(GetMaxColumnsInOrderBy)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxColumnsInSelect: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetMaxColumnsInSelect)
+    F.liftF(GetMaxColumnsInSelect)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxColumnsInTable: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetMaxColumnsInTable)
+    F.liftF(GetMaxColumnsInTable)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxConnections: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetMaxConnections)
+    F.liftF(GetMaxConnections)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxCursorNameLength: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetMaxCursorNameLength)
+    F.liftF(GetMaxCursorNameLength)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxIndexLength: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetMaxIndexLength)
+    F.liftF(GetMaxIndexLength)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val getMaxLogicalLobSize: DatabaseMetaDataIO[Long] =
+    F.liftF(GetMaxLogicalLobSize)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxProcedureNameLength: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetMaxProcedureNameLength)
+    F.liftF(GetMaxProcedureNameLength)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxRowSize: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetMaxRowSize)
+    F.liftF(GetMaxRowSize)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxSchemaNameLength: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetMaxSchemaNameLength)
+    F.liftF(GetMaxSchemaNameLength)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxStatementLength: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetMaxStatementLength)
+    F.liftF(GetMaxStatementLength)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxStatements: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetMaxStatements)
+    F.liftF(GetMaxStatements)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxTableNameLength: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetMaxTableNameLength)
+    F.liftF(GetMaxTableNameLength)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxTablesInSelect: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetMaxTablesInSelect)
+    F.liftF(GetMaxTablesInSelect)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxUserNameLength: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetMaxUserNameLength)
+    F.liftF(GetMaxUserNameLength)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getNumericFunctions: DatabaseMetaDataIO[String] =
-    F.liftFC(GetNumericFunctions)
+    F.liftF(GetNumericFunctions)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getPrimaryKeys(a: String, b: String, c: String): DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetPrimaryKeys(a, b, c))
+    F.liftF(GetPrimaryKeys(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getProcedureColumns(a: String, b: String, c: String, d: String): DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetProcedureColumns(a, b, c, d))
+    F.liftF(GetProcedureColumns(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getProcedureTerm: DatabaseMetaDataIO[String] =
-    F.liftFC(GetProcedureTerm)
+    F.liftF(GetProcedureTerm)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getProcedures(a: String, b: String, c: String): DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetProcedures(a, b, c))
+    F.liftF(GetProcedures(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getPseudoColumns(a: String, b: String, c: String, d: String): DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetPseudoColumns(a, b, c, d))
+    F.liftF(GetPseudoColumns(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getResultSetHoldability: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetResultSetHoldability)
+    F.liftF(GetResultSetHoldability)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getRowIdLifetime: DatabaseMetaDataIO[RowIdLifetime] =
-    F.liftFC(GetRowIdLifetime)
+    F.liftF(GetRowIdLifetime)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getSQLKeywords: DatabaseMetaDataIO[String] =
-    F.liftFC(GetSQLKeywords)
+    F.liftF(GetSQLKeywords)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getSQLStateType: DatabaseMetaDataIO[Int] =
-    F.liftFC(GetSQLStateType)
+    F.liftF(GetSQLStateType)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getSchemaTerm: DatabaseMetaDataIO[String] =
-    F.liftFC(GetSchemaTerm)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val getSchemas: DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetSchemas)
+    F.liftF(GetSchemaTerm)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getSchemas(a: String, b: String): DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetSchemas1(a, b))
+    F.liftF(GetSchemas(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val getSchemas: DatabaseMetaDataIO[ResultSet] =
+    F.liftF(GetSchemas1)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getSearchStringEscape: DatabaseMetaDataIO[String] =
-    F.liftFC(GetSearchStringEscape)
+    F.liftF(GetSearchStringEscape)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getStringFunctions: DatabaseMetaDataIO[String] =
-    F.liftFC(GetStringFunctions)
+    F.liftF(GetStringFunctions)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getSuperTables(a: String, b: String, c: String): DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetSuperTables(a, b, c))
+    F.liftF(GetSuperTables(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getSuperTypes(a: String, b: String, c: String): DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetSuperTypes(a, b, c))
+    F.liftF(GetSuperTypes(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getSystemFunctions: DatabaseMetaDataIO[String] =
-    F.liftFC(GetSystemFunctions)
+    F.liftF(GetSystemFunctions)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getTablePrivileges(a: String, b: String, c: String): DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetTablePrivileges(a, b, c))
+    F.liftF(GetTablePrivileges(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getTableTypes: DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetTableTypes)
+    F.liftF(GetTableTypes)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getTables(a: String, b: String, c: String, d: Array[String]): DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetTables(a, b, c, d))
+    F.liftF(GetTables(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getTimeDateFunctions: DatabaseMetaDataIO[String] =
-    F.liftFC(GetTimeDateFunctions)
+    F.liftF(GetTimeDateFunctions)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getTypeInfo: DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetTypeInfo)
+    F.liftF(GetTypeInfo)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getUDTs(a: String, b: String, c: String, d: Array[Int]): DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetUDTs(a, b, c, d))
+    F.liftF(GetUDTs(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getURL: DatabaseMetaDataIO[String] =
-    F.liftFC(GetURL)
+    F.liftF(GetURL)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getUserName: DatabaseMetaDataIO[String] =
-    F.liftFC(GetUserName)
+    F.liftF(GetUserName)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getVersionColumns(a: String, b: String, c: String): DatabaseMetaDataIO[ResultSet] =
-    F.liftFC(GetVersionColumns(a, b, c))
+    F.liftF(GetVersionColumns(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def insertsAreDetected(a: Int): DatabaseMetaDataIO[Boolean] =
-    F.liftFC(InsertsAreDetected(a))
+    F.liftF(InsertsAreDetected(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val isCatalogAtStart: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(IsCatalogAtStart)
+    F.liftF(IsCatalogAtStart)
 
   /** 
    * @group Constructors (Primitives)
    */
   val isReadOnly: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(IsReadOnly)
+    F.liftF(IsReadOnly)
 
   /** 
    * @group Constructors (Primitives)
    */
   def isWrapperFor(a: Class[_]): DatabaseMetaDataIO[Boolean] =
-    F.liftFC(IsWrapperFor(a))
+    F.liftF(IsWrapperFor(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val locatorsUpdateCopy: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(LocatorsUpdateCopy)
+    F.liftF(LocatorsUpdateCopy)
 
   /** 
    * @group Constructors (Primitives)
    */
   val nullPlusNonNullIsNull: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(NullPlusNonNullIsNull)
+    F.liftF(NullPlusNonNullIsNull)
 
   /** 
    * @group Constructors (Primitives)
    */
   val nullsAreSortedAtEnd: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(NullsAreSortedAtEnd)
+    F.liftF(NullsAreSortedAtEnd)
 
   /** 
    * @group Constructors (Primitives)
    */
   val nullsAreSortedAtStart: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(NullsAreSortedAtStart)
+    F.liftF(NullsAreSortedAtStart)
 
   /** 
    * @group Constructors (Primitives)
    */
   val nullsAreSortedHigh: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(NullsAreSortedHigh)
+    F.liftF(NullsAreSortedHigh)
 
   /** 
    * @group Constructors (Primitives)
    */
   val nullsAreSortedLow: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(NullsAreSortedLow)
+    F.liftF(NullsAreSortedLow)
 
   /** 
    * @group Constructors (Primitives)
    */
   def othersDeletesAreVisible(a: Int): DatabaseMetaDataIO[Boolean] =
-    F.liftFC(OthersDeletesAreVisible(a))
+    F.liftF(OthersDeletesAreVisible(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def othersInsertsAreVisible(a: Int): DatabaseMetaDataIO[Boolean] =
-    F.liftFC(OthersInsertsAreVisible(a))
+    F.liftF(OthersInsertsAreVisible(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def othersUpdatesAreVisible(a: Int): DatabaseMetaDataIO[Boolean] =
-    F.liftFC(OthersUpdatesAreVisible(a))
+    F.liftF(OthersUpdatesAreVisible(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def ownDeletesAreVisible(a: Int): DatabaseMetaDataIO[Boolean] =
-    F.liftFC(OwnDeletesAreVisible(a))
+    F.liftF(OwnDeletesAreVisible(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def ownInsertsAreVisible(a: Int): DatabaseMetaDataIO[Boolean] =
-    F.liftFC(OwnInsertsAreVisible(a))
+    F.liftF(OwnInsertsAreVisible(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def ownUpdatesAreVisible(a: Int): DatabaseMetaDataIO[Boolean] =
-    F.liftFC(OwnUpdatesAreVisible(a))
+    F.liftF(OwnUpdatesAreVisible(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val storesLowerCaseIdentifiers: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(StoresLowerCaseIdentifiers)
+    F.liftF(StoresLowerCaseIdentifiers)
 
   /** 
    * @group Constructors (Primitives)
    */
   val storesLowerCaseQuotedIdentifiers: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(StoresLowerCaseQuotedIdentifiers)
+    F.liftF(StoresLowerCaseQuotedIdentifiers)
 
   /** 
    * @group Constructors (Primitives)
    */
   val storesMixedCaseIdentifiers: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(StoresMixedCaseIdentifiers)
+    F.liftF(StoresMixedCaseIdentifiers)
 
   /** 
    * @group Constructors (Primitives)
    */
   val storesMixedCaseQuotedIdentifiers: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(StoresMixedCaseQuotedIdentifiers)
+    F.liftF(StoresMixedCaseQuotedIdentifiers)
 
   /** 
    * @group Constructors (Primitives)
    */
   val storesUpperCaseIdentifiers: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(StoresUpperCaseIdentifiers)
+    F.liftF(StoresUpperCaseIdentifiers)
 
   /** 
    * @group Constructors (Primitives)
    */
   val storesUpperCaseQuotedIdentifiers: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(StoresUpperCaseQuotedIdentifiers)
+    F.liftF(StoresUpperCaseQuotedIdentifiers)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsANSI92EntryLevelSQL: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsANSI92EntryLevelSQL)
+    F.liftF(SupportsANSI92EntryLevelSQL)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsANSI92FullSQL: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsANSI92FullSQL)
+    F.liftF(SupportsANSI92FullSQL)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsANSI92IntermediateSQL: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsANSI92IntermediateSQL)
+    F.liftF(SupportsANSI92IntermediateSQL)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsAlterTableWithAddColumn: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsAlterTableWithAddColumn)
+    F.liftF(SupportsAlterTableWithAddColumn)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsAlterTableWithDropColumn: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsAlterTableWithDropColumn)
+    F.liftF(SupportsAlterTableWithDropColumn)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsBatchUpdates: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsBatchUpdates)
+    F.liftF(SupportsBatchUpdates)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsCatalogsInDataManipulation: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsCatalogsInDataManipulation)
+    F.liftF(SupportsCatalogsInDataManipulation)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsCatalogsInIndexDefinitions: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsCatalogsInIndexDefinitions)
+    F.liftF(SupportsCatalogsInIndexDefinitions)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsCatalogsInPrivilegeDefinitions: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsCatalogsInPrivilegeDefinitions)
+    F.liftF(SupportsCatalogsInPrivilegeDefinitions)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsCatalogsInProcedureCalls: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsCatalogsInProcedureCalls)
+    F.liftF(SupportsCatalogsInProcedureCalls)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsCatalogsInTableDefinitions: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsCatalogsInTableDefinitions)
+    F.liftF(SupportsCatalogsInTableDefinitions)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsColumnAliasing: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsColumnAliasing)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val supportsConvert: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsConvert)
+    F.liftF(SupportsColumnAliasing)
 
   /** 
    * @group Constructors (Primitives)
    */
   def supportsConvert(a: Int, b: Int): DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsConvert1(a, b))
+    F.liftF(SupportsConvert(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val supportsConvert: DatabaseMetaDataIO[Boolean] =
+    F.liftF(SupportsConvert1)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsCoreSQLGrammar: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsCoreSQLGrammar)
+    F.liftF(SupportsCoreSQLGrammar)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsCorrelatedSubqueries: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsCorrelatedSubqueries)
+    F.liftF(SupportsCorrelatedSubqueries)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsDataDefinitionAndDataManipulationTransactions: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsDataDefinitionAndDataManipulationTransactions)
+    F.liftF(SupportsDataDefinitionAndDataManipulationTransactions)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsDataManipulationTransactionsOnly: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsDataManipulationTransactionsOnly)
+    F.liftF(SupportsDataManipulationTransactionsOnly)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsDifferentTableCorrelationNames: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsDifferentTableCorrelationNames)
+    F.liftF(SupportsDifferentTableCorrelationNames)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsExpressionsInOrderBy: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsExpressionsInOrderBy)
+    F.liftF(SupportsExpressionsInOrderBy)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsExtendedSQLGrammar: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsExtendedSQLGrammar)
+    F.liftF(SupportsExtendedSQLGrammar)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsFullOuterJoins: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsFullOuterJoins)
+    F.liftF(SupportsFullOuterJoins)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsGetGeneratedKeys: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsGetGeneratedKeys)
+    F.liftF(SupportsGetGeneratedKeys)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsGroupBy: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsGroupBy)
+    F.liftF(SupportsGroupBy)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsGroupByBeyondSelect: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsGroupByBeyondSelect)
+    F.liftF(SupportsGroupByBeyondSelect)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsGroupByUnrelated: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsGroupByUnrelated)
+    F.liftF(SupportsGroupByUnrelated)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsIntegrityEnhancementFacility: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsIntegrityEnhancementFacility)
+    F.liftF(SupportsIntegrityEnhancementFacility)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsLikeEscapeClause: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsLikeEscapeClause)
+    F.liftF(SupportsLikeEscapeClause)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsLimitedOuterJoins: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsLimitedOuterJoins)
+    F.liftF(SupportsLimitedOuterJoins)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsMinimumSQLGrammar: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsMinimumSQLGrammar)
+    F.liftF(SupportsMinimumSQLGrammar)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsMixedCaseIdentifiers: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsMixedCaseIdentifiers)
+    F.liftF(SupportsMixedCaseIdentifiers)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsMixedCaseQuotedIdentifiers: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsMixedCaseQuotedIdentifiers)
+    F.liftF(SupportsMixedCaseQuotedIdentifiers)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsMultipleOpenResults: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsMultipleOpenResults)
+    F.liftF(SupportsMultipleOpenResults)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsMultipleResultSets: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsMultipleResultSets)
+    F.liftF(SupportsMultipleResultSets)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsMultipleTransactions: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsMultipleTransactions)
+    F.liftF(SupportsMultipleTransactions)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsNamedParameters: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsNamedParameters)
+    F.liftF(SupportsNamedParameters)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsNonNullableColumns: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsNonNullableColumns)
+    F.liftF(SupportsNonNullableColumns)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsOpenCursorsAcrossCommit: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsOpenCursorsAcrossCommit)
+    F.liftF(SupportsOpenCursorsAcrossCommit)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsOpenCursorsAcrossRollback: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsOpenCursorsAcrossRollback)
+    F.liftF(SupportsOpenCursorsAcrossRollback)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsOpenStatementsAcrossCommit: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsOpenStatementsAcrossCommit)
+    F.liftF(SupportsOpenStatementsAcrossCommit)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsOpenStatementsAcrossRollback: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsOpenStatementsAcrossRollback)
+    F.liftF(SupportsOpenStatementsAcrossRollback)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsOrderByUnrelated: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsOrderByUnrelated)
+    F.liftF(SupportsOrderByUnrelated)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsOuterJoins: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsOuterJoins)
+    F.liftF(SupportsOuterJoins)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsPositionedDelete: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsPositionedDelete)
+    F.liftF(SupportsPositionedDelete)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsPositionedUpdate: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsPositionedUpdate)
+    F.liftF(SupportsPositionedUpdate)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val supportsRefCursors: DatabaseMetaDataIO[Boolean] =
+    F.liftF(SupportsRefCursors)
 
   /** 
    * @group Constructors (Primitives)
    */
   def supportsResultSetConcurrency(a: Int, b: Int): DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsResultSetConcurrency(a, b))
+    F.liftF(SupportsResultSetConcurrency(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def supportsResultSetHoldability(a: Int): DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsResultSetHoldability(a))
+    F.liftF(SupportsResultSetHoldability(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def supportsResultSetType(a: Int): DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsResultSetType(a))
+    F.liftF(SupportsResultSetType(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsSavepoints: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsSavepoints)
+    F.liftF(SupportsSavepoints)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsSchemasInDataManipulation: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsSchemasInDataManipulation)
+    F.liftF(SupportsSchemasInDataManipulation)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsSchemasInIndexDefinitions: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsSchemasInIndexDefinitions)
+    F.liftF(SupportsSchemasInIndexDefinitions)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsSchemasInPrivilegeDefinitions: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsSchemasInPrivilegeDefinitions)
+    F.liftF(SupportsSchemasInPrivilegeDefinitions)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsSchemasInProcedureCalls: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsSchemasInProcedureCalls)
+    F.liftF(SupportsSchemasInProcedureCalls)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsSchemasInTableDefinitions: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsSchemasInTableDefinitions)
+    F.liftF(SupportsSchemasInTableDefinitions)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsSelectForUpdate: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsSelectForUpdate)
+    F.liftF(SupportsSelectForUpdate)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsStatementPooling: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsStatementPooling)
+    F.liftF(SupportsStatementPooling)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsStoredFunctionsUsingCallSyntax: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsStoredFunctionsUsingCallSyntax)
+    F.liftF(SupportsStoredFunctionsUsingCallSyntax)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsStoredProcedures: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsStoredProcedures)
+    F.liftF(SupportsStoredProcedures)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsSubqueriesInComparisons: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsSubqueriesInComparisons)
+    F.liftF(SupportsSubqueriesInComparisons)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsSubqueriesInExists: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsSubqueriesInExists)
+    F.liftF(SupportsSubqueriesInExists)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsSubqueriesInIns: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsSubqueriesInIns)
+    F.liftF(SupportsSubqueriesInIns)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsSubqueriesInQuantifieds: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsSubqueriesInQuantifieds)
+    F.liftF(SupportsSubqueriesInQuantifieds)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsTableCorrelationNames: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsTableCorrelationNames)
+    F.liftF(SupportsTableCorrelationNames)
 
   /** 
    * @group Constructors (Primitives)
    */
   def supportsTransactionIsolationLevel(a: Int): DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsTransactionIsolationLevel(a))
+    F.liftF(SupportsTransactionIsolationLevel(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsTransactions: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsTransactions)
+    F.liftF(SupportsTransactions)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsUnion: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsUnion)
+    F.liftF(SupportsUnion)
 
   /** 
    * @group Constructors (Primitives)
    */
   val supportsUnionAll: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(SupportsUnionAll)
+    F.liftF(SupportsUnionAll)
 
   /** 
    * @group Constructors (Primitives)
    */
   def unwrap[T](a: Class[T]): DatabaseMetaDataIO[T] =
-    F.liftFC(Unwrap(a))
+    F.liftF(Unwrap(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updatesAreDetected(a: Int): DatabaseMetaDataIO[Boolean] =
-    F.liftFC(UpdatesAreDetected(a))
+    F.liftF(UpdatesAreDetected(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val usesLocalFilePerTable: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(UsesLocalFilePerTable)
+    F.liftF(UsesLocalFilePerTable)
 
   /** 
    * @group Constructors (Primitives)
    */
   val usesLocalFiles: DatabaseMetaDataIO[Boolean] =
-    F.liftFC(UsesLocalFiles)
+    F.liftF(UsesLocalFiles)
 
  /** 
   * Natural transformation from `DatabaseMetaDataOp` to `Kleisli` for the given `M`, consuming a `java.sql.DatabaseMetaData`. 

--- a/core/src/main/scala/doobie/free/databasemetadata.scala
+++ b/core/src/main/scala/doobie/free/databasemetadata.scala
@@ -48,7 +48,7 @@ import resultset.ResultSetIO
  *
  * `DatabaseMetaDataIO` is a free monad that must be run via an interpreter, most commonly via
  * natural transformation of its underlying algebra `DatabaseMetaDataOp` to another monad via
- * `Free.runFC`. 
+ * `Free#foldMap`.
  *
  * The library provides a natural transformation to `Kleisli[M, DatabaseMetaData, A]` for any
  * exception-trapping (`Catchable`) and effect-capturing (`Capture`) monad `M`. Such evidence is 
@@ -260,9 +260,6 @@ object databasemetadata {
     case object GetMaxIndexLength extends DatabaseMetaDataOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMaxIndexLength())
     }
-    case object GetMaxLogicalLobSize extends DatabaseMetaDataOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMaxLogicalLobSize())
-    }
     case object GetMaxProcedureNameLength extends DatabaseMetaDataOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMaxProcedureNameLength())
     }
@@ -320,11 +317,11 @@ object databasemetadata {
     case object GetSchemaTerm extends DatabaseMetaDataOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSchemaTerm())
     }
-    case class  GetSchemas(a: String, b: String) extends DatabaseMetaDataOp[ResultSet] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSchemas(a, b))
-    }
-    case object GetSchemas1 extends DatabaseMetaDataOp[ResultSet] {
+    case object GetSchemas extends DatabaseMetaDataOp[ResultSet] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSchemas())
+    }
+    case class  GetSchemas1(a: String, b: String) extends DatabaseMetaDataOp[ResultSet] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSchemas(a, b))
     }
     case object GetSearchStringEscape extends DatabaseMetaDataOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSearchStringEscape())
@@ -470,11 +467,11 @@ object databasemetadata {
     case object SupportsColumnAliasing extends DatabaseMetaDataOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.supportsColumnAliasing())
     }
-    case class  SupportsConvert(a: Int, b: Int) extends DatabaseMetaDataOp[Boolean] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.supportsConvert(a, b))
-    }
-    case object SupportsConvert1 extends DatabaseMetaDataOp[Boolean] {
+    case object SupportsConvert extends DatabaseMetaDataOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.supportsConvert())
+    }
+    case class  SupportsConvert1(a: Int, b: Int) extends DatabaseMetaDataOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.supportsConvert(a, b))
     }
     case object SupportsCoreSQLGrammar extends DatabaseMetaDataOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.supportsCoreSQLGrammar())
@@ -568,9 +565,6 @@ object databasemetadata {
     }
     case object SupportsPositionedUpdate extends DatabaseMetaDataOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.supportsPositionedUpdate())
-    }
-    case object SupportsRefCursors extends DatabaseMetaDataOp[Boolean] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.supportsRefCursors())
     }
     case class  SupportsResultSetConcurrency(a: Int, b: Int) extends DatabaseMetaDataOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.supportsResultSetConcurrency(a, b))
@@ -999,12 +993,6 @@ object databasemetadata {
   /** 
    * @group Constructors (Primitives)
    */
-  val getMaxLogicalLobSize: DatabaseMetaDataIO[Long] =
-    F.liftF(GetMaxLogicalLobSize)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   val getMaxProcedureNameLength: DatabaseMetaDataIO[Int] =
     F.liftF(GetMaxProcedureNameLength)
 
@@ -1119,14 +1107,14 @@ object databasemetadata {
   /** 
    * @group Constructors (Primitives)
    */
-  def getSchemas(a: String, b: String): DatabaseMetaDataIO[ResultSet] =
-    F.liftF(GetSchemas(a, b))
+  val getSchemas: DatabaseMetaDataIO[ResultSet] =
+    F.liftF(GetSchemas)
 
   /** 
    * @group Constructors (Primitives)
    */
-  val getSchemas: DatabaseMetaDataIO[ResultSet] =
-    F.liftF(GetSchemas1)
+  def getSchemas(a: String, b: String): DatabaseMetaDataIO[ResultSet] =
+    F.liftF(GetSchemas1(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1419,14 +1407,14 @@ object databasemetadata {
   /** 
    * @group Constructors (Primitives)
    */
-  def supportsConvert(a: Int, b: Int): DatabaseMetaDataIO[Boolean] =
-    F.liftF(SupportsConvert(a, b))
+  val supportsConvert: DatabaseMetaDataIO[Boolean] =
+    F.liftF(SupportsConvert)
 
   /** 
    * @group Constructors (Primitives)
    */
-  val supportsConvert: DatabaseMetaDataIO[Boolean] =
-    F.liftF(SupportsConvert1)
+  def supportsConvert(a: Int, b: Int): DatabaseMetaDataIO[Boolean] =
+    F.liftF(SupportsConvert1(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1613,12 +1601,6 @@ object databasemetadata {
    */
   val supportsPositionedUpdate: DatabaseMetaDataIO[Boolean] =
     F.liftF(SupportsPositionedUpdate)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val supportsRefCursors: DatabaseMetaDataIO[Boolean] =
-    F.liftF(SupportsRefCursors)
 
   /** 
    * @group Constructors (Primitives)

--- a/core/src/main/scala/doobie/free/driver.scala
+++ b/core/src/main/scala/doobie/free/driver.scala
@@ -1,6 +1,6 @@
 package doobie.free
 
-import scalaz.{ Catchable, Coyoneda, Free => F, Kleisli, Monad, ~>, \/ }
+import scalaz.{ Catchable, Free => F, Kleisli, Monad, ~>, \/ }
 import scalaz.concurrent.Task
 
 import doobie.util.capture._
@@ -98,7 +98,7 @@ object driver {
       }
 
     // Lifting
-    case class Lift[Op[_], A, J](j: J, action: F.FreeC[Op, A], mod: KleisliTrans.Aux[Op, J]) extends DriverOp[A] {
+    case class Lift[Op[_], A, J](j: J, action: F[Op, A], mod: KleisliTrans.Aux[Op, J]) extends DriverOp[A] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => mod.transK[M].apply(action).run(j))
     }
 
@@ -146,14 +146,7 @@ object driver {
    * a `java.sql.Driver` and produces a value of type `A`. 
    * @group Algebra 
    */
-  type DriverIO[A] = F.FreeC[DriverOp, A]
-
-  /**
-   * Monad instance for [[DriverIO]] (can't be inferred).
-   * @group Typeclass Instances 
-   */
-  implicit val MonadDriverIO: Monad[DriverIO] = 
-    F.freeMonad[({type λ[α] = Coyoneda[DriverOp, α]})#λ]
+  type DriverIO[A] = F[DriverOp, A]
 
   /**
    * Catchable instance for [[DriverIO]].
@@ -178,71 +171,71 @@ object driver {
    * Lift a different type of program that has a default Kleisli interpreter.
    * @group Constructors (Lifting)
    */
-  def lift[Op[_], A, J](j: J, action: F.FreeC[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): DriverIO[A] =
-    F.liftFC(Lift(j, action, mod))
+  def lift[Op[_], A, J](j: J, action: F[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): DriverIO[A] =
+    F.liftF(Lift(j, action, mod))
 
   /** 
    * Lift a DriverIO[A] into an exception-capturing DriverIO[Throwable \/ A].
    * @group Constructors (Lifting)
    */
   def attempt[A](a: DriverIO[A]): DriverIO[Throwable \/ A] =
-    F.liftFC[DriverOp, Throwable \/ A](Attempt(a))
+    F.liftF[DriverOp, Throwable \/ A](Attempt(a))
  
   /**
    * Non-strict unit for capturing effects.
    * @group Constructors (Lifting)
    */
   def delay[A](a: => A): DriverIO[A] =
-    F.liftFC(Pure(a _))
+    F.liftF(Pure(a _))
 
   /**
    * Backdoor for arbitrary computations on the underlying Driver.
    * @group Constructors (Lifting)
    */
   def raw[A](f: Driver => A): DriverIO[A] =
-    F.liftFC(Raw(f))
+    F.liftF(Raw(f))
 
   /** 
    * @group Constructors (Primitives)
    */
   def acceptsURL(a: String): DriverIO[Boolean] =
-    F.liftFC(AcceptsURL(a))
+    F.liftF(AcceptsURL(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def connect(a: String, b: Properties): DriverIO[Connection] =
-    F.liftFC(Connect(a, b))
+    F.liftF(Connect(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMajorVersion: DriverIO[Int] =
-    F.liftFC(GetMajorVersion)
+    F.liftF(GetMajorVersion)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMinorVersion: DriverIO[Int] =
-    F.liftFC(GetMinorVersion)
+    F.liftF(GetMinorVersion)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getParentLogger: DriverIO[Logger] =
-    F.liftFC(GetParentLogger)
+    F.liftF(GetParentLogger)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getPropertyInfo(a: String, b: Properties): DriverIO[Array[DriverPropertyInfo]] =
-    F.liftFC(GetPropertyInfo(a, b))
+    F.liftF(GetPropertyInfo(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   val jdbcCompliant: DriverIO[Boolean] =
-    F.liftFC(JdbcCompliant)
+    F.liftF(JdbcCompliant)
 
  /** 
   * Natural transformation from `DriverOp` to `Kleisli` for the given `M`, consuming a `java.sql.Driver`. 

--- a/core/src/main/scala/doobie/free/driver.scala
+++ b/core/src/main/scala/doobie/free/driver.scala
@@ -48,7 +48,7 @@ import resultset.ResultSetIO
  *
  * `DriverIO` is a free monad that must be run via an interpreter, most commonly via
  * natural transformation of its underlying algebra `DriverOp` to another monad via
- * `Free.runFC`. 
+ * `Free#foldMap`.
  *
  * The library provides a natural transformation to `Kleisli[M, Driver, A]` for any
  * exception-trapping (`Catchable`) and effect-capturing (`Capture`) monad `M`. Such evidence is 

--- a/core/src/main/scala/doobie/free/kleislitrans.scala
+++ b/core/src/main/scala/doobie/free/kleislitrans.scala
@@ -1,6 +1,6 @@
 package doobie.free
 
-import scalaz.{ Catchable, Coyoneda, Free => F, Kleisli, Monad, ~>, \/ }
+import scalaz.{ Catchable, Free => F, Kleisli, Monad, ~>, \/ }
 import scalaz.concurrent.Task
 
 import doobie.util.capture._
@@ -17,7 +17,7 @@ object kleislitrans {
     type J
 
     /** Free monad over the free functor of `Op`. */
-    type OpIO[A] = F.FreeC[Op, A]
+    type OpIO[A] = F[Op, A]
 
     /** 
      * Natural transformation from `Op` to `Kleisli` for the given `M`, consuming a `J`. 
@@ -32,7 +32,7 @@ object kleislitrans {
     def transK[M[_]: Monad: Catchable: Capture]: OpIO ~> Kleisli[M, J, ?] =
       new (OpIO ~> Kleisli[M, J, ?]) {
         def apply[A](ma: OpIO[A]): Kleisli[M, J, A] =
-          F.runFC[Op, Kleisli[M, J, ?], A](ma)(interpK[M])
+          ma.foldMap[Kleisli[M, J, ?]](interpK[M])
       }
 
     /** 

--- a/core/src/main/scala/doobie/free/nclob.scala
+++ b/core/src/main/scala/doobie/free/nclob.scala
@@ -49,7 +49,7 @@ import resultset.ResultSetIO
  *
  * `NClobIO` is a free monad that must be run via an interpreter, most commonly via
  * natural transformation of its underlying algebra `NClobOp` to another monad via
- * `Free.runFC`. 
+ * `Free#foldMap`.
  *
  * The library provides a natural transformation to `Kleisli[M, NClob, A]` for any
  * exception-trapping (`Catchable`) and effect-capturing (`Capture`) monad `M`. Such evidence is 
@@ -123,11 +123,11 @@ object nclob {
     case object GetAsciiStream extends NClobOp[InputStream] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getAsciiStream())
     }
-    case class  GetCharacterStream(a: Long, b: Long) extends NClobOp[Reader] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getCharacterStream(a, b))
-    }
-    case object GetCharacterStream1 extends NClobOp[Reader] {
+    case object GetCharacterStream extends NClobOp[Reader] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getCharacterStream())
+    }
+    case class  GetCharacterStream1(a: Long, b: Long) extends NClobOp[Reader] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getCharacterStream(a, b))
     }
     case class  GetSubString(a: Long, b: Int) extends NClobOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSubString(a, b))
@@ -147,11 +147,11 @@ object nclob {
     case class  SetCharacterStream(a: Long) extends NClobOp[Writer] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a))
     }
-    case class  SetString(a: Long, b: String) extends NClobOp[Int] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setString(a, b))
-    }
-    case class  SetString1(a: Long, b: String, c: Int, d: Int) extends NClobOp[Int] {
+    case class  SetString(a: Long, b: String, c: Int, d: Int) extends NClobOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setString(a, b, c, d))
+    }
+    case class  SetString1(a: Long, b: String) extends NClobOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setString(a, b))
     }
     case class  Truncate(a: Long) extends NClobOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.truncate(a))
@@ -229,14 +229,14 @@ object nclob {
   /** 
    * @group Constructors (Primitives)
    */
-  def getCharacterStream(a: Long, b: Long): NClobIO[Reader] =
-    F.liftF(GetCharacterStream(a, b))
+  val getCharacterStream: NClobIO[Reader] =
+    F.liftF(GetCharacterStream)
 
   /** 
    * @group Constructors (Primitives)
    */
-  val getCharacterStream: NClobIO[Reader] =
-    F.liftF(GetCharacterStream1)
+  def getCharacterStream(a: Long, b: Long): NClobIO[Reader] =
+    F.liftF(GetCharacterStream1(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -277,14 +277,14 @@ object nclob {
   /** 
    * @group Constructors (Primitives)
    */
-  def setString(a: Long, b: String): NClobIO[Int] =
-    F.liftF(SetString(a, b))
+  def setString(a: Long, b: String, c: Int, d: Int): NClobIO[Int] =
+    F.liftF(SetString(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setString(a: Long, b: String, c: Int, d: Int): NClobIO[Int] =
-    F.liftF(SetString1(a, b, c, d))
+  def setString(a: Long, b: String): NClobIO[Int] =
+    F.liftF(SetString1(a, b))
 
   /** 
    * @group Constructors (Primitives)

--- a/core/src/main/scala/doobie/free/preparedstatement.scala
+++ b/core/src/main/scala/doobie/free/preparedstatement.scala
@@ -30,7 +30,6 @@ import java.sql.RowId
 import java.sql.SQLData
 import java.sql.SQLInput
 import java.sql.SQLOutput
-import java.sql.SQLType
 import java.sql.SQLWarning
 import java.sql.SQLXML
 import java.sql.Statement
@@ -62,7 +61,7 @@ import resultset.ResultSetIO
  *
  * `PreparedStatementIO` is a free monad that must be run via an interpreter, most commonly via
  * natural transformation of its underlying algebra `PreparedStatementOp` to another monad via
- * `Free.runFC`. 
+ * `Free#foldMap`.
  *
  * The library provides a natural transformation to `Kleisli[M, PreparedStatement, A]` for any
  * exception-trapping (`Catchable`) and effect-capturing (`Capture`) monad `M`. Such evidence is 
@@ -157,38 +156,20 @@ object preparedstatement {
     case object Execute extends PreparedStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute())
     }
-    case class  Execute1(a: String, b: Array[String]) extends PreparedStatementOp[Boolean] {
+    case class  Execute1(a: String, b: Array[Int]) extends PreparedStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
     }
-    case class  Execute2(a: String) extends PreparedStatementOp[Boolean] {
+    case class  Execute2(a: String, b: Int) extends PreparedStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
+    }
+    case class  Execute3(a: String) extends PreparedStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a))
     }
-    case class  Execute3(a: String, b: Array[Int]) extends PreparedStatementOp[Boolean] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
-    }
-    case class  Execute4(a: String, b: Int) extends PreparedStatementOp[Boolean] {
+    case class  Execute4(a: String, b: Array[String]) extends PreparedStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
     }
     case object ExecuteBatch extends PreparedStatementOp[Array[Int]] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeBatch())
-    }
-    case object ExecuteLargeBatch extends PreparedStatementOp[Array[Long]] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeBatch())
-    }
-    case object ExecuteLargeUpdate extends PreparedStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate())
-    }
-    case class  ExecuteLargeUpdate1(a: String, b: Int) extends PreparedStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
-    }
-    case class  ExecuteLargeUpdate2(a: String, b: Array[Int]) extends PreparedStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
-    }
-    case class  ExecuteLargeUpdate3(a: String) extends PreparedStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a))
-    }
-    case class  ExecuteLargeUpdate4(a: String, b: Array[String]) extends PreparedStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
     }
     case object ExecuteQuery extends PreparedStatementOp[ResultSet] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeQuery())
@@ -199,8 +180,8 @@ object preparedstatement {
     case object ExecuteUpdate extends PreparedStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate())
     }
-    case class  ExecuteUpdate1(a: String, b: Int) extends PreparedStatementOp[Int] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
+    case class  ExecuteUpdate1(a: String) extends PreparedStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a))
     }
     case class  ExecuteUpdate2(a: String, b: Array[String]) extends PreparedStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
@@ -208,8 +189,8 @@ object preparedstatement {
     case class  ExecuteUpdate3(a: String, b: Array[Int]) extends PreparedStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
     }
-    case class  ExecuteUpdate4(a: String) extends PreparedStatementOp[Int] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a))
+    case class  ExecuteUpdate4(a: String, b: Int) extends PreparedStatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
     }
     case object GetConnection extends PreparedStatementOp[Connection] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getConnection())
@@ -222,12 +203,6 @@ object preparedstatement {
     }
     case object GetGeneratedKeys extends PreparedStatementOp[ResultSet] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getGeneratedKeys())
-    }
-    case object GetLargeMaxRows extends PreparedStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeMaxRows())
-    }
-    case object GetLargeUpdateCount extends PreparedStatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeUpdateCount())
     }
     case object GetMaxFieldSize extends PreparedStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMaxFieldSize())
@@ -283,10 +258,10 @@ object preparedstatement {
     case class  SetArray(a: Int, b: SqlArray) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setArray(a, b))
     }
-    case class  SetAsciiStream(a: Int, b: InputStream, c: Int) extends PreparedStatementOp[Unit] {
+    case class  SetAsciiStream(a: Int, b: InputStream, c: Long) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
     }
-    case class  SetAsciiStream1(a: Int, b: InputStream, c: Long) extends PreparedStatementOp[Unit] {
+    case class  SetAsciiStream1(a: Int, b: InputStream, c: Int) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
     }
     case class  SetAsciiStream2(a: Int, b: InputStream) extends PreparedStatementOp[Unit] {
@@ -304,11 +279,11 @@ object preparedstatement {
     case class  SetBinaryStream2(a: Int, b: InputStream, c: Long) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBinaryStream(a, b, c))
     }
-    case class  SetBlob(a: Int, b: InputStream, c: Long) extends PreparedStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b, c))
-    }
-    case class  SetBlob1(a: Int, b: Blob) extends PreparedStatementOp[Unit] {
+    case class  SetBlob(a: Int, b: Blob) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b))
+    }
+    case class  SetBlob1(a: Int, b: InputStream, c: Long) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b, c))
     }
     case class  SetBlob2(a: Int, b: InputStream) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBlob(a, b))
@@ -322,13 +297,13 @@ object preparedstatement {
     case class  SetBytes(a: Int, b: Array[Byte]) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBytes(a, b))
     }
-    case class  SetCharacterStream(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b, c))
-    }
-    case class  SetCharacterStream1(a: Int, b: Reader) extends PreparedStatementOp[Unit] {
+    case class  SetCharacterStream(a: Int, b: Reader) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b))
     }
-    case class  SetCharacterStream2(a: Int, b: Reader, c: Int) extends PreparedStatementOp[Unit] {
+    case class  SetCharacterStream1(a: Int, b: Reader, c: Int) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b, c))
+    }
+    case class  SetCharacterStream2(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b, c))
     }
     case class  SetClob(a: Int, b: Clob) extends PreparedStatementOp[Unit] {
@@ -343,11 +318,11 @@ object preparedstatement {
     case class  SetCursorName(a: String) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCursorName(a))
     }
-    case class  SetDate(a: Int, b: Date, c: Calendar) extends PreparedStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b, c))
-    }
-    case class  SetDate1(a: Int, b: Date) extends PreparedStatementOp[Unit] {
+    case class  SetDate(a: Int, b: Date) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b))
+    }
+    case class  SetDate1(a: Int, b: Date, c: Calendar) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDate(a, b, c))
     }
     case class  SetDouble(a: Int, b: Double) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setDouble(a, b))
@@ -367,9 +342,6 @@ object preparedstatement {
     case class  SetInt(a: Int, b: Int) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setInt(a, b))
     }
-    case class  SetLargeMaxRows(a: Long) extends PreparedStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setLargeMaxRows(a))
-    }
     case class  SetLong(a: Int, b: Long) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setLong(a, b))
     }
@@ -385,11 +357,11 @@ object preparedstatement {
     case class  SetNCharacterStream1(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNCharacterStream(a, b, c))
     }
-    case class  SetNClob(a: Int, b: NClob) extends PreparedStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
-    }
-    case class  SetNClob1(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit] {
+    case class  SetNClob(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b, c))
+    }
+    case class  SetNClob1(a: Int, b: NClob) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
     }
     case class  SetNClob2(a: Int, b: Reader) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
@@ -403,19 +375,13 @@ object preparedstatement {
     case class  SetNull1(a: Int, b: Int, c: String) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNull(a, b, c))
     }
-    case class  SetObject(a: Int, b: Object, c: SQLType, d: Int) extends PreparedStatementOp[Unit] {
+    case class  SetObject(a: Int, b: Object, c: Int, d: Int) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
     }
-    case class  SetObject1(a: Int, b: Object, c: SQLType) extends PreparedStatementOp[Unit] {
+    case class  SetObject1(a: Int, b: Object, c: Int) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
     }
-    case class  SetObject2(a: Int, b: Object, c: Int) extends PreparedStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
-    }
-    case class  SetObject3(a: Int, b: Object, c: Int, d: Int) extends PreparedStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
-    }
-    case class  SetObject4(a: Int, b: Object) extends PreparedStatementOp[Unit] {
+    case class  SetObject2(a: Int, b: Object) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b))
     }
     case class  SetPoolable(a: Boolean) extends PreparedStatementOp[Unit] {
@@ -575,25 +541,25 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def execute(a: String, b: Array[String]): PreparedStatementIO[Boolean] =
+  def execute(a: String, b: Array[Int]): PreparedStatementIO[Boolean] =
     F.liftF(Execute1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def execute(a: String): PreparedStatementIO[Boolean] =
-    F.liftF(Execute2(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def execute(a: String, b: Array[Int]): PreparedStatementIO[Boolean] =
-    F.liftF(Execute3(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def execute(a: String, b: Int): PreparedStatementIO[Boolean] =
+    F.liftF(Execute2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def execute(a: String): PreparedStatementIO[Boolean] =
+    F.liftF(Execute3(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def execute(a: String, b: Array[String]): PreparedStatementIO[Boolean] =
     F.liftF(Execute4(a, b))
 
   /** 
@@ -601,42 +567,6 @@ object preparedstatement {
    */
   val executeBatch: PreparedStatementIO[Array[Int]] =
     F.liftF(ExecuteBatch)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val executeLargeBatch: PreparedStatementIO[Array[Long]] =
-    F.liftF(ExecuteLargeBatch)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val executeLargeUpdate: PreparedStatementIO[Long] =
-    F.liftF(ExecuteLargeUpdate)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String, b: Int): PreparedStatementIO[Long] =
-    F.liftF(ExecuteLargeUpdate1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String, b: Array[Int]): PreparedStatementIO[Long] =
-    F.liftF(ExecuteLargeUpdate2(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String): PreparedStatementIO[Long] =
-    F.liftF(ExecuteLargeUpdate3(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String, b: Array[String]): PreparedStatementIO[Long] =
-    F.liftF(ExecuteLargeUpdate4(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -659,8 +589,8 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def executeUpdate(a: String, b: Int): PreparedStatementIO[Int] =
-    F.liftF(ExecuteUpdate1(a, b))
+  def executeUpdate(a: String): PreparedStatementIO[Int] =
+    F.liftF(ExecuteUpdate1(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -677,8 +607,8 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def executeUpdate(a: String): PreparedStatementIO[Int] =
-    F.liftF(ExecuteUpdate4(a))
+  def executeUpdate(a: String, b: Int): PreparedStatementIO[Int] =
+    F.liftF(ExecuteUpdate4(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -703,18 +633,6 @@ object preparedstatement {
    */
   val getGeneratedKeys: PreparedStatementIO[ResultSet] =
     F.liftF(GetGeneratedKeys)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val getLargeMaxRows: PreparedStatementIO[Long] =
-    F.liftF(GetLargeMaxRows)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val getLargeUpdateCount: PreparedStatementIO[Long] =
-    F.liftF(GetLargeUpdateCount)
 
   /** 
    * @group Constructors (Primitives)
@@ -827,13 +745,13 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setAsciiStream(a: Int, b: InputStream, c: Int): PreparedStatementIO[Unit] =
+  def setAsciiStream(a: Int, b: InputStream, c: Long): PreparedStatementIO[Unit] =
     F.liftF(SetAsciiStream(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setAsciiStream(a: Int, b: InputStream, c: Long): PreparedStatementIO[Unit] =
+  def setAsciiStream(a: Int, b: InputStream, c: Int): PreparedStatementIO[Unit] =
     F.liftF(SetAsciiStream1(a, b, c))
 
   /** 
@@ -869,14 +787,14 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setBlob(a: Int, b: InputStream, c: Long): PreparedStatementIO[Unit] =
-    F.liftF(SetBlob(a, b, c))
+  def setBlob(a: Int, b: Blob): PreparedStatementIO[Unit] =
+    F.liftF(SetBlob(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setBlob(a: Int, b: Blob): PreparedStatementIO[Unit] =
-    F.liftF(SetBlob1(a, b))
+  def setBlob(a: Int, b: InputStream, c: Long): PreparedStatementIO[Unit] =
+    F.liftF(SetBlob1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -905,19 +823,19 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setCharacterStream(a: Int, b: Reader, c: Long): PreparedStatementIO[Unit] =
-    F.liftF(SetCharacterStream(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def setCharacterStream(a: Int, b: Reader): PreparedStatementIO[Unit] =
-    F.liftF(SetCharacterStream1(a, b))
+    F.liftF(SetCharacterStream(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setCharacterStream(a: Int, b: Reader, c: Int): PreparedStatementIO[Unit] =
+    F.liftF(SetCharacterStream1(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setCharacterStream(a: Int, b: Reader, c: Long): PreparedStatementIO[Unit] =
     F.liftF(SetCharacterStream2(a, b, c))
 
   /** 
@@ -947,14 +865,14 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setDate(a: Int, b: Date, c: Calendar): PreparedStatementIO[Unit] =
-    F.liftF(SetDate(a, b, c))
+  def setDate(a: Int, b: Date): PreparedStatementIO[Unit] =
+    F.liftF(SetDate(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setDate(a: Int, b: Date): PreparedStatementIO[Unit] =
-    F.liftF(SetDate1(a, b))
+  def setDate(a: Int, b: Date, c: Calendar): PreparedStatementIO[Unit] =
+    F.liftF(SetDate1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -995,12 +913,6 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setLargeMaxRows(a: Long): PreparedStatementIO[Unit] =
-    F.liftF(SetLargeMaxRows(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def setLong(a: Int, b: Long): PreparedStatementIO[Unit] =
     F.liftF(SetLong(a, b))
 
@@ -1031,14 +943,14 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setNClob(a: Int, b: NClob): PreparedStatementIO[Unit] =
-    F.liftF(SetNClob(a, b))
+  def setNClob(a: Int, b: Reader, c: Long): PreparedStatementIO[Unit] =
+    F.liftF(SetNClob(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setNClob(a: Int, b: Reader, c: Long): PreparedStatementIO[Unit] =
-    F.liftF(SetNClob1(a, b, c))
+  def setNClob(a: Int, b: NClob): PreparedStatementIO[Unit] =
+    F.liftF(SetNClob1(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1067,32 +979,20 @@ object preparedstatement {
   /** 
    * @group Constructors (Primitives)
    */
-  def setObject(a: Int, b: Object, c: SQLType, d: Int): PreparedStatementIO[Unit] =
+  def setObject(a: Int, b: Object, c: Int, d: Int): PreparedStatementIO[Unit] =
     F.liftF(SetObject(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setObject(a: Int, b: Object, c: SQLType): PreparedStatementIO[Unit] =
+  def setObject(a: Int, b: Object, c: Int): PreparedStatementIO[Unit] =
     F.liftF(SetObject1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setObject(a: Int, b: Object, c: Int): PreparedStatementIO[Unit] =
-    F.liftF(SetObject2(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setObject(a: Int, b: Object, c: Int, d: Int): PreparedStatementIO[Unit] =
-    F.liftF(SetObject3(a, b, c, d))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def setObject(a: Int, b: Object): PreparedStatementIO[Unit] =
-    F.liftF(SetObject4(a, b))
+    F.liftF(SetObject2(a, b))
 
   /** 
    * @group Constructors (Primitives)

--- a/core/src/main/scala/doobie/free/preparedstatement.scala
+++ b/core/src/main/scala/doobie/free/preparedstatement.scala
@@ -1,6 +1,6 @@
 package doobie.free
 
-import scalaz.{ Catchable, Coyoneda, Free => F, Kleisli, Monad, ~>, \/ }
+import scalaz.{ Catchable, Free => F, Kleisli, Monad, ~>, \/ }
 import scalaz.concurrent.Task
 
 import doobie.util.capture._
@@ -30,6 +30,7 @@ import java.sql.RowId
 import java.sql.SQLData
 import java.sql.SQLInput
 import java.sql.SQLOutput
+import java.sql.SQLType
 import java.sql.SQLWarning
 import java.sql.SQLXML
 import java.sql.Statement
@@ -111,7 +112,7 @@ object preparedstatement {
       }
 
     // Lifting
-    case class Lift[Op[_], A, J](j: J, action: F.FreeC[Op, A], mod: KleisliTrans.Aux[Op, J]) extends PreparedStatementOp[A] {
+    case class Lift[Op[_], A, J](j: J, action: F[Op, A], mod: KleisliTrans.Aux[Op, J]) extends PreparedStatementOp[A] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => mod.transK[M].apply(action).run(j))
     }
 
@@ -156,20 +157,38 @@ object preparedstatement {
     case object Execute extends PreparedStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute())
     }
-    case class  Execute1(a: String, b: Array[Int]) extends PreparedStatementOp[Boolean] {
+    case class  Execute1(a: String, b: Array[String]) extends PreparedStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
     }
-    case class  Execute2(a: String, b: Int) extends PreparedStatementOp[Boolean] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
-    }
-    case class  Execute3(a: String) extends PreparedStatementOp[Boolean] {
+    case class  Execute2(a: String) extends PreparedStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a))
     }
-    case class  Execute4(a: String, b: Array[String]) extends PreparedStatementOp[Boolean] {
+    case class  Execute3(a: String, b: Array[Int]) extends PreparedStatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
+    }
+    case class  Execute4(a: String, b: Int) extends PreparedStatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
     }
     case object ExecuteBatch extends PreparedStatementOp[Array[Int]] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeBatch())
+    }
+    case object ExecuteLargeBatch extends PreparedStatementOp[Array[Long]] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeBatch())
+    }
+    case object ExecuteLargeUpdate extends PreparedStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate())
+    }
+    case class  ExecuteLargeUpdate1(a: String, b: Int) extends PreparedStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
+    }
+    case class  ExecuteLargeUpdate2(a: String, b: Array[Int]) extends PreparedStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
+    }
+    case class  ExecuteLargeUpdate3(a: String) extends PreparedStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a))
+    }
+    case class  ExecuteLargeUpdate4(a: String, b: Array[String]) extends PreparedStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
     }
     case object ExecuteQuery extends PreparedStatementOp[ResultSet] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeQuery())
@@ -180,10 +199,10 @@ object preparedstatement {
     case object ExecuteUpdate extends PreparedStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate())
     }
-    case class  ExecuteUpdate1(a: String, b: Array[String]) extends PreparedStatementOp[Int] {
+    case class  ExecuteUpdate1(a: String, b: Int) extends PreparedStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
     }
-    case class  ExecuteUpdate2(a: String, b: Int) extends PreparedStatementOp[Int] {
+    case class  ExecuteUpdate2(a: String, b: Array[String]) extends PreparedStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
     }
     case class  ExecuteUpdate3(a: String, b: Array[Int]) extends PreparedStatementOp[Int] {
@@ -203,6 +222,12 @@ object preparedstatement {
     }
     case object GetGeneratedKeys extends PreparedStatementOp[ResultSet] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getGeneratedKeys())
+    }
+    case object GetLargeMaxRows extends PreparedStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeMaxRows())
+    }
+    case object GetLargeUpdateCount extends PreparedStatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeUpdateCount())
     }
     case object GetMaxFieldSize extends PreparedStatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMaxFieldSize())
@@ -258,14 +283,14 @@ object preparedstatement {
     case class  SetArray(a: Int, b: SqlArray) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setArray(a, b))
     }
-    case class  SetAsciiStream(a: Int, b: InputStream) extends PreparedStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b))
+    case class  SetAsciiStream(a: Int, b: InputStream, c: Int) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
     }
     case class  SetAsciiStream1(a: Int, b: InputStream, c: Long) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
     }
-    case class  SetAsciiStream2(a: Int, b: InputStream, c: Int) extends PreparedStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b, c))
+    case class  SetAsciiStream2(a: Int, b: InputStream) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setAsciiStream(a, b))
     }
     case class  SetBigDecimal(a: Int, b: BigDecimal) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBigDecimal(a, b))
@@ -297,23 +322,23 @@ object preparedstatement {
     case class  SetBytes(a: Int, b: Array[Byte]) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setBytes(a, b))
     }
-    case class  SetCharacterStream(a: Int, b: Reader, c: Int) extends PreparedStatementOp[Unit] {
+    case class  SetCharacterStream(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b, c))
     }
     case class  SetCharacterStream1(a: Int, b: Reader) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b))
     }
-    case class  SetCharacterStream2(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit] {
+    case class  SetCharacterStream2(a: Int, b: Reader, c: Int) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCharacterStream(a, b, c))
     }
-    case class  SetClob(a: Int, b: Reader) extends PreparedStatementOp[Unit] {
+    case class  SetClob(a: Int, b: Clob) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
     }
-    case class  SetClob1(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit] {
+    case class  SetClob1(a: Int, b: Reader) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
+    }
+    case class  SetClob2(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b, c))
-    }
-    case class  SetClob2(a: Int, b: Clob) extends PreparedStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setClob(a, b))
     }
     case class  SetCursorName(a: String) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setCursorName(a))
@@ -342,6 +367,9 @@ object preparedstatement {
     case class  SetInt(a: Int, b: Int) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setInt(a, b))
     }
+    case class  SetLargeMaxRows(a: Long) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setLargeMaxRows(a))
+    }
     case class  SetLong(a: Int, b: Long) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setLong(a, b))
     }
@@ -357,11 +385,11 @@ object preparedstatement {
     case class  SetNCharacterStream1(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNCharacterStream(a, b, c))
     }
-    case class  SetNClob(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b, c))
-    }
-    case class  SetNClob1(a: Int, b: NClob) extends PreparedStatementOp[Unit] {
+    case class  SetNClob(a: Int, b: NClob) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
+    }
+    case class  SetNClob1(a: Int, b: Reader, c: Long) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b, c))
     }
     case class  SetNClob2(a: Int, b: Reader) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNClob(a, b))
@@ -375,13 +403,19 @@ object preparedstatement {
     case class  SetNull1(a: Int, b: Int, c: String) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setNull(a, b, c))
     }
-    case class  SetObject(a: Int, b: Object, c: Int, d: Int) extends PreparedStatementOp[Unit] {
+    case class  SetObject(a: Int, b: Object, c: SQLType, d: Int) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
     }
-    case class  SetObject1(a: Int, b: Object, c: Int) extends PreparedStatementOp[Unit] {
+    case class  SetObject1(a: Int, b: Object, c: SQLType) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
     }
-    case class  SetObject2(a: Int, b: Object) extends PreparedStatementOp[Unit] {
+    case class  SetObject2(a: Int, b: Object, c: Int) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c))
+    }
+    case class  SetObject3(a: Int, b: Object, c: Int, d: Int) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b, c, d))
+    }
+    case class  SetObject4(a: Int, b: Object) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a, b))
     }
     case class  SetPoolable(a: Boolean) extends PreparedStatementOp[Unit] {
@@ -405,17 +439,17 @@ object preparedstatement {
     case class  SetString(a: Int, b: String) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setString(a, b))
     }
-    case class  SetTime(a: Int, b: Time) extends PreparedStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTime(a, b))
-    }
-    case class  SetTime1(a: Int, b: Time, c: Calendar) extends PreparedStatementOp[Unit] {
+    case class  SetTime(a: Int, b: Time, c: Calendar) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTime(a, b, c))
     }
-    case class  SetTimestamp(a: Int, b: Timestamp, c: Calendar) extends PreparedStatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b, c))
+    case class  SetTime1(a: Int, b: Time) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTime(a, b))
     }
-    case class  SetTimestamp1(a: Int, b: Timestamp) extends PreparedStatementOp[Unit] {
+    case class  SetTimestamp(a: Int, b: Timestamp) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b))
+    }
+    case class  SetTimestamp1(a: Int, b: Timestamp, c: Calendar) extends PreparedStatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setTimestamp(a, b, c))
     }
     case class  SetURL(a: Int, b: URL) extends PreparedStatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setURL(a, b))
@@ -435,14 +469,7 @@ object preparedstatement {
    * a `java.sql.PreparedStatement` and produces a value of type `A`. 
    * @group Algebra 
    */
-  type PreparedStatementIO[A] = F.FreeC[PreparedStatementOp, A]
-
-  /**
-   * Monad instance for [[PreparedStatementIO]] (can't be inferred).
-   * @group Typeclass Instances 
-   */
-  implicit val MonadPreparedStatementIO: Monad[PreparedStatementIO] = 
-    F.freeMonad[({type λ[α] = Coyoneda[PreparedStatementOp, α]})#λ]
+  type PreparedStatementIO[A] = F[PreparedStatementOp, A]
 
   /**
    * Catchable instance for [[PreparedStatementIO]].
@@ -467,623 +494,689 @@ object preparedstatement {
    * Lift a different type of program that has a default Kleisli interpreter.
    * @group Constructors (Lifting)
    */
-  def lift[Op[_], A, J](j: J, action: F.FreeC[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): PreparedStatementIO[A] =
-    F.liftFC(Lift(j, action, mod))
+  def lift[Op[_], A, J](j: J, action: F[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): PreparedStatementIO[A] =
+    F.liftF(Lift(j, action, mod))
 
   /** 
    * Lift a PreparedStatementIO[A] into an exception-capturing PreparedStatementIO[Throwable \/ A].
    * @group Constructors (Lifting)
    */
   def attempt[A](a: PreparedStatementIO[A]): PreparedStatementIO[Throwable \/ A] =
-    F.liftFC[PreparedStatementOp, Throwable \/ A](Attempt(a))
+    F.liftF[PreparedStatementOp, Throwable \/ A](Attempt(a))
  
   /**
    * Non-strict unit for capturing effects.
    * @group Constructors (Lifting)
    */
   def delay[A](a: => A): PreparedStatementIO[A] =
-    F.liftFC(Pure(a _))
+    F.liftF(Pure(a _))
 
   /**
    * Backdoor for arbitrary computations on the underlying PreparedStatement.
    * @group Constructors (Lifting)
    */
   def raw[A](f: PreparedStatement => A): PreparedStatementIO[A] =
-    F.liftFC(Raw(f))
+    F.liftF(Raw(f))
 
   /** 
    * @group Constructors (Primitives)
    */
   val addBatch: PreparedStatementIO[Unit] =
-    F.liftFC(AddBatch)
+    F.liftF(AddBatch)
 
   /** 
    * @group Constructors (Primitives)
    */
   def addBatch(a: String): PreparedStatementIO[Unit] =
-    F.liftFC(AddBatch1(a))
+    F.liftF(AddBatch1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val cancel: PreparedStatementIO[Unit] =
-    F.liftFC(Cancel)
+    F.liftF(Cancel)
 
   /** 
    * @group Constructors (Primitives)
    */
   val clearBatch: PreparedStatementIO[Unit] =
-    F.liftFC(ClearBatch)
+    F.liftF(ClearBatch)
 
   /** 
    * @group Constructors (Primitives)
    */
   val clearParameters: PreparedStatementIO[Unit] =
-    F.liftFC(ClearParameters)
+    F.liftF(ClearParameters)
 
   /** 
    * @group Constructors (Primitives)
    */
   val clearWarnings: PreparedStatementIO[Unit] =
-    F.liftFC(ClearWarnings)
+    F.liftF(ClearWarnings)
 
   /** 
    * @group Constructors (Primitives)
    */
   val close: PreparedStatementIO[Unit] =
-    F.liftFC(Close)
+    F.liftF(Close)
 
   /** 
    * @group Constructors (Primitives)
    */
   val closeOnCompletion: PreparedStatementIO[Unit] =
-    F.liftFC(CloseOnCompletion)
+    F.liftF(CloseOnCompletion)
 
   /** 
    * @group Constructors (Primitives)
    */
   val execute: PreparedStatementIO[Boolean] =
-    F.liftFC(Execute)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def execute(a: String, b: Array[Int]): PreparedStatementIO[Boolean] =
-    F.liftFC(Execute1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def execute(a: String, b: Int): PreparedStatementIO[Boolean] =
-    F.liftFC(Execute2(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def execute(a: String): PreparedStatementIO[Boolean] =
-    F.liftFC(Execute3(a))
+    F.liftF(Execute)
 
   /** 
    * @group Constructors (Primitives)
    */
   def execute(a: String, b: Array[String]): PreparedStatementIO[Boolean] =
-    F.liftFC(Execute4(a, b))
+    F.liftF(Execute1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def execute(a: String): PreparedStatementIO[Boolean] =
+    F.liftF(Execute2(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def execute(a: String, b: Array[Int]): PreparedStatementIO[Boolean] =
+    F.liftF(Execute3(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def execute(a: String, b: Int): PreparedStatementIO[Boolean] =
+    F.liftF(Execute4(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   val executeBatch: PreparedStatementIO[Array[Int]] =
-    F.liftFC(ExecuteBatch)
+    F.liftF(ExecuteBatch)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val executeLargeBatch: PreparedStatementIO[Array[Long]] =
+    F.liftF(ExecuteLargeBatch)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val executeLargeUpdate: PreparedStatementIO[Long] =
+    F.liftF(ExecuteLargeUpdate)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String, b: Int): PreparedStatementIO[Long] =
+    F.liftF(ExecuteLargeUpdate1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String, b: Array[Int]): PreparedStatementIO[Long] =
+    F.liftF(ExecuteLargeUpdate2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String): PreparedStatementIO[Long] =
+    F.liftF(ExecuteLargeUpdate3(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String, b: Array[String]): PreparedStatementIO[Long] =
+    F.liftF(ExecuteLargeUpdate4(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   val executeQuery: PreparedStatementIO[ResultSet] =
-    F.liftFC(ExecuteQuery)
+    F.liftF(ExecuteQuery)
 
   /** 
    * @group Constructors (Primitives)
    */
   def executeQuery(a: String): PreparedStatementIO[ResultSet] =
-    F.liftFC(ExecuteQuery1(a))
+    F.liftF(ExecuteQuery1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val executeUpdate: PreparedStatementIO[Int] =
-    F.liftFC(ExecuteUpdate)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeUpdate(a: String, b: Array[String]): PreparedStatementIO[Int] =
-    F.liftFC(ExecuteUpdate1(a, b))
+    F.liftF(ExecuteUpdate)
 
   /** 
    * @group Constructors (Primitives)
    */
   def executeUpdate(a: String, b: Int): PreparedStatementIO[Int] =
-    F.liftFC(ExecuteUpdate2(a, b))
+    F.liftF(ExecuteUpdate1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeUpdate(a: String, b: Array[String]): PreparedStatementIO[Int] =
+    F.liftF(ExecuteUpdate2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def executeUpdate(a: String, b: Array[Int]): PreparedStatementIO[Int] =
-    F.liftFC(ExecuteUpdate3(a, b))
+    F.liftF(ExecuteUpdate3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def executeUpdate(a: String): PreparedStatementIO[Int] =
-    F.liftFC(ExecuteUpdate4(a))
+    F.liftF(ExecuteUpdate4(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getConnection: PreparedStatementIO[Connection] =
-    F.liftFC(GetConnection)
+    F.liftF(GetConnection)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getFetchDirection: PreparedStatementIO[Int] =
-    F.liftFC(GetFetchDirection)
+    F.liftF(GetFetchDirection)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getFetchSize: PreparedStatementIO[Int] =
-    F.liftFC(GetFetchSize)
+    F.liftF(GetFetchSize)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getGeneratedKeys: PreparedStatementIO[ResultSet] =
-    F.liftFC(GetGeneratedKeys)
+    F.liftF(GetGeneratedKeys)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val getLargeMaxRows: PreparedStatementIO[Long] =
+    F.liftF(GetLargeMaxRows)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val getLargeUpdateCount: PreparedStatementIO[Long] =
+    F.liftF(GetLargeUpdateCount)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxFieldSize: PreparedStatementIO[Int] =
-    F.liftFC(GetMaxFieldSize)
+    F.liftF(GetMaxFieldSize)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxRows: PreparedStatementIO[Int] =
-    F.liftFC(GetMaxRows)
+    F.liftF(GetMaxRows)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMetaData: PreparedStatementIO[ResultSetMetaData] =
-    F.liftFC(GetMetaData)
+    F.liftF(GetMetaData)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getMoreResults(a: Int): PreparedStatementIO[Boolean] =
-    F.liftFC(GetMoreResults(a))
+    F.liftF(GetMoreResults(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMoreResults: PreparedStatementIO[Boolean] =
-    F.liftFC(GetMoreResults1)
+    F.liftF(GetMoreResults1)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getParameterMetaData: PreparedStatementIO[ParameterMetaData] =
-    F.liftFC(GetParameterMetaData)
+    F.liftF(GetParameterMetaData)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getQueryTimeout: PreparedStatementIO[Int] =
-    F.liftFC(GetQueryTimeout)
+    F.liftF(GetQueryTimeout)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getResultSet: PreparedStatementIO[ResultSet] =
-    F.liftFC(GetResultSet)
+    F.liftF(GetResultSet)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getResultSetConcurrency: PreparedStatementIO[Int] =
-    F.liftFC(GetResultSetConcurrency)
+    F.liftF(GetResultSetConcurrency)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getResultSetHoldability: PreparedStatementIO[Int] =
-    F.liftFC(GetResultSetHoldability)
+    F.liftF(GetResultSetHoldability)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getResultSetType: PreparedStatementIO[Int] =
-    F.liftFC(GetResultSetType)
+    F.liftF(GetResultSetType)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getUpdateCount: PreparedStatementIO[Int] =
-    F.liftFC(GetUpdateCount)
+    F.liftF(GetUpdateCount)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getWarnings: PreparedStatementIO[SQLWarning] =
-    F.liftFC(GetWarnings)
+    F.liftF(GetWarnings)
 
   /** 
    * @group Constructors (Primitives)
    */
   val isCloseOnCompletion: PreparedStatementIO[Boolean] =
-    F.liftFC(IsCloseOnCompletion)
+    F.liftF(IsCloseOnCompletion)
 
   /** 
    * @group Constructors (Primitives)
    */
   val isClosed: PreparedStatementIO[Boolean] =
-    F.liftFC(IsClosed)
+    F.liftF(IsClosed)
 
   /** 
    * @group Constructors (Primitives)
    */
   val isPoolable: PreparedStatementIO[Boolean] =
-    F.liftFC(IsPoolable)
+    F.liftF(IsPoolable)
 
   /** 
    * @group Constructors (Primitives)
    */
   def isWrapperFor(a: Class[_]): PreparedStatementIO[Boolean] =
-    F.liftFC(IsWrapperFor(a))
+    F.liftF(IsWrapperFor(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setArray(a: Int, b: SqlArray): PreparedStatementIO[Unit] =
-    F.liftFC(SetArray(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setAsciiStream(a: Int, b: InputStream): PreparedStatementIO[Unit] =
-    F.liftFC(SetAsciiStream(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setAsciiStream(a: Int, b: InputStream, c: Long): PreparedStatementIO[Unit] =
-    F.liftFC(SetAsciiStream1(a, b, c))
+    F.liftF(SetArray(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setAsciiStream(a: Int, b: InputStream, c: Int): PreparedStatementIO[Unit] =
-    F.liftFC(SetAsciiStream2(a, b, c))
+    F.liftF(SetAsciiStream(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setAsciiStream(a: Int, b: InputStream, c: Long): PreparedStatementIO[Unit] =
+    F.liftF(SetAsciiStream1(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setAsciiStream(a: Int, b: InputStream): PreparedStatementIO[Unit] =
+    F.liftF(SetAsciiStream2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBigDecimal(a: Int, b: BigDecimal): PreparedStatementIO[Unit] =
-    F.liftFC(SetBigDecimal(a, b))
+    F.liftF(SetBigDecimal(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBinaryStream(a: Int, b: InputStream, c: Int): PreparedStatementIO[Unit] =
-    F.liftFC(SetBinaryStream(a, b, c))
+    F.liftF(SetBinaryStream(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBinaryStream(a: Int, b: InputStream): PreparedStatementIO[Unit] =
-    F.liftFC(SetBinaryStream1(a, b))
+    F.liftF(SetBinaryStream1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBinaryStream(a: Int, b: InputStream, c: Long): PreparedStatementIO[Unit] =
-    F.liftFC(SetBinaryStream2(a, b, c))
+    F.liftF(SetBinaryStream2(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBlob(a: Int, b: InputStream, c: Long): PreparedStatementIO[Unit] =
-    F.liftFC(SetBlob(a, b, c))
+    F.liftF(SetBlob(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBlob(a: Int, b: Blob): PreparedStatementIO[Unit] =
-    F.liftFC(SetBlob1(a, b))
+    F.liftF(SetBlob1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBlob(a: Int, b: InputStream): PreparedStatementIO[Unit] =
-    F.liftFC(SetBlob2(a, b))
+    F.liftF(SetBlob2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBoolean(a: Int, b: Boolean): PreparedStatementIO[Unit] =
-    F.liftFC(SetBoolean(a, b))
+    F.liftF(SetBoolean(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setByte(a: Int, b: Byte): PreparedStatementIO[Unit] =
-    F.liftFC(SetByte(a, b))
+    F.liftF(SetByte(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setBytes(a: Int, b: Array[Byte]): PreparedStatementIO[Unit] =
-    F.liftFC(SetBytes(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setCharacterStream(a: Int, b: Reader, c: Int): PreparedStatementIO[Unit] =
-    F.liftFC(SetCharacterStream(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setCharacterStream(a: Int, b: Reader): PreparedStatementIO[Unit] =
-    F.liftFC(SetCharacterStream1(a, b))
+    F.liftF(SetBytes(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setCharacterStream(a: Int, b: Reader, c: Long): PreparedStatementIO[Unit] =
-    F.liftFC(SetCharacterStream2(a, b, c))
+    F.liftF(SetCharacterStream(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setClob(a: Int, b: Reader): PreparedStatementIO[Unit] =
-    F.liftFC(SetClob(a, b))
+  def setCharacterStream(a: Int, b: Reader): PreparedStatementIO[Unit] =
+    F.liftF(SetCharacterStream1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setClob(a: Int, b: Reader, c: Long): PreparedStatementIO[Unit] =
-    F.liftFC(SetClob1(a, b, c))
+  def setCharacterStream(a: Int, b: Reader, c: Int): PreparedStatementIO[Unit] =
+    F.liftF(SetCharacterStream2(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setClob(a: Int, b: Clob): PreparedStatementIO[Unit] =
-    F.liftFC(SetClob2(a, b))
+    F.liftF(SetClob(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setClob(a: Int, b: Reader): PreparedStatementIO[Unit] =
+    F.liftF(SetClob1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setClob(a: Int, b: Reader, c: Long): PreparedStatementIO[Unit] =
+    F.liftF(SetClob2(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setCursorName(a: String): PreparedStatementIO[Unit] =
-    F.liftFC(SetCursorName(a))
+    F.liftF(SetCursorName(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setDate(a: Int, b: Date, c: Calendar): PreparedStatementIO[Unit] =
-    F.liftFC(SetDate(a, b, c))
+    F.liftF(SetDate(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setDate(a: Int, b: Date): PreparedStatementIO[Unit] =
-    F.liftFC(SetDate1(a, b))
+    F.liftF(SetDate1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setDouble(a: Int, b: Double): PreparedStatementIO[Unit] =
-    F.liftFC(SetDouble(a, b))
+    F.liftF(SetDouble(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setEscapeProcessing(a: Boolean): PreparedStatementIO[Unit] =
-    F.liftFC(SetEscapeProcessing(a))
+    F.liftF(SetEscapeProcessing(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setFetchDirection(a: Int): PreparedStatementIO[Unit] =
-    F.liftFC(SetFetchDirection(a))
+    F.liftF(SetFetchDirection(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setFetchSize(a: Int): PreparedStatementIO[Unit] =
-    F.liftFC(SetFetchSize(a))
+    F.liftF(SetFetchSize(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setFloat(a: Int, b: Float): PreparedStatementIO[Unit] =
-    F.liftFC(SetFloat(a, b))
+    F.liftF(SetFloat(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setInt(a: Int, b: Int): PreparedStatementIO[Unit] =
-    F.liftFC(SetInt(a, b))
+    F.liftF(SetInt(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setLargeMaxRows(a: Long): PreparedStatementIO[Unit] =
+    F.liftF(SetLargeMaxRows(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setLong(a: Int, b: Long): PreparedStatementIO[Unit] =
-    F.liftFC(SetLong(a, b))
+    F.liftF(SetLong(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setMaxFieldSize(a: Int): PreparedStatementIO[Unit] =
-    F.liftFC(SetMaxFieldSize(a))
+    F.liftF(SetMaxFieldSize(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setMaxRows(a: Int): PreparedStatementIO[Unit] =
-    F.liftFC(SetMaxRows(a))
+    F.liftF(SetMaxRows(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNCharacterStream(a: Int, b: Reader): PreparedStatementIO[Unit] =
-    F.liftFC(SetNCharacterStream(a, b))
+    F.liftF(SetNCharacterStream(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNCharacterStream(a: Int, b: Reader, c: Long): PreparedStatementIO[Unit] =
-    F.liftFC(SetNCharacterStream1(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setNClob(a: Int, b: Reader, c: Long): PreparedStatementIO[Unit] =
-    F.liftFC(SetNClob(a, b, c))
+    F.liftF(SetNCharacterStream1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNClob(a: Int, b: NClob): PreparedStatementIO[Unit] =
-    F.liftFC(SetNClob1(a, b))
+    F.liftF(SetNClob(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setNClob(a: Int, b: Reader, c: Long): PreparedStatementIO[Unit] =
+    F.liftF(SetNClob1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNClob(a: Int, b: Reader): PreparedStatementIO[Unit] =
-    F.liftFC(SetNClob2(a, b))
+    F.liftF(SetNClob2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNString(a: Int, b: String): PreparedStatementIO[Unit] =
-    F.liftFC(SetNString(a, b))
+    F.liftF(SetNString(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNull(a: Int, b: Int): PreparedStatementIO[Unit] =
-    F.liftFC(SetNull(a, b))
+    F.liftF(SetNull(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setNull(a: Int, b: Int, c: String): PreparedStatementIO[Unit] =
-    F.liftFC(SetNull1(a, b, c))
+    F.liftF(SetNull1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setObject(a: Int, b: Object, c: Int, d: Int): PreparedStatementIO[Unit] =
-    F.liftFC(SetObject(a, b, c, d))
+  def setObject(a: Int, b: Object, c: SQLType, d: Int): PreparedStatementIO[Unit] =
+    F.liftF(SetObject(a, b, c, d))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setObject(a: Int, b: Object, c: SQLType): PreparedStatementIO[Unit] =
+    F.liftF(SetObject1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setObject(a: Int, b: Object, c: Int): PreparedStatementIO[Unit] =
-    F.liftFC(SetObject1(a, b, c))
+    F.liftF(SetObject2(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setObject(a: Int, b: Object, c: Int, d: Int): PreparedStatementIO[Unit] =
+    F.liftF(SetObject3(a, b, c, d))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setObject(a: Int, b: Object): PreparedStatementIO[Unit] =
-    F.liftFC(SetObject2(a, b))
+    F.liftF(SetObject4(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setPoolable(a: Boolean): PreparedStatementIO[Unit] =
-    F.liftFC(SetPoolable(a))
+    F.liftF(SetPoolable(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setQueryTimeout(a: Int): PreparedStatementIO[Unit] =
-    F.liftFC(SetQueryTimeout(a))
+    F.liftF(SetQueryTimeout(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setRef(a: Int, b: Ref): PreparedStatementIO[Unit] =
-    F.liftFC(SetRef(a, b))
+    F.liftF(SetRef(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setRowId(a: Int, b: RowId): PreparedStatementIO[Unit] =
-    F.liftFC(SetRowId(a, b))
+    F.liftF(SetRowId(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setSQLXML(a: Int, b: SQLXML): PreparedStatementIO[Unit] =
-    F.liftFC(SetSQLXML(a, b))
+    F.liftF(SetSQLXML(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setShort(a: Int, b: Short): PreparedStatementIO[Unit] =
-    F.liftFC(SetShort(a, b))
+    F.liftF(SetShort(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setString(a: Int, b: String): PreparedStatementIO[Unit] =
-    F.liftFC(SetString(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setTime(a: Int, b: Time): PreparedStatementIO[Unit] =
-    F.liftFC(SetTime(a, b))
+    F.liftF(SetString(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setTime(a: Int, b: Time, c: Calendar): PreparedStatementIO[Unit] =
-    F.liftFC(SetTime1(a, b, c))
+    F.liftF(SetTime(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def setTimestamp(a: Int, b: Timestamp, c: Calendar): PreparedStatementIO[Unit] =
-    F.liftFC(SetTimestamp(a, b, c))
+  def setTime(a: Int, b: Time): PreparedStatementIO[Unit] =
+    F.liftF(SetTime1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setTimestamp(a: Int, b: Timestamp): PreparedStatementIO[Unit] =
-    F.liftFC(SetTimestamp1(a, b))
+    F.liftF(SetTimestamp(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setTimestamp(a: Int, b: Timestamp, c: Calendar): PreparedStatementIO[Unit] =
+    F.liftF(SetTimestamp1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setURL(a: Int, b: URL): PreparedStatementIO[Unit] =
-    F.liftFC(SetURL(a, b))
+    F.liftF(SetURL(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setUnicodeStream(a: Int, b: InputStream, c: Int): PreparedStatementIO[Unit] =
-    F.liftFC(SetUnicodeStream(a, b, c))
+    F.liftF(SetUnicodeStream(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def unwrap[T](a: Class[T]): PreparedStatementIO[T] =
-    F.liftFC(Unwrap(a))
+    F.liftF(Unwrap(a))
 
  /** 
   * Natural transformation from `PreparedStatementOp` to `Kleisli` for the given `M`, consuming a `java.sql.PreparedStatement`. 

--- a/core/src/main/scala/doobie/free/ref.scala
+++ b/core/src/main/scala/doobie/free/ref.scala
@@ -1,6 +1,6 @@
 package doobie.free
 
-import scalaz.{ Catchable, Coyoneda, Free => F, Kleisli, Monad, ~>, \/ }
+import scalaz.{ Catchable, Free => F, Kleisli, Monad, ~>, \/ }
 import scalaz.concurrent.Task
 
 import doobie.util.capture._
@@ -97,7 +97,7 @@ object ref {
       }
 
     // Lifting
-    case class Lift[Op[_], A, J](j: J, action: F.FreeC[Op, A], mod: KleisliTrans.Aux[Op, J]) extends RefOp[A] {
+    case class Lift[Op[_], A, J](j: J, action: F[Op, A], mod: KleisliTrans.Aux[Op, J]) extends RefOp[A] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => mod.transK[M].apply(action).run(j))
     }
 
@@ -118,11 +118,11 @@ object ref {
     case object GetBaseTypeName extends RefOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBaseTypeName())
     }
-    case object GetObject extends RefOp[Object] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject())
-    }
-    case class  GetObject1(a: Map[String, Class[_]]) extends RefOp[Object] {
+    case class  GetObject(a: Map[String, Class[_]]) extends RefOp[Object] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a))
+    }
+    case object GetObject1 extends RefOp[Object] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject())
     }
     case class  SetObject(a: Object) extends RefOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setObject(a))
@@ -136,14 +136,7 @@ object ref {
    * a `java.sql.Ref` and produces a value of type `A`. 
    * @group Algebra 
    */
-  type RefIO[A] = F.FreeC[RefOp, A]
-
-  /**
-   * Monad instance for [[RefIO]] (can't be inferred).
-   * @group Typeclass Instances 
-   */
-  implicit val MonadRefIO: Monad[RefIO] = 
-    F.freeMonad[({type λ[α] = Coyoneda[RefOp, α]})#λ]
+  type RefIO[A] = F[RefOp, A]
 
   /**
    * Catchable instance for [[RefIO]].
@@ -168,53 +161,53 @@ object ref {
    * Lift a different type of program that has a default Kleisli interpreter.
    * @group Constructors (Lifting)
    */
-  def lift[Op[_], A, J](j: J, action: F.FreeC[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): RefIO[A] =
-    F.liftFC(Lift(j, action, mod))
+  def lift[Op[_], A, J](j: J, action: F[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): RefIO[A] =
+    F.liftF(Lift(j, action, mod))
 
   /** 
    * Lift a RefIO[A] into an exception-capturing RefIO[Throwable \/ A].
    * @group Constructors (Lifting)
    */
   def attempt[A](a: RefIO[A]): RefIO[Throwable \/ A] =
-    F.liftFC[RefOp, Throwable \/ A](Attempt(a))
+    F.liftF[RefOp, Throwable \/ A](Attempt(a))
  
   /**
    * Non-strict unit for capturing effects.
    * @group Constructors (Lifting)
    */
   def delay[A](a: => A): RefIO[A] =
-    F.liftFC(Pure(a _))
+    F.liftF(Pure(a _))
 
   /**
    * Backdoor for arbitrary computations on the underlying Ref.
    * @group Constructors (Lifting)
    */
   def raw[A](f: Ref => A): RefIO[A] =
-    F.liftFC(Raw(f))
+    F.liftF(Raw(f))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getBaseTypeName: RefIO[String] =
-    F.liftFC(GetBaseTypeName)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val getObject: RefIO[Object] =
-    F.liftFC(GetObject)
+    F.liftF(GetBaseTypeName)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getObject(a: Map[String, Class[_]]): RefIO[Object] =
-    F.liftFC(GetObject1(a))
+    F.liftF(GetObject(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val getObject: RefIO[Object] =
+    F.liftF(GetObject1)
 
   /** 
    * @group Constructors (Primitives)
    */
   def setObject(a: Object): RefIO[Unit] =
-    F.liftFC(SetObject(a))
+    F.liftF(SetObject(a))
 
  /** 
   * Natural transformation from `RefOp` to `Kleisli` for the given `M`, consuming a `java.sql.Ref`. 

--- a/core/src/main/scala/doobie/free/ref.scala
+++ b/core/src/main/scala/doobie/free/ref.scala
@@ -47,7 +47,7 @@ import resultset.ResultSetIO
  *
  * `RefIO` is a free monad that must be run via an interpreter, most commonly via
  * natural transformation of its underlying algebra `RefOp` to another monad via
- * `Free.runFC`. 
+ * `Free#foldMap`.
  *
  * The library provides a natural transformation to `Kleisli[M, Ref, A]` for any
  * exception-trapping (`Catchable`) and effect-capturing (`Capture`) monad `M`. Such evidence is 

--- a/core/src/main/scala/doobie/free/resultset.scala
+++ b/core/src/main/scala/doobie/free/resultset.scala
@@ -1,6 +1,6 @@
 package doobie.free
 
-import scalaz.{ Catchable, Coyoneda, Free => F, Kleisli, Monad, ~>, \/ }
+import scalaz.{ Catchable, Free => F, Kleisli, Monad, ~>, \/ }
 import scalaz.concurrent.Task
 
 import doobie.util.capture._
@@ -29,6 +29,7 @@ import java.sql.RowId
 import java.sql.SQLData
 import java.sql.SQLInput
 import java.sql.SQLOutput
+import java.sql.SQLType
 import java.sql.SQLWarning
 import java.sql.SQLXML
 import java.sql.Statement
@@ -111,7 +112,7 @@ object resultset {
       }
 
     // Lifting
-    case class Lift[Op[_], A, J](j: J, action: F.FreeC[Op, A], mod: KleisliTrans.Aux[Op, J]) extends ResultSetOp[A] {
+    case class Lift[Op[_], A, J](j: J, action: F[Op, A], mod: KleisliTrans.Aux[Op, J]) extends ResultSetOp[A] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => mod.transK[M].apply(action).run(j))
     }
 
@@ -162,28 +163,28 @@ object resultset {
     case class  GetArray1(a: Int) extends ResultSetOp[SqlArray] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getArray(a))
     }
-    case class  GetAsciiStream(a: Int) extends ResultSetOp[InputStream] {
+    case class  GetAsciiStream(a: String) extends ResultSetOp[InputStream] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getAsciiStream(a))
     }
-    case class  GetAsciiStream1(a: String) extends ResultSetOp[InputStream] {
+    case class  GetAsciiStream1(a: Int) extends ResultSetOp[InputStream] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getAsciiStream(a))
     }
-    case class  GetBigDecimal(a: Int, b: Int) extends ResultSetOp[BigDecimal] {
+    case class  GetBigDecimal(a: String, b: Int) extends ResultSetOp[BigDecimal] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a, b))
     }
-    case class  GetBigDecimal1(a: String, b: Int) extends ResultSetOp[BigDecimal] {
+    case class  GetBigDecimal1(a: Int) extends ResultSetOp[BigDecimal] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a))
+    }
+    case class  GetBigDecimal2(a: Int, b: Int) extends ResultSetOp[BigDecimal] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a, b))
     }
-    case class  GetBigDecimal2(a: String) extends ResultSetOp[BigDecimal] {
+    case class  GetBigDecimal3(a: String) extends ResultSetOp[BigDecimal] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a))
     }
-    case class  GetBigDecimal3(a: Int) extends ResultSetOp[BigDecimal] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a))
-    }
-    case class  GetBinaryStream(a: Int) extends ResultSetOp[InputStream] {
+    case class  GetBinaryStream(a: String) extends ResultSetOp[InputStream] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBinaryStream(a))
     }
-    case class  GetBinaryStream1(a: String) extends ResultSetOp[InputStream] {
+    case class  GetBinaryStream1(a: Int) extends ResultSetOp[InputStream] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBinaryStream(a))
     }
     case class  GetBlob(a: Int) extends ResultSetOp[Blob] {
@@ -204,10 +205,10 @@ object resultset {
     case class  GetByte1(a: Int) extends ResultSetOp[Byte] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getByte(a))
     }
-    case class  GetBytes(a: Int) extends ResultSetOp[Array[Byte]] {
+    case class  GetBytes(a: String) extends ResultSetOp[Array[Byte]] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBytes(a))
     }
-    case class  GetBytes1(a: String) extends ResultSetOp[Array[Byte]] {
+    case class  GetBytes1(a: Int) extends ResultSetOp[Array[Byte]] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBytes(a))
     }
     case class  GetCharacterStream(a: Int) extends ResultSetOp[Reader] {
@@ -228,22 +229,22 @@ object resultset {
     case object GetCursorName extends ResultSetOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getCursorName())
     }
-    case class  GetDate(a: String) extends ResultSetOp[Date] {
+    case class  GetDate(a: Int) extends ResultSetOp[Date] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a))
     }
-    case class  GetDate1(a: Int, b: Calendar) extends ResultSetOp[Date] {
+    case class  GetDate1(a: String) extends ResultSetOp[Date] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a))
+    }
+    case class  GetDate2(a: Int, b: Calendar) extends ResultSetOp[Date] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a, b))
-    }
-    case class  GetDate2(a: Int) extends ResultSetOp[Date] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a))
     }
     case class  GetDate3(a: String, b: Calendar) extends ResultSetOp[Date] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a, b))
     }
-    case class  GetDouble(a: String) extends ResultSetOp[Double] {
+    case class  GetDouble(a: Int) extends ResultSetOp[Double] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDouble(a))
     }
-    case class  GetDouble1(a: Int) extends ResultSetOp[Double] {
+    case class  GetDouble1(a: String) extends ResultSetOp[Double] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDouble(a))
     }
     case object GetFetchDirection extends ResultSetOp[Int] {
@@ -297,25 +298,25 @@ object resultset {
     case class  GetObject(a: String, b: Map[String, Class[_]]) extends ResultSetOp[Object] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
     }
-    case class  GetObject1(a: Int, b: Map[String, Class[_]]) extends ResultSetOp[Object] {
+    case class  GetObject1[T](a: Int, b: Class[T]) extends ResultSetOp[T] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
     }
-    case class  GetObject2(a: Int) extends ResultSetOp[Object] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a))
-    }
-    case class  GetObject3(a: String) extends ResultSetOp[Object] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a))
-    }
-    case class  GetObject4[T](a: Int, b: Class[T]) extends ResultSetOp[T] {
+    case class  GetObject2(a: Int, b: Map[String, Class[_]]) extends ResultSetOp[Object] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
+    }
+    case class  GetObject3(a: Int) extends ResultSetOp[Object] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a))
+    }
+    case class  GetObject4(a: String) extends ResultSetOp[Object] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a))
     }
     case class  GetObject5[T](a: String, b: Class[T]) extends ResultSetOp[T] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
     }
-    case class  GetRef(a: Int) extends ResultSetOp[Ref] {
+    case class  GetRef(a: String) extends ResultSetOp[Ref] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getRef(a))
     }
-    case class  GetRef1(a: String) extends ResultSetOp[Ref] {
+    case class  GetRef1(a: Int) extends ResultSetOp[Ref] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getRef(a))
     }
     case object GetRow extends ResultSetOp[Int] {
@@ -327,58 +328,58 @@ object resultset {
     case class  GetRowId1(a: String) extends ResultSetOp[RowId] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getRowId(a))
     }
-    case class  GetSQLXML(a: String) extends ResultSetOp[SQLXML] {
+    case class  GetSQLXML(a: Int) extends ResultSetOp[SQLXML] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSQLXML(a))
     }
-    case class  GetSQLXML1(a: Int) extends ResultSetOp[SQLXML] {
+    case class  GetSQLXML1(a: String) extends ResultSetOp[SQLXML] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSQLXML(a))
     }
-    case class  GetShort(a: Int) extends ResultSetOp[Short] {
+    case class  GetShort(a: String) extends ResultSetOp[Short] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getShort(a))
     }
-    case class  GetShort1(a: String) extends ResultSetOp[Short] {
+    case class  GetShort1(a: Int) extends ResultSetOp[Short] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getShort(a))
     }
     case object GetStatement extends ResultSetOp[Statement] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getStatement())
     }
-    case class  GetString(a: Int) extends ResultSetOp[String] {
+    case class  GetString(a: String) extends ResultSetOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getString(a))
     }
-    case class  GetString1(a: String) extends ResultSetOp[String] {
+    case class  GetString1(a: Int) extends ResultSetOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getString(a))
     }
-    case class  GetTime(a: Int, b: Calendar) extends ResultSetOp[Time] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a, b))
-    }
-    case class  GetTime1(a: Int) extends ResultSetOp[Time] {
+    case class  GetTime(a: String) extends ResultSetOp[Time] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a))
     }
-    case class  GetTime2(a: String) extends ResultSetOp[Time] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a))
-    }
-    case class  GetTime3(a: String, b: Calendar) extends ResultSetOp[Time] {
+    case class  GetTime1(a: String, b: Calendar) extends ResultSetOp[Time] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a, b))
     }
-    case class  GetTimestamp(a: Int) extends ResultSetOp[Timestamp] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a))
+    case class  GetTime2(a: Int, b: Calendar) extends ResultSetOp[Time] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a, b))
     }
-    case class  GetTimestamp1(a: String) extends ResultSetOp[Timestamp] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a))
+    case class  GetTime3(a: Int) extends ResultSetOp[Time] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a))
     }
-    case class  GetTimestamp2(a: String, b: Calendar) extends ResultSetOp[Timestamp] {
+    case class  GetTimestamp(a: Int, b: Calendar) extends ResultSetOp[Timestamp] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a, b))
     }
-    case class  GetTimestamp3(a: Int, b: Calendar) extends ResultSetOp[Timestamp] {
+    case class  GetTimestamp1(a: String, b: Calendar) extends ResultSetOp[Timestamp] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a, b))
+    }
+    case class  GetTimestamp2(a: Int) extends ResultSetOp[Timestamp] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a))
+    }
+    case class  GetTimestamp3(a: String) extends ResultSetOp[Timestamp] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a))
     }
     case object GetType extends ResultSetOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getType())
     }
-    case class  GetURL(a: Int) extends ResultSetOp[URL] {
+    case class  GetURL(a: String) extends ResultSetOp[URL] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getURL(a))
     }
-    case class  GetURL1(a: String) extends ResultSetOp[URL] {
+    case class  GetURL1(a: Int) extends ResultSetOp[URL] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getURL(a))
     }
     case class  GetUnicodeStream(a: Int) extends ResultSetOp[InputStream] {
@@ -459,67 +460,67 @@ object resultset {
     case class  UpdateAsciiStream(a: String, b: InputStream) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateAsciiStream(a, b))
     }
-    case class  UpdateAsciiStream1(a: String, b: InputStream, c: Int) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateAsciiStream(a, b, c))
-    }
-    case class  UpdateAsciiStream2(a: Int, b: InputStream) extends ResultSetOp[Unit] {
+    case class  UpdateAsciiStream1(a: Int, b: InputStream) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateAsciiStream(a, b))
+    }
+    case class  UpdateAsciiStream2(a: Int, b: InputStream, c: Int) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateAsciiStream(a, b, c))
     }
     case class  UpdateAsciiStream3(a: String, b: InputStream, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateAsciiStream(a, b, c))
     }
-    case class  UpdateAsciiStream4(a: Int, b: InputStream, c: Long) extends ResultSetOp[Unit] {
+    case class  UpdateAsciiStream4(a: String, b: InputStream, c: Int) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateAsciiStream(a, b, c))
     }
-    case class  UpdateAsciiStream5(a: Int, b: InputStream, c: Int) extends ResultSetOp[Unit] {
+    case class  UpdateAsciiStream5(a: Int, b: InputStream, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateAsciiStream(a, b, c))
     }
-    case class  UpdateBigDecimal(a: String, b: BigDecimal) extends ResultSetOp[Unit] {
+    case class  UpdateBigDecimal(a: Int, b: BigDecimal) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBigDecimal(a, b))
     }
-    case class  UpdateBigDecimal1(a: Int, b: BigDecimal) extends ResultSetOp[Unit] {
+    case class  UpdateBigDecimal1(a: String, b: BigDecimal) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBigDecimal(a, b))
     }
     case class  UpdateBinaryStream(a: Int, b: InputStream, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b, c))
     }
-    case class  UpdateBinaryStream1(a: String, b: InputStream, c: Int) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b, c))
-    }
-    case class  UpdateBinaryStream2(a: Int, b: InputStream, c: Int) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b, c))
-    }
-    case class  UpdateBinaryStream3(a: String, b: InputStream, c: Long) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b, c))
-    }
-    case class  UpdateBinaryStream4(a: Int, b: InputStream) extends ResultSetOp[Unit] {
+    case class  UpdateBinaryStream1(a: Int, b: InputStream) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b))
     }
-    case class  UpdateBinaryStream5(a: String, b: InputStream) extends ResultSetOp[Unit] {
+    case class  UpdateBinaryStream2(a: String, b: InputStream) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b))
     }
-    case class  UpdateBlob(a: String, b: InputStream, c: Long) extends ResultSetOp[Unit] {
+    case class  UpdateBinaryStream3(a: String, b: InputStream, c: Int) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b, c))
+    }
+    case class  UpdateBinaryStream4(a: Int, b: InputStream, c: Int) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b, c))
+    }
+    case class  UpdateBinaryStream5(a: String, b: InputStream, c: Long) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b, c))
+    }
+    case class  UpdateBlob(a: Int, b: InputStream, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b, c))
     }
     case class  UpdateBlob1(a: Int, b: InputStream) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b))
     }
-    case class  UpdateBlob2(a: Int, b: InputStream, c: Long) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b, c))
+    case class  UpdateBlob2(a: Int, b: Blob) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b))
     }
-    case class  UpdateBlob3(a: Int, b: Blob) extends ResultSetOp[Unit] {
+    case class  UpdateBlob3(a: String, b: Blob) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b))
     }
     case class  UpdateBlob4(a: String, b: InputStream) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b))
     }
-    case class  UpdateBlob5(a: String, b: Blob) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b))
+    case class  UpdateBlob5(a: String, b: InputStream, c: Long) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b, c))
     }
-    case class  UpdateBoolean(a: String, b: Boolean) extends ResultSetOp[Unit] {
+    case class  UpdateBoolean(a: Int, b: Boolean) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBoolean(a, b))
     }
-    case class  UpdateBoolean1(a: Int, b: Boolean) extends ResultSetOp[Unit] {
+    case class  UpdateBoolean1(a: String, b: Boolean) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBoolean(a, b))
     }
     case class  UpdateByte(a: String, b: Byte) extends ResultSetOp[Unit] {
@@ -528,47 +529,47 @@ object resultset {
     case class  UpdateByte1(a: Int, b: Byte) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateByte(a, b))
     }
-    case class  UpdateBytes(a: Int, b: Array[Byte]) extends ResultSetOp[Unit] {
+    case class  UpdateBytes(a: String, b: Array[Byte]) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBytes(a, b))
     }
-    case class  UpdateBytes1(a: String, b: Array[Byte]) extends ResultSetOp[Unit] {
+    case class  UpdateBytes1(a: Int, b: Array[Byte]) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBytes(a, b))
     }
-    case class  UpdateCharacterStream(a: String, b: Reader, c: Long) extends ResultSetOp[Unit] {
+    case class  UpdateCharacterStream(a: Int, b: Reader, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateCharacterStream(a, b, c))
     }
     case class  UpdateCharacterStream1(a: Int, b: Reader, c: Int) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateCharacterStream(a, b, c))
     }
-    case class  UpdateCharacterStream2(a: Int, b: Reader, c: Long) extends ResultSetOp[Unit] {
+    case class  UpdateCharacterStream2(a: String, b: Reader, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateCharacterStream(a, b, c))
     }
-    case class  UpdateCharacterStream3(a: String, b: Reader) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateCharacterStream(a, b))
+    case class  UpdateCharacterStream3(a: String, b: Reader, c: Int) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateCharacterStream(a, b, c))
     }
     case class  UpdateCharacterStream4(a: Int, b: Reader) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateCharacterStream(a, b))
     }
-    case class  UpdateCharacterStream5(a: String, b: Reader, c: Int) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateCharacterStream(a, b, c))
+    case class  UpdateCharacterStream5(a: String, b: Reader) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateCharacterStream(a, b))
     }
-    case class  UpdateClob(a: String, b: Reader, c: Long) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateClob(a, b, c))
+    case class  UpdateClob(a: Int, b: Reader) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateClob(a, b))
     }
     case class  UpdateClob1(a: Int, b: Reader, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateClob(a, b, c))
     }
-    case class  UpdateClob2(a: String, b: Clob) extends ResultSetOp[Unit] {
+    case class  UpdateClob2(a: String, b: Reader) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateClob(a, b))
     }
-    case class  UpdateClob3(a: String, b: Reader) extends ResultSetOp[Unit] {
+    case class  UpdateClob3(a: String, b: Clob) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateClob(a, b))
     }
-    case class  UpdateClob4(a: Int, b: Reader) extends ResultSetOp[Unit] {
+    case class  UpdateClob4(a: Int, b: Clob) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateClob(a, b))
     }
-    case class  UpdateClob5(a: Int, b: Clob) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateClob(a, b))
+    case class  UpdateClob5(a: String, b: Reader, c: Long) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateClob(a, b, c))
     }
     case class  UpdateDate(a: String, b: Date) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateDate(a, b))
@@ -582,35 +583,35 @@ object resultset {
     case class  UpdateDouble1(a: Int, b: Double) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateDouble(a, b))
     }
-    case class  UpdateFloat(a: Int, b: Float) extends ResultSetOp[Unit] {
+    case class  UpdateFloat(a: String, b: Float) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateFloat(a, b))
     }
-    case class  UpdateFloat1(a: String, b: Float) extends ResultSetOp[Unit] {
+    case class  UpdateFloat1(a: Int, b: Float) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateFloat(a, b))
     }
-    case class  UpdateInt(a: String, b: Int) extends ResultSetOp[Unit] {
+    case class  UpdateInt(a: Int, b: Int) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateInt(a, b))
     }
-    case class  UpdateInt1(a: Int, b: Int) extends ResultSetOp[Unit] {
+    case class  UpdateInt1(a: String, b: Int) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateInt(a, b))
     }
-    case class  UpdateLong(a: Int, b: Long) extends ResultSetOp[Unit] {
+    case class  UpdateLong(a: String, b: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateLong(a, b))
     }
-    case class  UpdateLong1(a: String, b: Long) extends ResultSetOp[Unit] {
+    case class  UpdateLong1(a: Int, b: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateLong(a, b))
     }
-    case class  UpdateNCharacterStream(a: String, b: Reader) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNCharacterStream(a, b))
-    }
-    case class  UpdateNCharacterStream1(a: Int, b: Reader, c: Long) extends ResultSetOp[Unit] {
+    case class  UpdateNCharacterStream(a: Int, b: Reader, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNCharacterStream(a, b, c))
     }
-    case class  UpdateNCharacterStream2(a: Int, b: Reader) extends ResultSetOp[Unit] {
+    case class  UpdateNCharacterStream1(a: String, b: Reader) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNCharacterStream(a, b))
     }
-    case class  UpdateNCharacterStream3(a: String, b: Reader, c: Long) extends ResultSetOp[Unit] {
+    case class  UpdateNCharacterStream2(a: String, b: Reader, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNCharacterStream(a, b, c))
+    }
+    case class  UpdateNCharacterStream3(a: Int, b: Reader) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNCharacterStream(a, b))
     }
     case class  UpdateNClob(a: Int, b: Reader) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b))
@@ -618,17 +619,17 @@ object resultset {
     case class  UpdateNClob1(a: String, b: Reader) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b))
     }
-    case class  UpdateNClob2(a: Int, b: Reader, c: Long) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b, c))
-    }
-    case class  UpdateNClob3(a: String, b: Reader, c: Long) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b, c))
-    }
-    case class  UpdateNClob4(a: Int, b: NClob) extends ResultSetOp[Unit] {
+    case class  UpdateNClob2(a: Int, b: NClob) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b))
     }
-    case class  UpdateNClob5(a: String, b: NClob) extends ResultSetOp[Unit] {
+    case class  UpdateNClob3(a: String, b: NClob) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b))
+    }
+    case class  UpdateNClob4(a: String, b: Reader, c: Long) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b, c))
+    }
+    case class  UpdateNClob5(a: Int, b: Reader, c: Long) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b, c))
     }
     case class  UpdateNString(a: Int, b: String) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNString(a, b))
@@ -636,28 +637,40 @@ object resultset {
     case class  UpdateNString1(a: String, b: String) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNString(a, b))
     }
-    case class  UpdateNull(a: Int) extends ResultSetOp[Unit] {
+    case class  UpdateNull(a: String) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNull(a))
     }
-    case class  UpdateNull1(a: String) extends ResultSetOp[Unit] {
+    case class  UpdateNull1(a: Int) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNull(a))
     }
-    case class  UpdateObject(a: Int, b: Object, c: Int) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b, c))
-    }
-    case class  UpdateObject1(a: String, b: Object) extends ResultSetOp[Unit] {
+    case class  UpdateObject(a: Int, b: Object) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b))
     }
-    case class  UpdateObject2(a: String, b: Object, c: Int) extends ResultSetOp[Unit] {
+    case class  UpdateObject1(a: String, b: Object, c: Int) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b, c))
     }
-    case class  UpdateObject3(a: Int, b: Object) extends ResultSetOp[Unit] {
+    case class  UpdateObject2(a: String, b: Object) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b))
     }
-    case class  UpdateRef(a: Int, b: Ref) extends ResultSetOp[Unit] {
+    case class  UpdateObject3(a: Int, b: Object, c: SQLType) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b, c))
+    }
+    case class  UpdateObject4(a: Int, b: Object, c: SQLType, d: Int) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b, c, d))
+    }
+    case class  UpdateObject5(a: String, b: Object, c: SQLType, d: Int) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b, c, d))
+    }
+    case class  UpdateObject6(a: Int, b: Object, c: Int) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b, c))
+    }
+    case class  UpdateObject7(a: String, b: Object, c: SQLType) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b, c))
+    }
+    case class  UpdateRef(a: String, b: Ref) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateRef(a, b))
     }
-    case class  UpdateRef1(a: String, b: Ref) extends ResultSetOp[Unit] {
+    case class  UpdateRef1(a: Int, b: Ref) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateRef(a, b))
     }
     case object UpdateRow extends ResultSetOp[Unit] {
@@ -687,16 +700,16 @@ object resultset {
     case class  UpdateString1(a: Int, b: String) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateString(a, b))
     }
-    case class  UpdateTime(a: String, b: Time) extends ResultSetOp[Unit] {
+    case class  UpdateTime(a: Int, b: Time) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateTime(a, b))
     }
-    case class  UpdateTime1(a: Int, b: Time) extends ResultSetOp[Unit] {
+    case class  UpdateTime1(a: String, b: Time) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateTime(a, b))
     }
-    case class  UpdateTimestamp(a: String, b: Timestamp) extends ResultSetOp[Unit] {
+    case class  UpdateTimestamp(a: Int, b: Timestamp) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateTimestamp(a, b))
     }
-    case class  UpdateTimestamp1(a: Int, b: Timestamp) extends ResultSetOp[Unit] {
+    case class  UpdateTimestamp1(a: String, b: Timestamp) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateTimestamp(a, b))
     }
     case object WasNull extends ResultSetOp[Boolean] {
@@ -711,14 +724,7 @@ object resultset {
    * a `java.sql.ResultSet` and produces a value of type `A`. 
    * @group Algebra 
    */
-  type ResultSetIO[A] = F.FreeC[ResultSetOp, A]
-
-  /**
-   * Monad instance for [[ResultSetIO]] (can't be inferred).
-   * @group Typeclass Instances 
-   */
-  implicit val MonadResultSetIO: Monad[ResultSetIO] = 
-    F.freeMonad[({type λ[α] = Coyoneda[ResultSetOp, α]})#λ]
+  type ResultSetIO[A] = F[ResultSetOp, A]
 
   /**
    * Catchable instance for [[ResultSetIO]].
@@ -743,1175 +749,1199 @@ object resultset {
    * Lift a different type of program that has a default Kleisli interpreter.
    * @group Constructors (Lifting)
    */
-  def lift[Op[_], A, J](j: J, action: F.FreeC[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): ResultSetIO[A] =
-    F.liftFC(Lift(j, action, mod))
+  def lift[Op[_], A, J](j: J, action: F[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): ResultSetIO[A] =
+    F.liftF(Lift(j, action, mod))
 
   /** 
    * Lift a ResultSetIO[A] into an exception-capturing ResultSetIO[Throwable \/ A].
    * @group Constructors (Lifting)
    */
   def attempt[A](a: ResultSetIO[A]): ResultSetIO[Throwable \/ A] =
-    F.liftFC[ResultSetOp, Throwable \/ A](Attempt(a))
+    F.liftF[ResultSetOp, Throwable \/ A](Attempt(a))
  
   /**
    * Non-strict unit for capturing effects.
    * @group Constructors (Lifting)
    */
   def delay[A](a: => A): ResultSetIO[A] =
-    F.liftFC(Pure(a _))
+    F.liftF(Pure(a _))
 
   /**
    * Backdoor for arbitrary computations on the underlying ResultSet.
    * @group Constructors (Lifting)
    */
   def raw[A](f: ResultSet => A): ResultSetIO[A] =
-    F.liftFC(Raw(f))
+    F.liftF(Raw(f))
 
   /** 
    * @group Constructors (Primitives)
    */
   def absolute(a: Int): ResultSetIO[Boolean] =
-    F.liftFC(Absolute(a))
+    F.liftF(Absolute(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val afterLast: ResultSetIO[Unit] =
-    F.liftFC(AfterLast)
+    F.liftF(AfterLast)
 
   /** 
    * @group Constructors (Primitives)
    */
   val beforeFirst: ResultSetIO[Unit] =
-    F.liftFC(BeforeFirst)
+    F.liftF(BeforeFirst)
 
   /** 
    * @group Constructors (Primitives)
    */
   val cancelRowUpdates: ResultSetIO[Unit] =
-    F.liftFC(CancelRowUpdates)
+    F.liftF(CancelRowUpdates)
 
   /** 
    * @group Constructors (Primitives)
    */
   val clearWarnings: ResultSetIO[Unit] =
-    F.liftFC(ClearWarnings)
+    F.liftF(ClearWarnings)
 
   /** 
    * @group Constructors (Primitives)
    */
   val close: ResultSetIO[Unit] =
-    F.liftFC(Close)
+    F.liftF(Close)
 
   /** 
    * @group Constructors (Primitives)
    */
   val deleteRow: ResultSetIO[Unit] =
-    F.liftFC(DeleteRow)
+    F.liftF(DeleteRow)
 
   /** 
    * @group Constructors (Primitives)
    */
   def findColumn(a: String): ResultSetIO[Int] =
-    F.liftFC(FindColumn(a))
+    F.liftF(FindColumn(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val first: ResultSetIO[Boolean] =
-    F.liftFC(First)
+    F.liftF(First)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getArray(a: String): ResultSetIO[SqlArray] =
-    F.liftFC(GetArray(a))
+    F.liftF(GetArray(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getArray(a: Int): ResultSetIO[SqlArray] =
-    F.liftFC(GetArray1(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getAsciiStream(a: Int): ResultSetIO[InputStream] =
-    F.liftFC(GetAsciiStream(a))
+    F.liftF(GetArray1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getAsciiStream(a: String): ResultSetIO[InputStream] =
-    F.liftFC(GetAsciiStream1(a))
+    F.liftF(GetAsciiStream(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getBigDecimal(a: Int, b: Int): ResultSetIO[BigDecimal] =
-    F.liftFC(GetBigDecimal(a, b))
+  def getAsciiStream(a: Int): ResultSetIO[InputStream] =
+    F.liftF(GetAsciiStream1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getBigDecimal(a: String, b: Int): ResultSetIO[BigDecimal] =
-    F.liftFC(GetBigDecimal1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getBigDecimal(a: String): ResultSetIO[BigDecimal] =
-    F.liftFC(GetBigDecimal2(a))
+    F.liftF(GetBigDecimal(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getBigDecimal(a: Int): ResultSetIO[BigDecimal] =
-    F.liftFC(GetBigDecimal3(a))
+    F.liftF(GetBigDecimal1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getBinaryStream(a: Int): ResultSetIO[InputStream] =
-    F.liftFC(GetBinaryStream(a))
+  def getBigDecimal(a: Int, b: Int): ResultSetIO[BigDecimal] =
+    F.liftF(GetBigDecimal2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getBigDecimal(a: String): ResultSetIO[BigDecimal] =
+    F.liftF(GetBigDecimal3(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getBinaryStream(a: String): ResultSetIO[InputStream] =
-    F.liftFC(GetBinaryStream1(a))
+    F.liftF(GetBinaryStream(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getBinaryStream(a: Int): ResultSetIO[InputStream] =
+    F.liftF(GetBinaryStream1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getBlob(a: Int): ResultSetIO[Blob] =
-    F.liftFC(GetBlob(a))
+    F.liftF(GetBlob(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getBlob(a: String): ResultSetIO[Blob] =
-    F.liftFC(GetBlob1(a))
+    F.liftF(GetBlob1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getBoolean(a: String): ResultSetIO[Boolean] =
-    F.liftFC(GetBoolean(a))
+    F.liftF(GetBoolean(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getBoolean(a: Int): ResultSetIO[Boolean] =
-    F.liftFC(GetBoolean1(a))
+    F.liftF(GetBoolean1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getByte(a: String): ResultSetIO[Byte] =
-    F.liftFC(GetByte(a))
+    F.liftF(GetByte(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getByte(a: Int): ResultSetIO[Byte] =
-    F.liftFC(GetByte1(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getBytes(a: Int): ResultSetIO[Array[Byte]] =
-    F.liftFC(GetBytes(a))
+    F.liftF(GetByte1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getBytes(a: String): ResultSetIO[Array[Byte]] =
-    F.liftFC(GetBytes1(a))
+    F.liftF(GetBytes(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getBytes(a: Int): ResultSetIO[Array[Byte]] =
+    F.liftF(GetBytes1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getCharacterStream(a: Int): ResultSetIO[Reader] =
-    F.liftFC(GetCharacterStream(a))
+    F.liftF(GetCharacterStream(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getCharacterStream(a: String): ResultSetIO[Reader] =
-    F.liftFC(GetCharacterStream1(a))
+    F.liftF(GetCharacterStream1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getClob(a: Int): ResultSetIO[Clob] =
-    F.liftFC(GetClob(a))
+    F.liftF(GetClob(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getClob(a: String): ResultSetIO[Clob] =
-    F.liftFC(GetClob1(a))
+    F.liftF(GetClob1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getConcurrency: ResultSetIO[Int] =
-    F.liftFC(GetConcurrency)
+    F.liftF(GetConcurrency)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getCursorName: ResultSetIO[String] =
-    F.liftFC(GetCursorName)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getDate(a: String): ResultSetIO[Date] =
-    F.liftFC(GetDate(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getDate(a: Int, b: Calendar): ResultSetIO[Date] =
-    F.liftFC(GetDate1(a, b))
+    F.liftF(GetCursorName)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getDate(a: Int): ResultSetIO[Date] =
-    F.liftFC(GetDate2(a))
+    F.liftF(GetDate(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getDate(a: String): ResultSetIO[Date] =
+    F.liftF(GetDate1(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getDate(a: Int, b: Calendar): ResultSetIO[Date] =
+    F.liftF(GetDate2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getDate(a: String, b: Calendar): ResultSetIO[Date] =
-    F.liftFC(GetDate3(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getDouble(a: String): ResultSetIO[Double] =
-    F.liftFC(GetDouble(a))
+    F.liftF(GetDate3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getDouble(a: Int): ResultSetIO[Double] =
-    F.liftFC(GetDouble1(a))
+    F.liftF(GetDouble(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getDouble(a: String): ResultSetIO[Double] =
+    F.liftF(GetDouble1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getFetchDirection: ResultSetIO[Int] =
-    F.liftFC(GetFetchDirection)
+    F.liftF(GetFetchDirection)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getFetchSize: ResultSetIO[Int] =
-    F.liftFC(GetFetchSize)
+    F.liftF(GetFetchSize)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getFloat(a: Int): ResultSetIO[Float] =
-    F.liftFC(GetFloat(a))
+    F.liftF(GetFloat(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getFloat(a: String): ResultSetIO[Float] =
-    F.liftFC(GetFloat1(a))
+    F.liftF(GetFloat1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getHoldability: ResultSetIO[Int] =
-    F.liftFC(GetHoldability)
+    F.liftF(GetHoldability)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getInt(a: String): ResultSetIO[Int] =
-    F.liftFC(GetInt(a))
+    F.liftF(GetInt(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getInt(a: Int): ResultSetIO[Int] =
-    F.liftFC(GetInt1(a))
+    F.liftF(GetInt1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getLong(a: String): ResultSetIO[Long] =
-    F.liftFC(GetLong(a))
+    F.liftF(GetLong(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getLong(a: Int): ResultSetIO[Long] =
-    F.liftFC(GetLong1(a))
+    F.liftF(GetLong1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMetaData: ResultSetIO[ResultSetMetaData] =
-    F.liftFC(GetMetaData)
+    F.liftF(GetMetaData)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getNCharacterStream(a: Int): ResultSetIO[Reader] =
-    F.liftFC(GetNCharacterStream(a))
+    F.liftF(GetNCharacterStream(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getNCharacterStream(a: String): ResultSetIO[Reader] =
-    F.liftFC(GetNCharacterStream1(a))
+    F.liftF(GetNCharacterStream1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getNClob(a: String): ResultSetIO[NClob] =
-    F.liftFC(GetNClob(a))
+    F.liftF(GetNClob(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getNClob(a: Int): ResultSetIO[NClob] =
-    F.liftFC(GetNClob1(a))
+    F.liftF(GetNClob1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getNString(a: Int): ResultSetIO[String] =
-    F.liftFC(GetNString(a))
+    F.liftF(GetNString(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getNString(a: String): ResultSetIO[String] =
-    F.liftFC(GetNString1(a))
+    F.liftF(GetNString1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getObject(a: String, b: Map[String, Class[_]]): ResultSetIO[Object] =
-    F.liftFC(GetObject(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getObject(a: Int, b: Map[String, Class[_]]): ResultSetIO[Object] =
-    F.liftFC(GetObject1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getObject(a: Int): ResultSetIO[Object] =
-    F.liftFC(GetObject2(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getObject(a: String): ResultSetIO[Object] =
-    F.liftFC(GetObject3(a))
+    F.liftF(GetObject(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getObject[T](a: Int, b: Class[T]): ResultSetIO[T] =
-    F.liftFC(GetObject4(a, b))
+    F.liftF(GetObject1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getObject(a: Int, b: Map[String, Class[_]]): ResultSetIO[Object] =
+    F.liftF(GetObject2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getObject(a: Int): ResultSetIO[Object] =
+    F.liftF(GetObject3(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getObject(a: String): ResultSetIO[Object] =
+    F.liftF(GetObject4(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getObject[T](a: String, b: Class[T]): ResultSetIO[T] =
-    F.liftFC(GetObject5(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getRef(a: Int): ResultSetIO[Ref] =
-    F.liftFC(GetRef(a))
+    F.liftF(GetObject5(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getRef(a: String): ResultSetIO[Ref] =
-    F.liftFC(GetRef1(a))
+    F.liftF(GetRef(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getRef(a: Int): ResultSetIO[Ref] =
+    F.liftF(GetRef1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getRow: ResultSetIO[Int] =
-    F.liftFC(GetRow)
+    F.liftF(GetRow)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getRowId(a: Int): ResultSetIO[RowId] =
-    F.liftFC(GetRowId(a))
+    F.liftF(GetRowId(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getRowId(a: String): ResultSetIO[RowId] =
-    F.liftFC(GetRowId1(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getSQLXML(a: String): ResultSetIO[SQLXML] =
-    F.liftFC(GetSQLXML(a))
+    F.liftF(GetRowId1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getSQLXML(a: Int): ResultSetIO[SQLXML] =
-    F.liftFC(GetSQLXML1(a))
+    F.liftF(GetSQLXML(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getShort(a: Int): ResultSetIO[Short] =
-    F.liftFC(GetShort(a))
+  def getSQLXML(a: String): ResultSetIO[SQLXML] =
+    F.liftF(GetSQLXML1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getShort(a: String): ResultSetIO[Short] =
-    F.liftFC(GetShort1(a))
+    F.liftF(GetShort(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getShort(a: Int): ResultSetIO[Short] =
+    F.liftF(GetShort1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getStatement: ResultSetIO[Statement] =
-    F.liftFC(GetStatement)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getString(a: Int): ResultSetIO[String] =
-    F.liftFC(GetString(a))
+    F.liftF(GetStatement)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getString(a: String): ResultSetIO[String] =
-    F.liftFC(GetString1(a))
+    F.liftF(GetString(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getTime(a: Int, b: Calendar): ResultSetIO[Time] =
-    F.liftFC(GetTime(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getTime(a: Int): ResultSetIO[Time] =
-    F.liftFC(GetTime1(a))
+  def getString(a: Int): ResultSetIO[String] =
+    F.liftF(GetString1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getTime(a: String): ResultSetIO[Time] =
-    F.liftFC(GetTime2(a))
+    F.liftF(GetTime(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getTime(a: String, b: Calendar): ResultSetIO[Time] =
-    F.liftFC(GetTime3(a, b))
+    F.liftF(GetTime1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getTimestamp(a: Int): ResultSetIO[Timestamp] =
-    F.liftFC(GetTimestamp(a))
+  def getTime(a: Int, b: Calendar): ResultSetIO[Time] =
+    F.liftF(GetTime2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getTimestamp(a: String): ResultSetIO[Timestamp] =
-    F.liftFC(GetTimestamp1(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getTimestamp(a: String, b: Calendar): ResultSetIO[Timestamp] =
-    F.liftFC(GetTimestamp2(a, b))
+  def getTime(a: Int): ResultSetIO[Time] =
+    F.liftF(GetTime3(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getTimestamp(a: Int, b: Calendar): ResultSetIO[Timestamp] =
-    F.liftFC(GetTimestamp3(a, b))
+    F.liftF(GetTimestamp(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getTimestamp(a: String, b: Calendar): ResultSetIO[Timestamp] =
+    F.liftF(GetTimestamp1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getTimestamp(a: Int): ResultSetIO[Timestamp] =
+    F.liftF(GetTimestamp2(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getTimestamp(a: String): ResultSetIO[Timestamp] =
+    F.liftF(GetTimestamp3(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getType: ResultSetIO[Int] =
-    F.liftFC(GetType)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getURL(a: Int): ResultSetIO[URL] =
-    F.liftFC(GetURL(a))
+    F.liftF(GetType)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getURL(a: String): ResultSetIO[URL] =
-    F.liftFC(GetURL1(a))
+    F.liftF(GetURL(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def getURL(a: Int): ResultSetIO[URL] =
+    F.liftF(GetURL1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getUnicodeStream(a: Int): ResultSetIO[InputStream] =
-    F.liftFC(GetUnicodeStream(a))
+    F.liftF(GetUnicodeStream(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getUnicodeStream(a: String): ResultSetIO[InputStream] =
-    F.liftFC(GetUnicodeStream1(a))
+    F.liftF(GetUnicodeStream1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getWarnings: ResultSetIO[SQLWarning] =
-    F.liftFC(GetWarnings)
+    F.liftF(GetWarnings)
 
   /** 
    * @group Constructors (Primitives)
    */
   val insertRow: ResultSetIO[Unit] =
-    F.liftFC(InsertRow)
+    F.liftF(InsertRow)
 
   /** 
    * @group Constructors (Primitives)
    */
   val isAfterLast: ResultSetIO[Boolean] =
-    F.liftFC(IsAfterLast)
+    F.liftF(IsAfterLast)
 
   /** 
    * @group Constructors (Primitives)
    */
   val isBeforeFirst: ResultSetIO[Boolean] =
-    F.liftFC(IsBeforeFirst)
+    F.liftF(IsBeforeFirst)
 
   /** 
    * @group Constructors (Primitives)
    */
   val isClosed: ResultSetIO[Boolean] =
-    F.liftFC(IsClosed)
+    F.liftF(IsClosed)
 
   /** 
    * @group Constructors (Primitives)
    */
   val isFirst: ResultSetIO[Boolean] =
-    F.liftFC(IsFirst)
+    F.liftF(IsFirst)
 
   /** 
    * @group Constructors (Primitives)
    */
   val isLast: ResultSetIO[Boolean] =
-    F.liftFC(IsLast)
+    F.liftF(IsLast)
 
   /** 
    * @group Constructors (Primitives)
    */
   def isWrapperFor(a: Class[_]): ResultSetIO[Boolean] =
-    F.liftFC(IsWrapperFor(a))
+    F.liftF(IsWrapperFor(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val last: ResultSetIO[Boolean] =
-    F.liftFC(Last)
+    F.liftF(Last)
 
   /** 
    * @group Constructors (Primitives)
    */
   val moveToCurrentRow: ResultSetIO[Unit] =
-    F.liftFC(MoveToCurrentRow)
+    F.liftF(MoveToCurrentRow)
 
   /** 
    * @group Constructors (Primitives)
    */
   val moveToInsertRow: ResultSetIO[Unit] =
-    F.liftFC(MoveToInsertRow)
+    F.liftF(MoveToInsertRow)
 
   /** 
    * @group Constructors (Primitives)
    */
   val next: ResultSetIO[Boolean] =
-    F.liftFC(Next)
+    F.liftF(Next)
 
   /** 
    * @group Constructors (Primitives)
    */
   val previous: ResultSetIO[Boolean] =
-    F.liftFC(Previous)
+    F.liftF(Previous)
 
   /** 
    * @group Constructors (Primitives)
    */
   val refreshRow: ResultSetIO[Unit] =
-    F.liftFC(RefreshRow)
+    F.liftF(RefreshRow)
 
   /** 
    * @group Constructors (Primitives)
    */
   def relative(a: Int): ResultSetIO[Boolean] =
-    F.liftFC(Relative(a))
+    F.liftF(Relative(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val rowDeleted: ResultSetIO[Boolean] =
-    F.liftFC(RowDeleted)
+    F.liftF(RowDeleted)
 
   /** 
    * @group Constructors (Primitives)
    */
   val rowInserted: ResultSetIO[Boolean] =
-    F.liftFC(RowInserted)
+    F.liftF(RowInserted)
 
   /** 
    * @group Constructors (Primitives)
    */
   val rowUpdated: ResultSetIO[Boolean] =
-    F.liftFC(RowUpdated)
+    F.liftF(RowUpdated)
 
   /** 
    * @group Constructors (Primitives)
    */
   def setFetchDirection(a: Int): ResultSetIO[Unit] =
-    F.liftFC(SetFetchDirection(a))
+    F.liftF(SetFetchDirection(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setFetchSize(a: Int): ResultSetIO[Unit] =
-    F.liftFC(SetFetchSize(a))
+    F.liftF(SetFetchSize(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def unwrap[T](a: Class[T]): ResultSetIO[T] =
-    F.liftFC(Unwrap(a))
+    F.liftF(Unwrap(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateArray(a: Int, b: SqlArray): ResultSetIO[Unit] =
-    F.liftFC(UpdateArray(a, b))
+    F.liftF(UpdateArray(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateArray(a: String, b: SqlArray): ResultSetIO[Unit] =
-    F.liftFC(UpdateArray1(a, b))
+    F.liftF(UpdateArray1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateAsciiStream(a: String, b: InputStream): ResultSetIO[Unit] =
-    F.liftFC(UpdateAsciiStream(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateAsciiStream(a: String, b: InputStream, c: Int): ResultSetIO[Unit] =
-    F.liftFC(UpdateAsciiStream1(a, b, c))
+    F.liftF(UpdateAsciiStream(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateAsciiStream(a: Int, b: InputStream): ResultSetIO[Unit] =
-    F.liftFC(UpdateAsciiStream2(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateAsciiStream(a: String, b: InputStream, c: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateAsciiStream3(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateAsciiStream(a: Int, b: InputStream, c: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateAsciiStream4(a, b, c))
+    F.liftF(UpdateAsciiStream1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateAsciiStream(a: Int, b: InputStream, c: Int): ResultSetIO[Unit] =
-    F.liftFC(UpdateAsciiStream5(a, b, c))
+    F.liftF(UpdateAsciiStream2(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateBigDecimal(a: String, b: BigDecimal): ResultSetIO[Unit] =
-    F.liftFC(UpdateBigDecimal(a, b))
+  def updateAsciiStream(a: String, b: InputStream, c: Long): ResultSetIO[Unit] =
+    F.liftF(UpdateAsciiStream3(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateAsciiStream(a: String, b: InputStream, c: Int): ResultSetIO[Unit] =
+    F.liftF(UpdateAsciiStream4(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateAsciiStream(a: Int, b: InputStream, c: Long): ResultSetIO[Unit] =
+    F.liftF(UpdateAsciiStream5(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateBigDecimal(a: Int, b: BigDecimal): ResultSetIO[Unit] =
-    F.liftFC(UpdateBigDecimal1(a, b))
+    F.liftF(UpdateBigDecimal(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateBigDecimal(a: String, b: BigDecimal): ResultSetIO[Unit] =
+    F.liftF(UpdateBigDecimal1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateBinaryStream(a: Int, b: InputStream, c: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateBinaryStream(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateBinaryStream(a: String, b: InputStream, c: Int): ResultSetIO[Unit] =
-    F.liftFC(UpdateBinaryStream1(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateBinaryStream(a: Int, b: InputStream, c: Int): ResultSetIO[Unit] =
-    F.liftFC(UpdateBinaryStream2(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateBinaryStream(a: String, b: InputStream, c: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateBinaryStream3(a, b, c))
+    F.liftF(UpdateBinaryStream(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateBinaryStream(a: Int, b: InputStream): ResultSetIO[Unit] =
-    F.liftFC(UpdateBinaryStream4(a, b))
+    F.liftF(UpdateBinaryStream1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateBinaryStream(a: String, b: InputStream): ResultSetIO[Unit] =
-    F.liftFC(UpdateBinaryStream5(a, b))
+    F.liftF(UpdateBinaryStream2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateBlob(a: String, b: InputStream, c: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateBlob(a, b, c))
+  def updateBinaryStream(a: String, b: InputStream, c: Int): ResultSetIO[Unit] =
+    F.liftF(UpdateBinaryStream3(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateBlob(a: Int, b: InputStream): ResultSetIO[Unit] =
-    F.liftFC(UpdateBlob1(a, b))
+  def updateBinaryStream(a: Int, b: InputStream, c: Int): ResultSetIO[Unit] =
+    F.liftF(UpdateBinaryStream4(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateBinaryStream(a: String, b: InputStream, c: Long): ResultSetIO[Unit] =
+    F.liftF(UpdateBinaryStream5(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateBlob(a: Int, b: InputStream, c: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateBlob2(a, b, c))
+    F.liftF(UpdateBlob(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateBlob(a: Int, b: InputStream): ResultSetIO[Unit] =
+    F.liftF(UpdateBlob1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateBlob(a: Int, b: Blob): ResultSetIO[Unit] =
-    F.liftFC(UpdateBlob3(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateBlob(a: String, b: InputStream): ResultSetIO[Unit] =
-    F.liftFC(UpdateBlob4(a, b))
+    F.liftF(UpdateBlob2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateBlob(a: String, b: Blob): ResultSetIO[Unit] =
-    F.liftFC(UpdateBlob5(a, b))
+    F.liftF(UpdateBlob3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateBoolean(a: String, b: Boolean): ResultSetIO[Unit] =
-    F.liftFC(UpdateBoolean(a, b))
+  def updateBlob(a: String, b: InputStream): ResultSetIO[Unit] =
+    F.liftF(UpdateBlob4(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateBlob(a: String, b: InputStream, c: Long): ResultSetIO[Unit] =
+    F.liftF(UpdateBlob5(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateBoolean(a: Int, b: Boolean): ResultSetIO[Unit] =
-    F.liftFC(UpdateBoolean1(a, b))
+    F.liftF(UpdateBoolean(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateBoolean(a: String, b: Boolean): ResultSetIO[Unit] =
+    F.liftF(UpdateBoolean1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateByte(a: String, b: Byte): ResultSetIO[Unit] =
-    F.liftFC(UpdateByte(a, b))
+    F.liftF(UpdateByte(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateByte(a: Int, b: Byte): ResultSetIO[Unit] =
-    F.liftFC(UpdateByte1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateBytes(a: Int, b: Array[Byte]): ResultSetIO[Unit] =
-    F.liftFC(UpdateBytes(a, b))
+    F.liftF(UpdateByte1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateBytes(a: String, b: Array[Byte]): ResultSetIO[Unit] =
-    F.liftFC(UpdateBytes1(a, b))
+    F.liftF(UpdateBytes(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateCharacterStream(a: String, b: Reader, c: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateCharacterStream(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateCharacterStream(a: Int, b: Reader, c: Int): ResultSetIO[Unit] =
-    F.liftFC(UpdateCharacterStream1(a, b, c))
+  def updateBytes(a: Int, b: Array[Byte]): ResultSetIO[Unit] =
+    F.liftF(UpdateBytes1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateCharacterStream(a: Int, b: Reader, c: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateCharacterStream2(a, b, c))
+    F.liftF(UpdateCharacterStream(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateCharacterStream(a: String, b: Reader): ResultSetIO[Unit] =
-    F.liftFC(UpdateCharacterStream3(a, b))
+  def updateCharacterStream(a: Int, b: Reader, c: Int): ResultSetIO[Unit] =
+    F.liftF(UpdateCharacterStream1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateCharacterStream(a: Int, b: Reader): ResultSetIO[Unit] =
-    F.liftFC(UpdateCharacterStream4(a, b))
+  def updateCharacterStream(a: String, b: Reader, c: Long): ResultSetIO[Unit] =
+    F.liftF(UpdateCharacterStream2(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateCharacterStream(a: String, b: Reader, c: Int): ResultSetIO[Unit] =
-    F.liftFC(UpdateCharacterStream5(a, b, c))
+    F.liftF(UpdateCharacterStream3(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateClob(a: String, b: Reader, c: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateClob(a, b, c))
+  def updateCharacterStream(a: Int, b: Reader): ResultSetIO[Unit] =
+    F.liftF(UpdateCharacterStream4(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateClob(a: Int, b: Reader, c: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateClob1(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateClob(a: String, b: Clob): ResultSetIO[Unit] =
-    F.liftFC(UpdateClob2(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateClob(a: String, b: Reader): ResultSetIO[Unit] =
-    F.liftFC(UpdateClob3(a, b))
+  def updateCharacterStream(a: String, b: Reader): ResultSetIO[Unit] =
+    F.liftF(UpdateCharacterStream5(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateClob(a: Int, b: Reader): ResultSetIO[Unit] =
-    F.liftFC(UpdateClob4(a, b))
+    F.liftF(UpdateClob(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateClob(a: Int, b: Reader, c: Long): ResultSetIO[Unit] =
+    F.liftF(UpdateClob1(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateClob(a: String, b: Reader): ResultSetIO[Unit] =
+    F.liftF(UpdateClob2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateClob(a: String, b: Clob): ResultSetIO[Unit] =
+    F.liftF(UpdateClob3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateClob(a: Int, b: Clob): ResultSetIO[Unit] =
-    F.liftFC(UpdateClob5(a, b))
+    F.liftF(UpdateClob4(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateClob(a: String, b: Reader, c: Long): ResultSetIO[Unit] =
+    F.liftF(UpdateClob5(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateDate(a: String, b: Date): ResultSetIO[Unit] =
-    F.liftFC(UpdateDate(a, b))
+    F.liftF(UpdateDate(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateDate(a: Int, b: Date): ResultSetIO[Unit] =
-    F.liftFC(UpdateDate1(a, b))
+    F.liftF(UpdateDate1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateDouble(a: String, b: Double): ResultSetIO[Unit] =
-    F.liftFC(UpdateDouble(a, b))
+    F.liftF(UpdateDouble(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateDouble(a: Int, b: Double): ResultSetIO[Unit] =
-    F.liftFC(UpdateDouble1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateFloat(a: Int, b: Float): ResultSetIO[Unit] =
-    F.liftFC(UpdateFloat(a, b))
+    F.liftF(UpdateDouble1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateFloat(a: String, b: Float): ResultSetIO[Unit] =
-    F.liftFC(UpdateFloat1(a, b))
+    F.liftF(UpdateFloat(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateInt(a: String, b: Int): ResultSetIO[Unit] =
-    F.liftFC(UpdateInt(a, b))
+  def updateFloat(a: Int, b: Float): ResultSetIO[Unit] =
+    F.liftF(UpdateFloat1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateInt(a: Int, b: Int): ResultSetIO[Unit] =
-    F.liftFC(UpdateInt1(a, b))
+    F.liftF(UpdateInt(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateLong(a: Int, b: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateLong(a, b))
+  def updateInt(a: String, b: Int): ResultSetIO[Unit] =
+    F.liftF(UpdateInt1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateLong(a: String, b: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateLong1(a, b))
+    F.liftF(UpdateLong(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateNCharacterStream(a: String, b: Reader): ResultSetIO[Unit] =
-    F.liftFC(UpdateNCharacterStream(a, b))
+  def updateLong(a: Int, b: Long): ResultSetIO[Unit] =
+    F.liftF(UpdateLong1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateNCharacterStream(a: Int, b: Reader, c: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateNCharacterStream1(a, b, c))
+    F.liftF(UpdateNCharacterStream(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateNCharacterStream(a: Int, b: Reader): ResultSetIO[Unit] =
-    F.liftFC(UpdateNCharacterStream2(a, b))
+  def updateNCharacterStream(a: String, b: Reader): ResultSetIO[Unit] =
+    F.liftF(UpdateNCharacterStream1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateNCharacterStream(a: String, b: Reader, c: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateNCharacterStream3(a, b, c))
+    F.liftF(UpdateNCharacterStream2(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateNCharacterStream(a: Int, b: Reader): ResultSetIO[Unit] =
+    F.liftF(UpdateNCharacterStream3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateNClob(a: Int, b: Reader): ResultSetIO[Unit] =
-    F.liftFC(UpdateNClob(a, b))
+    F.liftF(UpdateNClob(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateNClob(a: String, b: Reader): ResultSetIO[Unit] =
-    F.liftFC(UpdateNClob1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateNClob(a: Int, b: Reader, c: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateNClob2(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateNClob(a: String, b: Reader, c: Long): ResultSetIO[Unit] =
-    F.liftFC(UpdateNClob3(a, b, c))
+    F.liftF(UpdateNClob1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateNClob(a: Int, b: NClob): ResultSetIO[Unit] =
-    F.liftFC(UpdateNClob4(a, b))
+    F.liftF(UpdateNClob2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateNClob(a: String, b: NClob): ResultSetIO[Unit] =
-    F.liftFC(UpdateNClob5(a, b))
+    F.liftF(UpdateNClob3(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateNClob(a: String, b: Reader, c: Long): ResultSetIO[Unit] =
+    F.liftF(UpdateNClob4(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateNClob(a: Int, b: Reader, c: Long): ResultSetIO[Unit] =
+    F.liftF(UpdateNClob5(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateNString(a: Int, b: String): ResultSetIO[Unit] =
-    F.liftFC(UpdateNString(a, b))
+    F.liftF(UpdateNString(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateNString(a: String, b: String): ResultSetIO[Unit] =
-    F.liftFC(UpdateNString1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateNull(a: Int): ResultSetIO[Unit] =
-    F.liftFC(UpdateNull(a))
+    F.liftF(UpdateNString1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateNull(a: String): ResultSetIO[Unit] =
-    F.liftFC(UpdateNull1(a))
+    F.liftF(UpdateNull(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateObject(a: Int, b: Object, c: Int): ResultSetIO[Unit] =
-    F.liftFC(UpdateObject(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateObject(a: String, b: Object): ResultSetIO[Unit] =
-    F.liftFC(UpdateObject1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateObject(a: String, b: Object, c: Int): ResultSetIO[Unit] =
-    F.liftFC(UpdateObject2(a, b, c))
+  def updateNull(a: Int): ResultSetIO[Unit] =
+    F.liftF(UpdateNull1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateObject(a: Int, b: Object): ResultSetIO[Unit] =
-    F.liftFC(UpdateObject3(a, b))
+    F.liftF(UpdateObject(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateRef(a: Int, b: Ref): ResultSetIO[Unit] =
-    F.liftFC(UpdateRef(a, b))
+  def updateObject(a: String, b: Object, c: Int): ResultSetIO[Unit] =
+    F.liftF(UpdateObject1(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateObject(a: String, b: Object): ResultSetIO[Unit] =
+    F.liftF(UpdateObject2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateObject(a: Int, b: Object, c: SQLType): ResultSetIO[Unit] =
+    F.liftF(UpdateObject3(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateObject(a: Int, b: Object, c: SQLType, d: Int): ResultSetIO[Unit] =
+    F.liftF(UpdateObject4(a, b, c, d))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateObject(a: String, b: Object, c: SQLType, d: Int): ResultSetIO[Unit] =
+    F.liftF(UpdateObject5(a, b, c, d))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateObject(a: Int, b: Object, c: Int): ResultSetIO[Unit] =
+    F.liftF(UpdateObject6(a, b, c))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateObject(a: String, b: Object, c: SQLType): ResultSetIO[Unit] =
+    F.liftF(UpdateObject7(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateRef(a: String, b: Ref): ResultSetIO[Unit] =
-    F.liftFC(UpdateRef1(a, b))
+    F.liftF(UpdateRef(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateRef(a: Int, b: Ref): ResultSetIO[Unit] =
+    F.liftF(UpdateRef1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   val updateRow: ResultSetIO[Unit] =
-    F.liftFC(UpdateRow)
+    F.liftF(UpdateRow)
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateRowId(a: Int, b: RowId): ResultSetIO[Unit] =
-    F.liftFC(UpdateRowId(a, b))
+    F.liftF(UpdateRowId(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateRowId(a: String, b: RowId): ResultSetIO[Unit] =
-    F.liftFC(UpdateRowId1(a, b))
+    F.liftF(UpdateRowId1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateSQLXML(a: Int, b: SQLXML): ResultSetIO[Unit] =
-    F.liftFC(UpdateSQLXML(a, b))
+    F.liftF(UpdateSQLXML(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateSQLXML(a: String, b: SQLXML): ResultSetIO[Unit] =
-    F.liftFC(UpdateSQLXML1(a, b))
+    F.liftF(UpdateSQLXML1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateShort(a: Int, b: Short): ResultSetIO[Unit] =
-    F.liftFC(UpdateShort(a, b))
+    F.liftF(UpdateShort(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateShort(a: String, b: Short): ResultSetIO[Unit] =
-    F.liftFC(UpdateShort1(a, b))
+    F.liftF(UpdateShort1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateString(a: String, b: String): ResultSetIO[Unit] =
-    F.liftFC(UpdateString(a, b))
+    F.liftF(UpdateString(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateString(a: Int, b: String): ResultSetIO[Unit] =
-    F.liftFC(UpdateString1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateTime(a: String, b: Time): ResultSetIO[Unit] =
-    F.liftFC(UpdateTime(a, b))
+    F.liftF(UpdateString1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateTime(a: Int, b: Time): ResultSetIO[Unit] =
-    F.liftFC(UpdateTime1(a, b))
+    F.liftF(UpdateTime(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateTimestamp(a: String, b: Timestamp): ResultSetIO[Unit] =
-    F.liftFC(UpdateTimestamp(a, b))
+  def updateTime(a: String, b: Time): ResultSetIO[Unit] =
+    F.liftF(UpdateTime1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateTimestamp(a: Int, b: Timestamp): ResultSetIO[Unit] =
-    F.liftFC(UpdateTimestamp1(a, b))
+    F.liftF(UpdateTimestamp(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateTimestamp(a: String, b: Timestamp): ResultSetIO[Unit] =
+    F.liftF(UpdateTimestamp1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   val wasNull: ResultSetIO[Boolean] =
-    F.liftFC(WasNull)
+    F.liftF(WasNull)
 
  /** 
   * Natural transformation from `ResultSetOp` to `Kleisli` for the given `M`, consuming a `java.sql.ResultSet`. 

--- a/core/src/main/scala/doobie/free/resultset.scala
+++ b/core/src/main/scala/doobie/free/resultset.scala
@@ -29,7 +29,6 @@ import java.sql.RowId
 import java.sql.SQLData
 import java.sql.SQLInput
 import java.sql.SQLOutput
-import java.sql.SQLType
 import java.sql.SQLWarning
 import java.sql.SQLXML
 import java.sql.Statement
@@ -62,7 +61,7 @@ import resultset.ResultSetIO
  *
  * `ResultSetIO` is a free monad that must be run via an interpreter, most commonly via
  * natural transformation of its underlying algebra `ResultSetOp` to another monad via
- * `Free.runFC`. 
+ * `Free#foldMap`.
  *
  * The library provides a natural transformation to `Kleisli[M, ResultSet, A]` for any
  * exception-trapping (`Catchable`) and effect-capturing (`Capture`) monad `M`. Such evidence is 
@@ -163,28 +162,28 @@ object resultset {
     case class  GetArray1(a: Int) extends ResultSetOp[SqlArray] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getArray(a))
     }
-    case class  GetAsciiStream(a: String) extends ResultSetOp[InputStream] {
+    case class  GetAsciiStream(a: Int) extends ResultSetOp[InputStream] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getAsciiStream(a))
     }
-    case class  GetAsciiStream1(a: Int) extends ResultSetOp[InputStream] {
+    case class  GetAsciiStream1(a: String) extends ResultSetOp[InputStream] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getAsciiStream(a))
     }
-    case class  GetBigDecimal(a: String, b: Int) extends ResultSetOp[BigDecimal] {
+    case class  GetBigDecimal(a: Int, b: Int) extends ResultSetOp[BigDecimal] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a, b))
     }
-    case class  GetBigDecimal1(a: Int) extends ResultSetOp[BigDecimal] {
+    case class  GetBigDecimal1(a: String, b: Int) extends ResultSetOp[BigDecimal] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a, b))
+    }
+    case class  GetBigDecimal2(a: Int) extends ResultSetOp[BigDecimal] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a))
-    }
-    case class  GetBigDecimal2(a: Int, b: Int) extends ResultSetOp[BigDecimal] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a, b))
     }
     case class  GetBigDecimal3(a: String) extends ResultSetOp[BigDecimal] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBigDecimal(a))
     }
-    case class  GetBinaryStream(a: String) extends ResultSetOp[InputStream] {
+    case class  GetBinaryStream(a: Int) extends ResultSetOp[InputStream] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBinaryStream(a))
     }
-    case class  GetBinaryStream1(a: Int) extends ResultSetOp[InputStream] {
+    case class  GetBinaryStream1(a: String) extends ResultSetOp[InputStream] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBinaryStream(a))
     }
     case class  GetBlob(a: Int) extends ResultSetOp[Blob] {
@@ -193,10 +192,10 @@ object resultset {
     case class  GetBlob1(a: String) extends ResultSetOp[Blob] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBlob(a))
     }
-    case class  GetBoolean(a: String) extends ResultSetOp[Boolean] {
+    case class  GetBoolean(a: Int) extends ResultSetOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBoolean(a))
     }
-    case class  GetBoolean1(a: Int) extends ResultSetOp[Boolean] {
+    case class  GetBoolean1(a: String) extends ResultSetOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBoolean(a))
     }
     case class  GetByte(a: String) extends ResultSetOp[Byte] {
@@ -205,22 +204,22 @@ object resultset {
     case class  GetByte1(a: Int) extends ResultSetOp[Byte] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getByte(a))
     }
-    case class  GetBytes(a: String) extends ResultSetOp[Array[Byte]] {
+    case class  GetBytes(a: Int) extends ResultSetOp[Array[Byte]] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBytes(a))
     }
-    case class  GetBytes1(a: Int) extends ResultSetOp[Array[Byte]] {
+    case class  GetBytes1(a: String) extends ResultSetOp[Array[Byte]] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getBytes(a))
     }
-    case class  GetCharacterStream(a: Int) extends ResultSetOp[Reader] {
+    case class  GetCharacterStream(a: String) extends ResultSetOp[Reader] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getCharacterStream(a))
     }
-    case class  GetCharacterStream1(a: String) extends ResultSetOp[Reader] {
+    case class  GetCharacterStream1(a: Int) extends ResultSetOp[Reader] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getCharacterStream(a))
     }
-    case class  GetClob(a: Int) extends ResultSetOp[Clob] {
+    case class  GetClob(a: String) extends ResultSetOp[Clob] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getClob(a))
     }
-    case class  GetClob1(a: String) extends ResultSetOp[Clob] {
+    case class  GetClob1(a: Int) extends ResultSetOp[Clob] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getClob(a))
     }
     case object GetConcurrency extends ResultSetOp[Int] {
@@ -232,19 +231,19 @@ object resultset {
     case class  GetDate(a: Int) extends ResultSetOp[Date] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a))
     }
-    case class  GetDate1(a: String) extends ResultSetOp[Date] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a))
-    }
-    case class  GetDate2(a: Int, b: Calendar) extends ResultSetOp[Date] {
+    case class  GetDate1(a: Int, b: Calendar) extends ResultSetOp[Date] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a, b))
+    }
+    case class  GetDate2(a: String) extends ResultSetOp[Date] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a))
     }
     case class  GetDate3(a: String, b: Calendar) extends ResultSetOp[Date] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDate(a, b))
     }
-    case class  GetDouble(a: Int) extends ResultSetOp[Double] {
+    case class  GetDouble(a: String) extends ResultSetOp[Double] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDouble(a))
     }
-    case class  GetDouble1(a: String) extends ResultSetOp[Double] {
+    case class  GetDouble1(a: Int) extends ResultSetOp[Double] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getDouble(a))
     }
     case object GetFetchDirection extends ResultSetOp[Int] {
@@ -253,34 +252,34 @@ object resultset {
     case object GetFetchSize extends ResultSetOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getFetchSize())
     }
-    case class  GetFloat(a: Int) extends ResultSetOp[Float] {
+    case class  GetFloat(a: String) extends ResultSetOp[Float] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getFloat(a))
     }
-    case class  GetFloat1(a: String) extends ResultSetOp[Float] {
+    case class  GetFloat1(a: Int) extends ResultSetOp[Float] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getFloat(a))
     }
     case object GetHoldability extends ResultSetOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getHoldability())
     }
-    case class  GetInt(a: String) extends ResultSetOp[Int] {
+    case class  GetInt(a: Int) extends ResultSetOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getInt(a))
     }
-    case class  GetInt1(a: Int) extends ResultSetOp[Int] {
+    case class  GetInt1(a: String) extends ResultSetOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getInt(a))
     }
-    case class  GetLong(a: String) extends ResultSetOp[Long] {
+    case class  GetLong(a: Int) extends ResultSetOp[Long] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLong(a))
     }
-    case class  GetLong1(a: Int) extends ResultSetOp[Long] {
+    case class  GetLong1(a: String) extends ResultSetOp[Long] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLong(a))
     }
     case object GetMetaData extends ResultSetOp[ResultSetMetaData] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMetaData())
     }
-    case class  GetNCharacterStream(a: Int) extends ResultSetOp[Reader] {
+    case class  GetNCharacterStream(a: String) extends ResultSetOp[Reader] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNCharacterStream(a))
     }
-    case class  GetNCharacterStream1(a: String) extends ResultSetOp[Reader] {
+    case class  GetNCharacterStream1(a: Int) extends ResultSetOp[Reader] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNCharacterStream(a))
     }
     case class  GetNClob(a: String) extends ResultSetOp[NClob] {
@@ -289,34 +288,34 @@ object resultset {
     case class  GetNClob1(a: Int) extends ResultSetOp[NClob] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNClob(a))
     }
-    case class  GetNString(a: Int) extends ResultSetOp[String] {
+    case class  GetNString(a: String) extends ResultSetOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNString(a))
     }
-    case class  GetNString1(a: String) extends ResultSetOp[String] {
+    case class  GetNString1(a: Int) extends ResultSetOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getNString(a))
     }
-    case class  GetObject(a: String, b: Map[String, Class[_]]) extends ResultSetOp[Object] {
+    case class  GetObject[T](a: Int, b: Class[T]) extends ResultSetOp[T] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
     }
-    case class  GetObject1[T](a: Int, b: Class[T]) extends ResultSetOp[T] {
+    case class  GetObject1(a: String, b: Map[String, Class[_]]) extends ResultSetOp[Object] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
     }
-    case class  GetObject2(a: Int, b: Map[String, Class[_]]) extends ResultSetOp[Object] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
-    }
-    case class  GetObject3(a: Int) extends ResultSetOp[Object] {
+    case class  GetObject2(a: String) extends ResultSetOp[Object] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a))
     }
-    case class  GetObject4(a: String) extends ResultSetOp[Object] {
+    case class  GetObject3(a: Int, b: Map[String, Class[_]]) extends ResultSetOp[Object] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
+    }
+    case class  GetObject4(a: Int) extends ResultSetOp[Object] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a))
     }
     case class  GetObject5[T](a: String, b: Class[T]) extends ResultSetOp[T] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getObject(a, b))
     }
-    case class  GetRef(a: String) extends ResultSetOp[Ref] {
+    case class  GetRef(a: Int) extends ResultSetOp[Ref] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getRef(a))
     }
-    case class  GetRef1(a: Int) extends ResultSetOp[Ref] {
+    case class  GetRef1(a: String) extends ResultSetOp[Ref] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getRef(a))
     }
     case object GetRow extends ResultSetOp[Int] {
@@ -328,10 +327,10 @@ object resultset {
     case class  GetRowId1(a: String) extends ResultSetOp[RowId] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getRowId(a))
     }
-    case class  GetSQLXML(a: Int) extends ResultSetOp[SQLXML] {
+    case class  GetSQLXML(a: String) extends ResultSetOp[SQLXML] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSQLXML(a))
     }
-    case class  GetSQLXML1(a: String) extends ResultSetOp[SQLXML] {
+    case class  GetSQLXML1(a: Int) extends ResultSetOp[SQLXML] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getSQLXML(a))
     }
     case class  GetShort(a: String) extends ResultSetOp[Short] {
@@ -343,43 +342,43 @@ object resultset {
     case object GetStatement extends ResultSetOp[Statement] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getStatement())
     }
-    case class  GetString(a: String) extends ResultSetOp[String] {
+    case class  GetString(a: Int) extends ResultSetOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getString(a))
     }
-    case class  GetString1(a: Int) extends ResultSetOp[String] {
+    case class  GetString1(a: String) extends ResultSetOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getString(a))
     }
     case class  GetTime(a: String) extends ResultSetOp[Time] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a))
     }
-    case class  GetTime1(a: String, b: Calendar) extends ResultSetOp[Time] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a, b))
-    }
-    case class  GetTime2(a: Int, b: Calendar) extends ResultSetOp[Time] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a, b))
-    }
-    case class  GetTime3(a: Int) extends ResultSetOp[Time] {
+    case class  GetTime1(a: Int) extends ResultSetOp[Time] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a))
     }
-    case class  GetTimestamp(a: Int, b: Calendar) extends ResultSetOp[Timestamp] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a, b))
+    case class  GetTime2(a: String, b: Calendar) extends ResultSetOp[Time] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a, b))
+    }
+    case class  GetTime3(a: Int, b: Calendar) extends ResultSetOp[Time] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTime(a, b))
+    }
+    case class  GetTimestamp(a: Int) extends ResultSetOp[Timestamp] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a))
     }
     case class  GetTimestamp1(a: String, b: Calendar) extends ResultSetOp[Timestamp] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a, b))
     }
-    case class  GetTimestamp2(a: Int) extends ResultSetOp[Timestamp] {
+    case class  GetTimestamp2(a: String) extends ResultSetOp[Timestamp] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a))
     }
-    case class  GetTimestamp3(a: String) extends ResultSetOp[Timestamp] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a))
+    case class  GetTimestamp3(a: Int, b: Calendar) extends ResultSetOp[Timestamp] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getTimestamp(a, b))
     }
     case object GetType extends ResultSetOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getType())
     }
-    case class  GetURL(a: String) extends ResultSetOp[URL] {
+    case class  GetURL(a: Int) extends ResultSetOp[URL] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getURL(a))
     }
-    case class  GetURL1(a: Int) extends ResultSetOp[URL] {
+    case class  GetURL1(a: String) extends ResultSetOp[URL] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getURL(a))
     }
     case class  GetUnicodeStream(a: Int) extends ResultSetOp[InputStream] {
@@ -451,26 +450,26 @@ object resultset {
     case class  Unwrap[T](a: Class[T]) extends ResultSetOp[T] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.unwrap(a))
     }
-    case class  UpdateArray(a: Int, b: SqlArray) extends ResultSetOp[Unit] {
+    case class  UpdateArray(a: String, b: SqlArray) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateArray(a, b))
     }
-    case class  UpdateArray1(a: String, b: SqlArray) extends ResultSetOp[Unit] {
+    case class  UpdateArray1(a: Int, b: SqlArray) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateArray(a, b))
     }
-    case class  UpdateAsciiStream(a: String, b: InputStream) extends ResultSetOp[Unit] {
+    case class  UpdateAsciiStream(a: String, b: InputStream, c: Long) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateAsciiStream(a, b, c))
+    }
+    case class  UpdateAsciiStream1(a: String, b: InputStream) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateAsciiStream(a, b))
     }
-    case class  UpdateAsciiStream1(a: Int, b: InputStream) extends ResultSetOp[Unit] {
+    case class  UpdateAsciiStream2(a: String, b: InputStream, c: Int) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateAsciiStream(a, b, c))
+    }
+    case class  UpdateAsciiStream3(a: Int, b: InputStream, c: Int) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateAsciiStream(a, b, c))
+    }
+    case class  UpdateAsciiStream4(a: Int, b: InputStream) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateAsciiStream(a, b))
-    }
-    case class  UpdateAsciiStream2(a: Int, b: InputStream, c: Int) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateAsciiStream(a, b, c))
-    }
-    case class  UpdateAsciiStream3(a: String, b: InputStream, c: Long) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateAsciiStream(a, b, c))
-    }
-    case class  UpdateAsciiStream4(a: String, b: InputStream, c: Int) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateAsciiStream(a, b, c))
     }
     case class  UpdateAsciiStream5(a: Int, b: InputStream, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateAsciiStream(a, b, c))
@@ -484,38 +483,38 @@ object resultset {
     case class  UpdateBinaryStream(a: Int, b: InputStream, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b, c))
     }
-    case class  UpdateBinaryStream1(a: Int, b: InputStream) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b))
+    case class  UpdateBinaryStream1(a: String, b: InputStream, c: Int) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b, c))
     }
     case class  UpdateBinaryStream2(a: String, b: InputStream) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b))
     }
-    case class  UpdateBinaryStream3(a: String, b: InputStream, c: Int) extends ResultSetOp[Unit] {
+    case class  UpdateBinaryStream3(a: String, b: InputStream, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b, c))
     }
-    case class  UpdateBinaryStream4(a: Int, b: InputStream, c: Int) extends ResultSetOp[Unit] {
+    case class  UpdateBinaryStream4(a: Int, b: InputStream) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b))
+    }
+    case class  UpdateBinaryStream5(a: Int, b: InputStream, c: Int) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b, c))
     }
-    case class  UpdateBinaryStream5(a: String, b: InputStream, c: Long) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBinaryStream(a, b, c))
+    case class  UpdateBlob(a: Int, b: Blob) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b))
     }
-    case class  UpdateBlob(a: Int, b: InputStream, c: Long) extends ResultSetOp[Unit] {
+    case class  UpdateBlob1(a: Int, b: InputStream, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b, c))
     }
-    case class  UpdateBlob1(a: Int, b: InputStream) extends ResultSetOp[Unit] {
+    case class  UpdateBlob2(a: Int, b: InputStream) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b))
     }
-    case class  UpdateBlob2(a: Int, b: Blob) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b))
-    }
-    case class  UpdateBlob3(a: String, b: Blob) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b))
+    case class  UpdateBlob3(a: String, b: InputStream, c: Long) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b, c))
     }
     case class  UpdateBlob4(a: String, b: InputStream) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b))
     }
-    case class  UpdateBlob5(a: String, b: InputStream, c: Long) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b, c))
+    case class  UpdateBlob5(a: String, b: Blob) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBlob(a, b))
     }
     case class  UpdateBoolean(a: Int, b: Boolean) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBoolean(a, b))
@@ -535,16 +534,16 @@ object resultset {
     case class  UpdateBytes1(a: Int, b: Array[Byte]) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateBytes(a, b))
     }
-    case class  UpdateCharacterStream(a: Int, b: Reader, c: Long) extends ResultSetOp[Unit] {
+    case class  UpdateCharacterStream(a: String, b: Reader, c: Int) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateCharacterStream(a, b, c))
     }
     case class  UpdateCharacterStream1(a: Int, b: Reader, c: Int) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateCharacterStream(a, b, c))
     }
-    case class  UpdateCharacterStream2(a: String, b: Reader, c: Long) extends ResultSetOp[Unit] {
+    case class  UpdateCharacterStream2(a: Int, b: Reader, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateCharacterStream(a, b, c))
     }
-    case class  UpdateCharacterStream3(a: String, b: Reader, c: Int) extends ResultSetOp[Unit] {
+    case class  UpdateCharacterStream3(a: String, b: Reader, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateCharacterStream(a, b, c))
     }
     case class  UpdateCharacterStream4(a: Int, b: Reader) extends ResultSetOp[Unit] {
@@ -553,19 +552,19 @@ object resultset {
     case class  UpdateCharacterStream5(a: String, b: Reader) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateCharacterStream(a, b))
     }
-    case class  UpdateClob(a: Int, b: Reader) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateClob(a, b))
-    }
-    case class  UpdateClob1(a: Int, b: Reader, c: Long) extends ResultSetOp[Unit] {
+    case class  UpdateClob(a: Int, b: Reader, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateClob(a, b, c))
     }
-    case class  UpdateClob2(a: String, b: Reader) extends ResultSetOp[Unit] {
+    case class  UpdateClob1(a: Int, b: Clob) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateClob(a, b))
     }
-    case class  UpdateClob3(a: String, b: Clob) extends ResultSetOp[Unit] {
+    case class  UpdateClob2(a: String, b: Clob) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateClob(a, b))
     }
-    case class  UpdateClob4(a: Int, b: Clob) extends ResultSetOp[Unit] {
+    case class  UpdateClob3(a: Int, b: Reader) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateClob(a, b))
+    }
+    case class  UpdateClob4(a: String, b: Reader) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateClob(a, b))
     }
     case class  UpdateClob5(a: String, b: Reader, c: Long) extends ResultSetOp[Unit] {
@@ -595,41 +594,41 @@ object resultset {
     case class  UpdateInt1(a: String, b: Int) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateInt(a, b))
     }
-    case class  UpdateLong(a: String, b: Long) extends ResultSetOp[Unit] {
+    case class  UpdateLong(a: Int, b: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateLong(a, b))
     }
-    case class  UpdateLong1(a: Int, b: Long) extends ResultSetOp[Unit] {
+    case class  UpdateLong1(a: String, b: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateLong(a, b))
     }
     case class  UpdateNCharacterStream(a: Int, b: Reader, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNCharacterStream(a, b, c))
     }
-    case class  UpdateNCharacterStream1(a: String, b: Reader) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNCharacterStream(a, b))
-    }
-    case class  UpdateNCharacterStream2(a: String, b: Reader, c: Long) extends ResultSetOp[Unit] {
+    case class  UpdateNCharacterStream1(a: String, b: Reader, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNCharacterStream(a, b, c))
     }
-    case class  UpdateNCharacterStream3(a: Int, b: Reader) extends ResultSetOp[Unit] {
+    case class  UpdateNCharacterStream2(a: Int, b: Reader) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNCharacterStream(a, b))
     }
-    case class  UpdateNClob(a: Int, b: Reader) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b))
+    case class  UpdateNCharacterStream3(a: String, b: Reader) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNCharacterStream(a, b))
+    }
+    case class  UpdateNClob(a: Int, b: Reader, c: Long) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b, c))
     }
     case class  UpdateNClob1(a: String, b: Reader) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b))
     }
-    case class  UpdateNClob2(a: Int, b: NClob) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b))
-    }
-    case class  UpdateNClob3(a: String, b: NClob) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b))
-    }
-    case class  UpdateNClob4(a: String, b: Reader, c: Long) extends ResultSetOp[Unit] {
+    case class  UpdateNClob2(a: String, b: Reader, c: Long) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b, c))
     }
-    case class  UpdateNClob5(a: Int, b: Reader, c: Long) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b, c))
+    case class  UpdateNClob3(a: Int, b: Reader) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b))
+    }
+    case class  UpdateNClob4(a: String, b: NClob) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b))
+    }
+    case class  UpdateNClob5(a: Int, b: NClob) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNClob(a, b))
     }
     case class  UpdateNString(a: Int, b: String) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNString(a, b))
@@ -643,29 +642,17 @@ object resultset {
     case class  UpdateNull1(a: Int) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateNull(a))
     }
-    case class  UpdateObject(a: Int, b: Object) extends ResultSetOp[Unit] {
+    case class  UpdateObject(a: String, b: Object) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b))
     }
     case class  UpdateObject1(a: String, b: Object, c: Int) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b, c))
     }
-    case class  UpdateObject2(a: String, b: Object) extends ResultSetOp[Unit] {
+    case class  UpdateObject2(a: Int, b: Object, c: Int) extends ResultSetOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b, c))
+    }
+    case class  UpdateObject3(a: Int, b: Object) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b))
-    }
-    case class  UpdateObject3(a: Int, b: Object, c: SQLType) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b, c))
-    }
-    case class  UpdateObject4(a: Int, b: Object, c: SQLType, d: Int) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b, c, d))
-    }
-    case class  UpdateObject5(a: String, b: Object, c: SQLType, d: Int) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b, c, d))
-    }
-    case class  UpdateObject6(a: Int, b: Object, c: Int) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b, c))
-    }
-    case class  UpdateObject7(a: String, b: Object, c: SQLType) extends ResultSetOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateObject(a, b, c))
     }
     case class  UpdateRef(a: String, b: Ref) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateRef(a, b))
@@ -688,10 +675,10 @@ object resultset {
     case class  UpdateSQLXML1(a: String, b: SQLXML) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateSQLXML(a, b))
     }
-    case class  UpdateShort(a: Int, b: Short) extends ResultSetOp[Unit] {
+    case class  UpdateShort(a: String, b: Short) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateShort(a, b))
     }
-    case class  UpdateShort1(a: String, b: Short) extends ResultSetOp[Unit] {
+    case class  UpdateShort1(a: Int, b: Short) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateShort(a, b))
     }
     case class  UpdateString(a: String, b: String) extends ResultSetOp[Unit] {
@@ -700,10 +687,10 @@ object resultset {
     case class  UpdateString1(a: Int, b: String) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateString(a, b))
     }
-    case class  UpdateTime(a: Int, b: Time) extends ResultSetOp[Unit] {
+    case class  UpdateTime(a: String, b: Time) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateTime(a, b))
     }
-    case class  UpdateTime1(a: String, b: Time) extends ResultSetOp[Unit] {
+    case class  UpdateTime1(a: Int, b: Time) extends ResultSetOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.updateTime(a, b))
     }
     case class  UpdateTimestamp(a: Int, b: Timestamp) extends ResultSetOp[Unit] {
@@ -842,32 +829,32 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getAsciiStream(a: String): ResultSetIO[InputStream] =
+  def getAsciiStream(a: Int): ResultSetIO[InputStream] =
     F.liftF(GetAsciiStream(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getAsciiStream(a: Int): ResultSetIO[InputStream] =
+  def getAsciiStream(a: String): ResultSetIO[InputStream] =
     F.liftF(GetAsciiStream1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getBigDecimal(a: String, b: Int): ResultSetIO[BigDecimal] =
+  def getBigDecimal(a: Int, b: Int): ResultSetIO[BigDecimal] =
     F.liftF(GetBigDecimal(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getBigDecimal(a: Int): ResultSetIO[BigDecimal] =
-    F.liftF(GetBigDecimal1(a))
+  def getBigDecimal(a: String, b: Int): ResultSetIO[BigDecimal] =
+    F.liftF(GetBigDecimal1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getBigDecimal(a: Int, b: Int): ResultSetIO[BigDecimal] =
-    F.liftF(GetBigDecimal2(a, b))
+  def getBigDecimal(a: Int): ResultSetIO[BigDecimal] =
+    F.liftF(GetBigDecimal2(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -878,13 +865,13 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getBinaryStream(a: String): ResultSetIO[InputStream] =
+  def getBinaryStream(a: Int): ResultSetIO[InputStream] =
     F.liftF(GetBinaryStream(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getBinaryStream(a: Int): ResultSetIO[InputStream] =
+  def getBinaryStream(a: String): ResultSetIO[InputStream] =
     F.liftF(GetBinaryStream1(a))
 
   /** 
@@ -902,13 +889,13 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getBoolean(a: String): ResultSetIO[Boolean] =
+  def getBoolean(a: Int): ResultSetIO[Boolean] =
     F.liftF(GetBoolean(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getBoolean(a: Int): ResultSetIO[Boolean] =
+  def getBoolean(a: String): ResultSetIO[Boolean] =
     F.liftF(GetBoolean1(a))
 
   /** 
@@ -926,37 +913,37 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getBytes(a: String): ResultSetIO[Array[Byte]] =
+  def getBytes(a: Int): ResultSetIO[Array[Byte]] =
     F.liftF(GetBytes(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getBytes(a: Int): ResultSetIO[Array[Byte]] =
+  def getBytes(a: String): ResultSetIO[Array[Byte]] =
     F.liftF(GetBytes1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getCharacterStream(a: Int): ResultSetIO[Reader] =
+  def getCharacterStream(a: String): ResultSetIO[Reader] =
     F.liftF(GetCharacterStream(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getCharacterStream(a: String): ResultSetIO[Reader] =
+  def getCharacterStream(a: Int): ResultSetIO[Reader] =
     F.liftF(GetCharacterStream1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getClob(a: Int): ResultSetIO[Clob] =
+  def getClob(a: String): ResultSetIO[Clob] =
     F.liftF(GetClob(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getClob(a: String): ResultSetIO[Clob] =
+  def getClob(a: Int): ResultSetIO[Clob] =
     F.liftF(GetClob1(a))
 
   /** 
@@ -980,14 +967,14 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getDate(a: String): ResultSetIO[Date] =
-    F.liftF(GetDate1(a))
+  def getDate(a: Int, b: Calendar): ResultSetIO[Date] =
+    F.liftF(GetDate1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getDate(a: Int, b: Calendar): ResultSetIO[Date] =
-    F.liftF(GetDate2(a, b))
+  def getDate(a: String): ResultSetIO[Date] =
+    F.liftF(GetDate2(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -998,13 +985,13 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getDouble(a: Int): ResultSetIO[Double] =
+  def getDouble(a: String): ResultSetIO[Double] =
     F.liftF(GetDouble(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getDouble(a: String): ResultSetIO[Double] =
+  def getDouble(a: Int): ResultSetIO[Double] =
     F.liftF(GetDouble1(a))
 
   /** 
@@ -1022,13 +1009,13 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getFloat(a: Int): ResultSetIO[Float] =
+  def getFloat(a: String): ResultSetIO[Float] =
     F.liftF(GetFloat(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getFloat(a: String): ResultSetIO[Float] =
+  def getFloat(a: Int): ResultSetIO[Float] =
     F.liftF(GetFloat1(a))
 
   /** 
@@ -1040,25 +1027,25 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getInt(a: String): ResultSetIO[Int] =
+  def getInt(a: Int): ResultSetIO[Int] =
     F.liftF(GetInt(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getInt(a: Int): ResultSetIO[Int] =
+  def getInt(a: String): ResultSetIO[Int] =
     F.liftF(GetInt1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getLong(a: String): ResultSetIO[Long] =
+  def getLong(a: Int): ResultSetIO[Long] =
     F.liftF(GetLong(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getLong(a: Int): ResultSetIO[Long] =
+  def getLong(a: String): ResultSetIO[Long] =
     F.liftF(GetLong1(a))
 
   /** 
@@ -1070,13 +1057,13 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getNCharacterStream(a: Int): ResultSetIO[Reader] =
+  def getNCharacterStream(a: String): ResultSetIO[Reader] =
     F.liftF(GetNCharacterStream(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getNCharacterStream(a: String): ResultSetIO[Reader] =
+  def getNCharacterStream(a: Int): ResultSetIO[Reader] =
     F.liftF(GetNCharacterStream1(a))
 
   /** 
@@ -1094,43 +1081,43 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getNString(a: Int): ResultSetIO[String] =
+  def getNString(a: String): ResultSetIO[String] =
     F.liftF(GetNString(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getNString(a: String): ResultSetIO[String] =
+  def getNString(a: Int): ResultSetIO[String] =
     F.liftF(GetNString1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getObject(a: String, b: Map[String, Class[_]]): ResultSetIO[Object] =
+  def getObject[T](a: Int, b: Class[T]): ResultSetIO[T] =
     F.liftF(GetObject(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getObject[T](a: Int, b: Class[T]): ResultSetIO[T] =
+  def getObject(a: String, b: Map[String, Class[_]]): ResultSetIO[Object] =
     F.liftF(GetObject1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
+  def getObject(a: String): ResultSetIO[Object] =
+    F.liftF(GetObject2(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
   def getObject(a: Int, b: Map[String, Class[_]]): ResultSetIO[Object] =
-    F.liftF(GetObject2(a, b))
+    F.liftF(GetObject3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def getObject(a: Int): ResultSetIO[Object] =
-    F.liftF(GetObject3(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def getObject(a: String): ResultSetIO[Object] =
     F.liftF(GetObject4(a))
 
   /** 
@@ -1142,13 +1129,13 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getRef(a: String): ResultSetIO[Ref] =
+  def getRef(a: Int): ResultSetIO[Ref] =
     F.liftF(GetRef(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getRef(a: Int): ResultSetIO[Ref] =
+  def getRef(a: String): ResultSetIO[Ref] =
     F.liftF(GetRef1(a))
 
   /** 
@@ -1172,13 +1159,13 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getSQLXML(a: Int): ResultSetIO[SQLXML] =
+  def getSQLXML(a: String): ResultSetIO[SQLXML] =
     F.liftF(GetSQLXML(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getSQLXML(a: String): ResultSetIO[SQLXML] =
+  def getSQLXML(a: Int): ResultSetIO[SQLXML] =
     F.liftF(GetSQLXML1(a))
 
   /** 
@@ -1202,13 +1189,13 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getString(a: String): ResultSetIO[String] =
+  def getString(a: Int): ResultSetIO[String] =
     F.liftF(GetString(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getString(a: Int): ResultSetIO[String] =
+  def getString(a: String): ResultSetIO[String] =
     F.liftF(GetString1(a))
 
   /** 
@@ -1220,26 +1207,26 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getTime(a: String, b: Calendar): ResultSetIO[Time] =
-    F.liftF(GetTime1(a, b))
+  def getTime(a: Int): ResultSetIO[Time] =
+    F.liftF(GetTime1(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getTime(a: Int, b: Calendar): ResultSetIO[Time] =
+  def getTime(a: String, b: Calendar): ResultSetIO[Time] =
     F.liftF(GetTime2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getTime(a: Int): ResultSetIO[Time] =
-    F.liftF(GetTime3(a))
+  def getTime(a: Int, b: Calendar): ResultSetIO[Time] =
+    F.liftF(GetTime3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getTimestamp(a: Int, b: Calendar): ResultSetIO[Timestamp] =
-    F.liftF(GetTimestamp(a, b))
+  def getTimestamp(a: Int): ResultSetIO[Timestamp] =
+    F.liftF(GetTimestamp(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -1250,14 +1237,14 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getTimestamp(a: Int): ResultSetIO[Timestamp] =
+  def getTimestamp(a: String): ResultSetIO[Timestamp] =
     F.liftF(GetTimestamp2(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getTimestamp(a: String): ResultSetIO[Timestamp] =
-    F.liftF(GetTimestamp3(a))
+  def getTimestamp(a: Int, b: Calendar): ResultSetIO[Timestamp] =
+    F.liftF(GetTimestamp3(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1268,13 +1255,13 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def getURL(a: String): ResultSetIO[URL] =
+  def getURL(a: Int): ResultSetIO[URL] =
     F.liftF(GetURL(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def getURL(a: Int): ResultSetIO[URL] =
+  def getURL(a: String): ResultSetIO[URL] =
     F.liftF(GetURL1(a))
 
   /** 
@@ -1418,44 +1405,44 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateArray(a: Int, b: SqlArray): ResultSetIO[Unit] =
+  def updateArray(a: String, b: SqlArray): ResultSetIO[Unit] =
     F.liftF(UpdateArray(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateArray(a: String, b: SqlArray): ResultSetIO[Unit] =
+  def updateArray(a: Int, b: SqlArray): ResultSetIO[Unit] =
     F.liftF(UpdateArray1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateAsciiStream(a: String, b: InputStream): ResultSetIO[Unit] =
-    F.liftF(UpdateAsciiStream(a, b))
+  def updateAsciiStream(a: String, b: InputStream, c: Long): ResultSetIO[Unit] =
+    F.liftF(UpdateAsciiStream(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateAsciiStream(a: Int, b: InputStream): ResultSetIO[Unit] =
+  def updateAsciiStream(a: String, b: InputStream): ResultSetIO[Unit] =
     F.liftF(UpdateAsciiStream1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateAsciiStream(a: Int, b: InputStream, c: Int): ResultSetIO[Unit] =
+  def updateAsciiStream(a: String, b: InputStream, c: Int): ResultSetIO[Unit] =
     F.liftF(UpdateAsciiStream2(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateAsciiStream(a: String, b: InputStream, c: Long): ResultSetIO[Unit] =
+  def updateAsciiStream(a: Int, b: InputStream, c: Int): ResultSetIO[Unit] =
     F.liftF(UpdateAsciiStream3(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateAsciiStream(a: String, b: InputStream, c: Int): ResultSetIO[Unit] =
-    F.liftF(UpdateAsciiStream4(a, b, c))
+  def updateAsciiStream(a: Int, b: InputStream): ResultSetIO[Unit] =
+    F.liftF(UpdateAsciiStream4(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1484,8 +1471,8 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateBinaryStream(a: Int, b: InputStream): ResultSetIO[Unit] =
-    F.liftF(UpdateBinaryStream1(a, b))
+  def updateBinaryStream(a: String, b: InputStream, c: Int): ResultSetIO[Unit] =
+    F.liftF(UpdateBinaryStream1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -1496,44 +1483,44 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateBinaryStream(a: String, b: InputStream, c: Int): ResultSetIO[Unit] =
+  def updateBinaryStream(a: String, b: InputStream, c: Long): ResultSetIO[Unit] =
     F.liftF(UpdateBinaryStream3(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateBinaryStream(a: Int, b: InputStream, c: Int): ResultSetIO[Unit] =
-    F.liftF(UpdateBinaryStream4(a, b, c))
+  def updateBinaryStream(a: Int, b: InputStream): ResultSetIO[Unit] =
+    F.liftF(UpdateBinaryStream4(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateBinaryStream(a: String, b: InputStream, c: Long): ResultSetIO[Unit] =
+  def updateBinaryStream(a: Int, b: InputStream, c: Int): ResultSetIO[Unit] =
     F.liftF(UpdateBinaryStream5(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
+  def updateBlob(a: Int, b: Blob): ResultSetIO[Unit] =
+    F.liftF(UpdateBlob(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
   def updateBlob(a: Int, b: InputStream, c: Long): ResultSetIO[Unit] =
-    F.liftF(UpdateBlob(a, b, c))
+    F.liftF(UpdateBlob1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateBlob(a: Int, b: InputStream): ResultSetIO[Unit] =
-    F.liftF(UpdateBlob1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateBlob(a: Int, b: Blob): ResultSetIO[Unit] =
     F.liftF(UpdateBlob2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateBlob(a: String, b: Blob): ResultSetIO[Unit] =
-    F.liftF(UpdateBlob3(a, b))
+  def updateBlob(a: String, b: InputStream, c: Long): ResultSetIO[Unit] =
+    F.liftF(UpdateBlob3(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -1544,8 +1531,8 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateBlob(a: String, b: InputStream, c: Long): ResultSetIO[Unit] =
-    F.liftF(UpdateBlob5(a, b, c))
+  def updateBlob(a: String, b: Blob): ResultSetIO[Unit] =
+    F.liftF(UpdateBlob5(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1586,7 +1573,7 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateCharacterStream(a: Int, b: Reader, c: Long): ResultSetIO[Unit] =
+  def updateCharacterStream(a: String, b: Reader, c: Int): ResultSetIO[Unit] =
     F.liftF(UpdateCharacterStream(a, b, c))
 
   /** 
@@ -1598,13 +1585,13 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateCharacterStream(a: String, b: Reader, c: Long): ResultSetIO[Unit] =
+  def updateCharacterStream(a: Int, b: Reader, c: Long): ResultSetIO[Unit] =
     F.liftF(UpdateCharacterStream2(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateCharacterStream(a: String, b: Reader, c: Int): ResultSetIO[Unit] =
+  def updateCharacterStream(a: String, b: Reader, c: Long): ResultSetIO[Unit] =
     F.liftF(UpdateCharacterStream3(a, b, c))
 
   /** 
@@ -1622,31 +1609,31 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateClob(a: Int, b: Reader): ResultSetIO[Unit] =
-    F.liftF(UpdateClob(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def updateClob(a: Int, b: Reader, c: Long): ResultSetIO[Unit] =
-    F.liftF(UpdateClob1(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateClob(a: String, b: Reader): ResultSetIO[Unit] =
-    F.liftF(UpdateClob2(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateClob(a: String, b: Clob): ResultSetIO[Unit] =
-    F.liftF(UpdateClob3(a, b))
+    F.liftF(UpdateClob(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateClob(a: Int, b: Clob): ResultSetIO[Unit] =
+    F.liftF(UpdateClob1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateClob(a: String, b: Clob): ResultSetIO[Unit] =
+    F.liftF(UpdateClob2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateClob(a: Int, b: Reader): ResultSetIO[Unit] =
+    F.liftF(UpdateClob3(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateClob(a: String, b: Reader): ResultSetIO[Unit] =
     F.liftF(UpdateClob4(a, b))
 
   /** 
@@ -1706,13 +1693,13 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateLong(a: String, b: Long): ResultSetIO[Unit] =
+  def updateLong(a: Int, b: Long): ResultSetIO[Unit] =
     F.liftF(UpdateLong(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateLong(a: Int, b: Long): ResultSetIO[Unit] =
+  def updateLong(a: String, b: Long): ResultSetIO[Unit] =
     F.liftF(UpdateLong1(a, b))
 
   /** 
@@ -1724,26 +1711,26 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateNCharacterStream(a: String, b: Reader): ResultSetIO[Unit] =
-    F.liftF(UpdateNCharacterStream1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def updateNCharacterStream(a: String, b: Reader, c: Long): ResultSetIO[Unit] =
-    F.liftF(UpdateNCharacterStream2(a, b, c))
+    F.liftF(UpdateNCharacterStream1(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
   def updateNCharacterStream(a: Int, b: Reader): ResultSetIO[Unit] =
+    F.liftF(UpdateNCharacterStream2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def updateNCharacterStream(a: String, b: Reader): ResultSetIO[Unit] =
     F.liftF(UpdateNCharacterStream3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateNClob(a: Int, b: Reader): ResultSetIO[Unit] =
-    F.liftF(UpdateNClob(a, b))
+  def updateNClob(a: Int, b: Reader, c: Long): ResultSetIO[Unit] =
+    F.liftF(UpdateNClob(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
@@ -1754,26 +1741,26 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateNClob(a: Int, b: NClob): ResultSetIO[Unit] =
-    F.liftF(UpdateNClob2(a, b))
+  def updateNClob(a: String, b: Reader, c: Long): ResultSetIO[Unit] =
+    F.liftF(UpdateNClob2(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateNClob(a: String, b: NClob): ResultSetIO[Unit] =
+  def updateNClob(a: Int, b: Reader): ResultSetIO[Unit] =
     F.liftF(UpdateNClob3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateNClob(a: String, b: Reader, c: Long): ResultSetIO[Unit] =
-    F.liftF(UpdateNClob4(a, b, c))
+  def updateNClob(a: String, b: NClob): ResultSetIO[Unit] =
+    F.liftF(UpdateNClob4(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateNClob(a: Int, b: Reader, c: Long): ResultSetIO[Unit] =
-    F.liftF(UpdateNClob5(a, b, c))
+  def updateNClob(a: Int, b: NClob): ResultSetIO[Unit] =
+    F.liftF(UpdateNClob5(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1802,7 +1789,7 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateObject(a: Int, b: Object): ResultSetIO[Unit] =
+  def updateObject(a: String, b: Object): ResultSetIO[Unit] =
     F.liftF(UpdateObject(a, b))
 
   /** 
@@ -1814,38 +1801,14 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateObject(a: String, b: Object): ResultSetIO[Unit] =
-    F.liftF(UpdateObject2(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateObject(a: Int, b: Object, c: SQLType): ResultSetIO[Unit] =
-    F.liftF(UpdateObject3(a, b, c))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateObject(a: Int, b: Object, c: SQLType, d: Int): ResultSetIO[Unit] =
-    F.liftF(UpdateObject4(a, b, c, d))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def updateObject(a: String, b: Object, c: SQLType, d: Int): ResultSetIO[Unit] =
-    F.liftF(UpdateObject5(a, b, c, d))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def updateObject(a: Int, b: Object, c: Int): ResultSetIO[Unit] =
-    F.liftF(UpdateObject6(a, b, c))
+    F.liftF(UpdateObject2(a, b, c))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateObject(a: String, b: Object, c: SQLType): ResultSetIO[Unit] =
-    F.liftF(UpdateObject7(a, b, c))
+  def updateObject(a: Int, b: Object): ResultSetIO[Unit] =
+    F.liftF(UpdateObject3(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -1892,13 +1855,13 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateShort(a: Int, b: Short): ResultSetIO[Unit] =
+  def updateShort(a: String, b: Short): ResultSetIO[Unit] =
     F.liftF(UpdateShort(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateShort(a: String, b: Short): ResultSetIO[Unit] =
+  def updateShort(a: Int, b: Short): ResultSetIO[Unit] =
     F.liftF(UpdateShort1(a, b))
 
   /** 
@@ -1916,13 +1879,13 @@ object resultset {
   /** 
    * @group Constructors (Primitives)
    */
-  def updateTime(a: Int, b: Time): ResultSetIO[Unit] =
+  def updateTime(a: String, b: Time): ResultSetIO[Unit] =
     F.liftF(UpdateTime(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def updateTime(a: String, b: Time): ResultSetIO[Unit] =
+  def updateTime(a: Int, b: Time): ResultSetIO[Unit] =
     F.liftF(UpdateTime1(a, b))
 
   /** 

--- a/core/src/main/scala/doobie/free/sqldata.scala
+++ b/core/src/main/scala/doobie/free/sqldata.scala
@@ -45,7 +45,7 @@ import resultset.ResultSetIO
  *
  * `SQLDataIO` is a free monad that must be run via an interpreter, most commonly via
  * natural transformation of its underlying algebra `SQLDataOp` to another monad via
- * `Free.runFC`. 
+ * `Free#foldMap`.
  *
  * The library provides a natural transformation to `Kleisli[M, SQLData, A]` for any
  * exception-trapping (`Catchable`) and effect-capturing (`Capture`) monad `M`. Such evidence is 

--- a/core/src/main/scala/doobie/free/sqldata.scala
+++ b/core/src/main/scala/doobie/free/sqldata.scala
@@ -1,6 +1,6 @@
 package doobie.free
 
-import scalaz.{ Catchable, Coyoneda, Free => F, Kleisli, Monad, ~>, \/ }
+import scalaz.{ Catchable, Free => F, Kleisli, Monad, ~>, \/ }
 import scalaz.concurrent.Task
 
 import doobie.util.capture._
@@ -95,7 +95,7 @@ object sqldata {
       }
 
     // Lifting
-    case class Lift[Op[_], A, J](j: J, action: F.FreeC[Op, A], mod: KleisliTrans.Aux[Op, J]) extends SQLDataOp[A] {
+    case class Lift[Op[_], A, J](j: J, action: F[Op, A], mod: KleisliTrans.Aux[Op, J]) extends SQLDataOp[A] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => mod.transK[M].apply(action).run(j))
     }
 
@@ -131,14 +131,7 @@ object sqldata {
    * a `java.sql.SQLData` and produces a value of type `A`. 
    * @group Algebra 
    */
-  type SQLDataIO[A] = F.FreeC[SQLDataOp, A]
-
-  /**
-   * Monad instance for [[SQLDataIO]] (can't be inferred).
-   * @group Typeclass Instances 
-   */
-  implicit val MonadSQLDataIO: Monad[SQLDataIO] = 
-    F.freeMonad[({type λ[α] = Coyoneda[SQLDataOp, α]})#λ]
+  type SQLDataIO[A] = F[SQLDataOp, A]
 
   /**
    * Catchable instance for [[SQLDataIO]].
@@ -163,47 +156,47 @@ object sqldata {
    * Lift a different type of program that has a default Kleisli interpreter.
    * @group Constructors (Lifting)
    */
-  def lift[Op[_], A, J](j: J, action: F.FreeC[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): SQLDataIO[A] =
-    F.liftFC(Lift(j, action, mod))
+  def lift[Op[_], A, J](j: J, action: F[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): SQLDataIO[A] =
+    F.liftF(Lift(j, action, mod))
 
   /** 
    * Lift a SQLDataIO[A] into an exception-capturing SQLDataIO[Throwable \/ A].
    * @group Constructors (Lifting)
    */
   def attempt[A](a: SQLDataIO[A]): SQLDataIO[Throwable \/ A] =
-    F.liftFC[SQLDataOp, Throwable \/ A](Attempt(a))
+    F.liftF[SQLDataOp, Throwable \/ A](Attempt(a))
  
   /**
    * Non-strict unit for capturing effects.
    * @group Constructors (Lifting)
    */
   def delay[A](a: => A): SQLDataIO[A] =
-    F.liftFC(Pure(a _))
+    F.liftF(Pure(a _))
 
   /**
    * Backdoor for arbitrary computations on the underlying SQLData.
    * @group Constructors (Lifting)
    */
   def raw[A](f: SQLData => A): SQLDataIO[A] =
-    F.liftFC(Raw(f))
+    F.liftF(Raw(f))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getSQLTypeName: SQLDataIO[String] =
-    F.liftFC(GetSQLTypeName)
+    F.liftF(GetSQLTypeName)
 
   /** 
    * @group Constructors (Primitives)
    */
   def readSQL(a: SQLInput, b: String): SQLDataIO[Unit] =
-    F.liftFC(ReadSQL(a, b))
+    F.liftF(ReadSQL(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def writeSQL(a: SQLOutput): SQLDataIO[Unit] =
-    F.liftFC(WriteSQL(a))
+    F.liftF(WriteSQL(a))
 
  /** 
   * Natural transformation from `SQLDataOp` to `Kleisli` for the given `M`, consuming a `java.sql.SQLData`. 

--- a/core/src/main/scala/doobie/free/sqlinput.scala
+++ b/core/src/main/scala/doobie/free/sqlinput.scala
@@ -8,7 +8,6 @@ import doobie.free.kleislitrans._
 
 import java.io.InputStream
 import java.io.Reader
-import java.lang.Class
 import java.lang.Object
 import java.lang.String
 import java.math.BigDecimal
@@ -57,7 +56,7 @@ import resultset.ResultSetIO
  *
  * `SQLInputIO` is a free monad that must be run via an interpreter, most commonly via
  * natural transformation of its underlying algebra `SQLInputOp` to another monad via
- * `Free.runFC`. 
+ * `Free#foldMap`.
  *
  * The library provides a natural transformation to `Kleisli[M, SQLInput, A]` for any
  * exception-trapping (`Catchable`) and effect-capturing (`Capture`) monad `M`. Such evidence is 
@@ -176,10 +175,7 @@ object sqlinput {
     case object ReadNString extends SQLInputOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readNString())
     }
-    case class  ReadObject[T](a: Class[T]) extends SQLInputOp[T] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readObject(a))
-    }
-    case object ReadObject1 extends SQLInputOp[Object] {
+    case object ReadObject extends SQLInputOp[Object] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readObject())
     }
     case object ReadRef extends SQLInputOp[Ref] {
@@ -372,14 +368,8 @@ object sqlinput {
   /** 
    * @group Constructors (Primitives)
    */
-  def readObject[T](a: Class[T]): SQLInputIO[T] =
-    F.liftF(ReadObject(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   val readObject: SQLInputIO[Object] =
-    F.liftF(ReadObject1)
+    F.liftF(ReadObject)
 
   /** 
    * @group Constructors (Primitives)

--- a/core/src/main/scala/doobie/free/sqlinput.scala
+++ b/core/src/main/scala/doobie/free/sqlinput.scala
@@ -1,6 +1,6 @@
 package doobie.free
 
-import scalaz.{ Catchable, Coyoneda, Free => F, Kleisli, Monad, ~>, \/ }
+import scalaz.{ Catchable, Free => F, Kleisli, Monad, ~>, \/ }
 import scalaz.concurrent.Task
 
 import doobie.util.capture._
@@ -8,6 +8,7 @@ import doobie.free.kleislitrans._
 
 import java.io.InputStream
 import java.io.Reader
+import java.lang.Class
 import java.lang.Object
 import java.lang.String
 import java.math.BigDecimal
@@ -106,7 +107,7 @@ object sqlinput {
       }
 
     // Lifting
-    case class Lift[Op[_], A, J](j: J, action: F.FreeC[Op, A], mod: KleisliTrans.Aux[Op, J]) extends SQLInputOp[A] {
+    case class Lift[Op[_], A, J](j: J, action: F[Op, A], mod: KleisliTrans.Aux[Op, J]) extends SQLInputOp[A] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => mod.transK[M].apply(action).run(j))
     }
 
@@ -175,7 +176,10 @@ object sqlinput {
     case object ReadNString extends SQLInputOp[String] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readNString())
     }
-    case object ReadObject extends SQLInputOp[Object] {
+    case class  ReadObject[T](a: Class[T]) extends SQLInputOp[T] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readObject(a))
+    }
+    case object ReadObject1 extends SQLInputOp[Object] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.readObject())
     }
     case object ReadRef extends SQLInputOp[Ref] {
@@ -214,14 +218,7 @@ object sqlinput {
    * a `java.sql.SQLInput` and produces a value of type `A`. 
    * @group Algebra 
    */
-  type SQLInputIO[A] = F.FreeC[SQLInputOp, A]
-
-  /**
-   * Monad instance for [[SQLInputIO]] (can't be inferred).
-   * @group Typeclass Instances 
-   */
-  implicit val MonadSQLInputIO: Monad[SQLInputIO] = 
-    F.freeMonad[({type λ[α] = Coyoneda[SQLInputOp, α]})#λ]
+  type SQLInputIO[A] = F[SQLInputOp, A]
 
   /**
    * Catchable instance for [[SQLInputIO]].
@@ -246,191 +243,197 @@ object sqlinput {
    * Lift a different type of program that has a default Kleisli interpreter.
    * @group Constructors (Lifting)
    */
-  def lift[Op[_], A, J](j: J, action: F.FreeC[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): SQLInputIO[A] =
-    F.liftFC(Lift(j, action, mod))
+  def lift[Op[_], A, J](j: J, action: F[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): SQLInputIO[A] =
+    F.liftF(Lift(j, action, mod))
 
   /** 
    * Lift a SQLInputIO[A] into an exception-capturing SQLInputIO[Throwable \/ A].
    * @group Constructors (Lifting)
    */
   def attempt[A](a: SQLInputIO[A]): SQLInputIO[Throwable \/ A] =
-    F.liftFC[SQLInputOp, Throwable \/ A](Attempt(a))
+    F.liftF[SQLInputOp, Throwable \/ A](Attempt(a))
  
   /**
    * Non-strict unit for capturing effects.
    * @group Constructors (Lifting)
    */
   def delay[A](a: => A): SQLInputIO[A] =
-    F.liftFC(Pure(a _))
+    F.liftF(Pure(a _))
 
   /**
    * Backdoor for arbitrary computations on the underlying SQLInput.
    * @group Constructors (Lifting)
    */
   def raw[A](f: SQLInput => A): SQLInputIO[A] =
-    F.liftFC(Raw(f))
+    F.liftF(Raw(f))
 
   /** 
    * @group Constructors (Primitives)
    */
   val readArray: SQLInputIO[SqlArray] =
-    F.liftFC(ReadArray)
+    F.liftF(ReadArray)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readAsciiStream: SQLInputIO[InputStream] =
-    F.liftFC(ReadAsciiStream)
+    F.liftF(ReadAsciiStream)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readBigDecimal: SQLInputIO[BigDecimal] =
-    F.liftFC(ReadBigDecimal)
+    F.liftF(ReadBigDecimal)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readBinaryStream: SQLInputIO[InputStream] =
-    F.liftFC(ReadBinaryStream)
+    F.liftF(ReadBinaryStream)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readBlob: SQLInputIO[Blob] =
-    F.liftFC(ReadBlob)
+    F.liftF(ReadBlob)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readBoolean: SQLInputIO[Boolean] =
-    F.liftFC(ReadBoolean)
+    F.liftF(ReadBoolean)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readByte: SQLInputIO[Byte] =
-    F.liftFC(ReadByte)
+    F.liftF(ReadByte)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readBytes: SQLInputIO[Array[Byte]] =
-    F.liftFC(ReadBytes)
+    F.liftF(ReadBytes)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readCharacterStream: SQLInputIO[Reader] =
-    F.liftFC(ReadCharacterStream)
+    F.liftF(ReadCharacterStream)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readClob: SQLInputIO[Clob] =
-    F.liftFC(ReadClob)
+    F.liftF(ReadClob)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readDate: SQLInputIO[Date] =
-    F.liftFC(ReadDate)
+    F.liftF(ReadDate)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readDouble: SQLInputIO[Double] =
-    F.liftFC(ReadDouble)
+    F.liftF(ReadDouble)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readFloat: SQLInputIO[Float] =
-    F.liftFC(ReadFloat)
+    F.liftF(ReadFloat)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readInt: SQLInputIO[Int] =
-    F.liftFC(ReadInt)
+    F.liftF(ReadInt)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readLong: SQLInputIO[Long] =
-    F.liftFC(ReadLong)
+    F.liftF(ReadLong)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readNClob: SQLInputIO[NClob] =
-    F.liftFC(ReadNClob)
+    F.liftF(ReadNClob)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readNString: SQLInputIO[String] =
-    F.liftFC(ReadNString)
+    F.liftF(ReadNString)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def readObject[T](a: Class[T]): SQLInputIO[T] =
+    F.liftF(ReadObject(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val readObject: SQLInputIO[Object] =
-    F.liftFC(ReadObject)
+    F.liftF(ReadObject1)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readRef: SQLInputIO[Ref] =
-    F.liftFC(ReadRef)
+    F.liftF(ReadRef)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readRowId: SQLInputIO[RowId] =
-    F.liftFC(ReadRowId)
+    F.liftF(ReadRowId)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readSQLXML: SQLInputIO[SQLXML] =
-    F.liftFC(ReadSQLXML)
+    F.liftF(ReadSQLXML)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readShort: SQLInputIO[Short] =
-    F.liftFC(ReadShort)
+    F.liftF(ReadShort)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readString: SQLInputIO[String] =
-    F.liftFC(ReadString)
+    F.liftF(ReadString)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readTime: SQLInputIO[Time] =
-    F.liftFC(ReadTime)
+    F.liftF(ReadTime)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readTimestamp: SQLInputIO[Timestamp] =
-    F.liftFC(ReadTimestamp)
+    F.liftF(ReadTimestamp)
 
   /** 
    * @group Constructors (Primitives)
    */
   val readURL: SQLInputIO[URL] =
-    F.liftFC(ReadURL)
+    F.liftF(ReadURL)
 
   /** 
    * @group Constructors (Primitives)
    */
   val wasNull: SQLInputIO[Boolean] =
-    F.liftFC(WasNull)
+    F.liftF(WasNull)
 
  /** 
   * Natural transformation from `SQLInputOp` to `Kleisli` for the given `M`, consuming a `java.sql.SQLInput`. 

--- a/core/src/main/scala/doobie/free/sqloutput.scala
+++ b/core/src/main/scala/doobie/free/sqloutput.scala
@@ -8,7 +8,6 @@ import doobie.free.kleislitrans._
 
 import java.io.InputStream
 import java.io.Reader
-import java.lang.Object
 import java.lang.String
 import java.math.BigDecimal
 import java.net.URL
@@ -27,7 +26,6 @@ import java.sql.RowId
 import java.sql.SQLData
 import java.sql.SQLInput
 import java.sql.SQLOutput
-import java.sql.SQLType
 import java.sql.SQLXML
 import java.sql.Statement
 import java.sql.Struct
@@ -58,7 +56,7 @@ import resultset.ResultSetIO
  *
  * `SQLOutputIO` is a free monad that must be run via an interpreter, most commonly via
  * natural transformation of its underlying algebra `SQLOutputOp` to another monad via
- * `Free.runFC`. 
+ * `Free#foldMap`.
  *
  * The library provides a natural transformation to `Kleisli[M, SQLOutput, A]` for any
  * exception-trapping (`Catchable`) and effect-capturing (`Capture`) monad `M`. Such evidence is 
@@ -179,9 +177,6 @@ object sqloutput {
     }
     case class  WriteObject(a: SQLData) extends SQLOutputOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeObject(a))
-    }
-    case class  WriteObject1(a: Object, b: SQLType) extends SQLOutputOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeObject(a, b))
     }
     case class  WriteRef(a: Ref) extends SQLOutputOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.writeRef(a))
@@ -375,12 +370,6 @@ object sqloutput {
    */
   def writeObject(a: SQLData): SQLOutputIO[Unit] =
     F.liftF(WriteObject(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def writeObject(a: Object, b: SQLType): SQLOutputIO[Unit] =
-    F.liftF(WriteObject1(a, b))
 
   /** 
    * @group Constructors (Primitives)

--- a/core/src/main/scala/doobie/free/statement.scala
+++ b/core/src/main/scala/doobie/free/statement.scala
@@ -1,6 +1,6 @@
 package doobie.free
 
-import scalaz.{ Catchable, Coyoneda, Free => F, Kleisli, Monad, ~>, \/ }
+import scalaz.{ Catchable, Free => F, Kleisli, Monad, ~>, \/ }
 import scalaz.concurrent.Task
 
 import doobie.util.capture._
@@ -98,7 +98,7 @@ object statement {
       }
 
     // Lifting
-    case class Lift[Op[_], A, J](j: J, action: F.FreeC[Op, A], mod: KleisliTrans.Aux[Op, J]) extends StatementOp[A] {
+    case class Lift[Op[_], A, J](j: J, action: F[Op, A], mod: KleisliTrans.Aux[Op, J]) extends StatementOp[A] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = Kleisli(_ => mod.transK[M].apply(action).run(j))
     }
 
@@ -134,28 +134,43 @@ object statement {
     case object CloseOnCompletion extends StatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.closeOnCompletion())
     }
-    case class  Execute(a: String, b: Array[Int]) extends StatementOp[Boolean] {
+    case class  Execute(a: String, b: Array[String]) extends StatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
     }
-    case class  Execute1(a: String, b: Int) extends StatementOp[Boolean] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
-    }
-    case class  Execute2(a: String) extends StatementOp[Boolean] {
+    case class  Execute1(a: String) extends StatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a))
     }
-    case class  Execute3(a: String, b: Array[String]) extends StatementOp[Boolean] {
+    case class  Execute2(a: String, b: Array[Int]) extends StatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
+    }
+    case class  Execute3(a: String, b: Int) extends StatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
     }
     case object ExecuteBatch extends StatementOp[Array[Int]] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeBatch())
     }
+    case object ExecuteLargeBatch extends StatementOp[Array[Long]] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeBatch())
+    }
+    case class  ExecuteLargeUpdate(a: String, b: Int) extends StatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
+    }
+    case class  ExecuteLargeUpdate1(a: String, b: Array[Int]) extends StatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
+    }
+    case class  ExecuteLargeUpdate2(a: String) extends StatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a))
+    }
+    case class  ExecuteLargeUpdate3(a: String, b: Array[String]) extends StatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
+    }
     case class  ExecuteQuery(a: String) extends StatementOp[ResultSet] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeQuery(a))
     }
-    case class  ExecuteUpdate(a: String, b: Array[String]) extends StatementOp[Int] {
+    case class  ExecuteUpdate(a: String, b: Int) extends StatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
     }
-    case class  ExecuteUpdate1(a: String, b: Int) extends StatementOp[Int] {
+    case class  ExecuteUpdate1(a: String, b: Array[String]) extends StatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
     }
     case class  ExecuteUpdate2(a: String, b: Array[Int]) extends StatementOp[Int] {
@@ -175,6 +190,12 @@ object statement {
     }
     case object GetGeneratedKeys extends StatementOp[ResultSet] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getGeneratedKeys())
+    }
+    case object GetLargeMaxRows extends StatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeMaxRows())
+    }
+    case object GetLargeUpdateCount extends StatementOp[Long] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeUpdateCount())
     }
     case object GetMaxFieldSize extends StatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMaxFieldSize())
@@ -233,6 +254,9 @@ object statement {
     case class  SetFetchSize(a: Int) extends StatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setFetchSize(a))
     }
+    case class  SetLargeMaxRows(a: Long) extends StatementOp[Unit] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setLargeMaxRows(a))
+    }
     case class  SetMaxFieldSize(a: Int) extends StatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setMaxFieldSize(a))
     }
@@ -257,14 +281,7 @@ object statement {
    * a `java.sql.Statement` and produces a value of type `A`. 
    * @group Algebra 
    */
-  type StatementIO[A] = F.FreeC[StatementOp, A]
-
-  /**
-   * Monad instance for [[StatementIO]] (can't be inferred).
-   * @group Typeclass Instances 
-   */
-  implicit val MonadStatementIO: Monad[StatementIO] = 
-    F.freeMonad[({type λ[α] = Coyoneda[StatementOp, α]})#λ]
+  type StatementIO[A] = F[StatementOp, A]
 
   /**
    * Catchable instance for [[StatementIO]].
@@ -289,293 +306,341 @@ object statement {
    * Lift a different type of program that has a default Kleisli interpreter.
    * @group Constructors (Lifting)
    */
-  def lift[Op[_], A, J](j: J, action: F.FreeC[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): StatementIO[A] =
-    F.liftFC(Lift(j, action, mod))
+  def lift[Op[_], A, J](j: J, action: F[Op, A])(implicit mod: KleisliTrans.Aux[Op, J]): StatementIO[A] =
+    F.liftF(Lift(j, action, mod))
 
   /** 
    * Lift a StatementIO[A] into an exception-capturing StatementIO[Throwable \/ A].
    * @group Constructors (Lifting)
    */
   def attempt[A](a: StatementIO[A]): StatementIO[Throwable \/ A] =
-    F.liftFC[StatementOp, Throwable \/ A](Attempt(a))
+    F.liftF[StatementOp, Throwable \/ A](Attempt(a))
  
   /**
    * Non-strict unit for capturing effects.
    * @group Constructors (Lifting)
    */
   def delay[A](a: => A): StatementIO[A] =
-    F.liftFC(Pure(a _))
+    F.liftF(Pure(a _))
 
   /**
    * Backdoor for arbitrary computations on the underlying Statement.
    * @group Constructors (Lifting)
    */
   def raw[A](f: Statement => A): StatementIO[A] =
-    F.liftFC(Raw(f))
+    F.liftF(Raw(f))
 
   /** 
    * @group Constructors (Primitives)
    */
   def addBatch(a: String): StatementIO[Unit] =
-    F.liftFC(AddBatch(a))
+    F.liftF(AddBatch(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val cancel: StatementIO[Unit] =
-    F.liftFC(Cancel)
+    F.liftF(Cancel)
 
   /** 
    * @group Constructors (Primitives)
    */
   val clearBatch: StatementIO[Unit] =
-    F.liftFC(ClearBatch)
+    F.liftF(ClearBatch)
 
   /** 
    * @group Constructors (Primitives)
    */
   val clearWarnings: StatementIO[Unit] =
-    F.liftFC(ClearWarnings)
+    F.liftF(ClearWarnings)
 
   /** 
    * @group Constructors (Primitives)
    */
   val close: StatementIO[Unit] =
-    F.liftFC(Close)
+    F.liftF(Close)
 
   /** 
    * @group Constructors (Primitives)
    */
   val closeOnCompletion: StatementIO[Unit] =
-    F.liftFC(CloseOnCompletion)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def execute(a: String, b: Array[Int]): StatementIO[Boolean] =
-    F.liftFC(Execute(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def execute(a: String, b: Int): StatementIO[Boolean] =
-    F.liftFC(Execute1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def execute(a: String): StatementIO[Boolean] =
-    F.liftFC(Execute2(a))
+    F.liftF(CloseOnCompletion)
 
   /** 
    * @group Constructors (Primitives)
    */
   def execute(a: String, b: Array[String]): StatementIO[Boolean] =
-    F.liftFC(Execute3(a, b))
+    F.liftF(Execute(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def execute(a: String): StatementIO[Boolean] =
+    F.liftF(Execute1(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def execute(a: String, b: Array[Int]): StatementIO[Boolean] =
+    F.liftF(Execute2(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def execute(a: String, b: Int): StatementIO[Boolean] =
+    F.liftF(Execute3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   val executeBatch: StatementIO[Array[Int]] =
-    F.liftFC(ExecuteBatch)
+    F.liftF(ExecuteBatch)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val executeLargeBatch: StatementIO[Array[Long]] =
+    F.liftF(ExecuteLargeBatch)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String, b: Int): StatementIO[Long] =
+    F.liftF(ExecuteLargeUpdate(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String, b: Array[Int]): StatementIO[Long] =
+    F.liftF(ExecuteLargeUpdate1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String): StatementIO[Long] =
+    F.liftF(ExecuteLargeUpdate2(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeLargeUpdate(a: String, b: Array[String]): StatementIO[Long] =
+    F.liftF(ExecuteLargeUpdate3(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def executeQuery(a: String): StatementIO[ResultSet] =
-    F.liftFC(ExecuteQuery(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeUpdate(a: String, b: Array[String]): StatementIO[Int] =
-    F.liftFC(ExecuteUpdate(a, b))
+    F.liftF(ExecuteQuery(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def executeUpdate(a: String, b: Int): StatementIO[Int] =
-    F.liftFC(ExecuteUpdate1(a, b))
+    F.liftF(ExecuteUpdate(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def executeUpdate(a: String, b: Array[String]): StatementIO[Int] =
+    F.liftF(ExecuteUpdate1(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def executeUpdate(a: String, b: Array[Int]): StatementIO[Int] =
-    F.liftFC(ExecuteUpdate2(a, b))
+    F.liftF(ExecuteUpdate2(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
   def executeUpdate(a: String): StatementIO[Int] =
-    F.liftFC(ExecuteUpdate3(a))
+    F.liftF(ExecuteUpdate3(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getConnection: StatementIO[Connection] =
-    F.liftFC(GetConnection)
+    F.liftF(GetConnection)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getFetchDirection: StatementIO[Int] =
-    F.liftFC(GetFetchDirection)
+    F.liftF(GetFetchDirection)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getFetchSize: StatementIO[Int] =
-    F.liftFC(GetFetchSize)
+    F.liftF(GetFetchSize)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getGeneratedKeys: StatementIO[ResultSet] =
-    F.liftFC(GetGeneratedKeys)
+    F.liftF(GetGeneratedKeys)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val getLargeMaxRows: StatementIO[Long] =
+    F.liftF(GetLargeMaxRows)
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  val getLargeUpdateCount: StatementIO[Long] =
+    F.liftF(GetLargeUpdateCount)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxFieldSize: StatementIO[Int] =
-    F.liftFC(GetMaxFieldSize)
+    F.liftF(GetMaxFieldSize)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMaxRows: StatementIO[Int] =
-    F.liftFC(GetMaxRows)
+    F.liftF(GetMaxRows)
 
   /** 
    * @group Constructors (Primitives)
    */
   def getMoreResults(a: Int): StatementIO[Boolean] =
-    F.liftFC(GetMoreResults(a))
+    F.liftF(GetMoreResults(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   val getMoreResults: StatementIO[Boolean] =
-    F.liftFC(GetMoreResults1)
+    F.liftF(GetMoreResults1)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getQueryTimeout: StatementIO[Int] =
-    F.liftFC(GetQueryTimeout)
+    F.liftF(GetQueryTimeout)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getResultSet: StatementIO[ResultSet] =
-    F.liftFC(GetResultSet)
+    F.liftF(GetResultSet)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getResultSetConcurrency: StatementIO[Int] =
-    F.liftFC(GetResultSetConcurrency)
+    F.liftF(GetResultSetConcurrency)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getResultSetHoldability: StatementIO[Int] =
-    F.liftFC(GetResultSetHoldability)
+    F.liftF(GetResultSetHoldability)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getResultSetType: StatementIO[Int] =
-    F.liftFC(GetResultSetType)
+    F.liftF(GetResultSetType)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getUpdateCount: StatementIO[Int] =
-    F.liftFC(GetUpdateCount)
+    F.liftF(GetUpdateCount)
 
   /** 
    * @group Constructors (Primitives)
    */
   val getWarnings: StatementIO[SQLWarning] =
-    F.liftFC(GetWarnings)
+    F.liftF(GetWarnings)
 
   /** 
    * @group Constructors (Primitives)
    */
   val isCloseOnCompletion: StatementIO[Boolean] =
-    F.liftFC(IsCloseOnCompletion)
+    F.liftF(IsCloseOnCompletion)
 
   /** 
    * @group Constructors (Primitives)
    */
   val isClosed: StatementIO[Boolean] =
-    F.liftFC(IsClosed)
+    F.liftF(IsClosed)
 
   /** 
    * @group Constructors (Primitives)
    */
   val isPoolable: StatementIO[Boolean] =
-    F.liftFC(IsPoolable)
+    F.liftF(IsPoolable)
 
   /** 
    * @group Constructors (Primitives)
    */
   def isWrapperFor(a: Class[_]): StatementIO[Boolean] =
-    F.liftFC(IsWrapperFor(a))
+    F.liftF(IsWrapperFor(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setCursorName(a: String): StatementIO[Unit] =
-    F.liftFC(SetCursorName(a))
+    F.liftF(SetCursorName(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setEscapeProcessing(a: Boolean): StatementIO[Unit] =
-    F.liftFC(SetEscapeProcessing(a))
+    F.liftF(SetEscapeProcessing(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setFetchDirection(a: Int): StatementIO[Unit] =
-    F.liftFC(SetFetchDirection(a))
+    F.liftF(SetFetchDirection(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setFetchSize(a: Int): StatementIO[Unit] =
-    F.liftFC(SetFetchSize(a))
+    F.liftF(SetFetchSize(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def setLargeMaxRows(a: Long): StatementIO[Unit] =
+    F.liftF(SetLargeMaxRows(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setMaxFieldSize(a: Int): StatementIO[Unit] =
-    F.liftFC(SetMaxFieldSize(a))
+    F.liftF(SetMaxFieldSize(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setMaxRows(a: Int): StatementIO[Unit] =
-    F.liftFC(SetMaxRows(a))
+    F.liftF(SetMaxRows(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setPoolable(a: Boolean): StatementIO[Unit] =
-    F.liftFC(SetPoolable(a))
+    F.liftF(SetPoolable(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def setQueryTimeout(a: Int): StatementIO[Unit] =
-    F.liftFC(SetQueryTimeout(a))
+    F.liftF(SetQueryTimeout(a))
 
   /** 
    * @group Constructors (Primitives)
    */
   def unwrap[T](a: Class[T]): StatementIO[T] =
-    F.liftFC(Unwrap(a))
+    F.liftF(Unwrap(a))
 
  /** 
   * Natural transformation from `StatementOp` to `Kleisli` for the given `M`, consuming a `java.sql.Statement`. 

--- a/core/src/main/scala/doobie/free/statement.scala
+++ b/core/src/main/scala/doobie/free/statement.scala
@@ -48,7 +48,7 @@ import resultset.ResultSetIO
  *
  * `StatementIO` is a free monad that must be run via an interpreter, most commonly via
  * natural transformation of its underlying algebra `StatementOp` to another monad via
- * `Free.runFC`. 
+ * `Free#foldMap`.
  *
  * The library provides a natural transformation to `Kleisli[M, Statement, A]` for any
  * exception-trapping (`Catchable`) and effect-capturing (`Capture`) monad `M`. Such evidence is 
@@ -134,41 +134,26 @@ object statement {
     case object CloseOnCompletion extends StatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.closeOnCompletion())
     }
-    case class  Execute(a: String, b: Array[String]) extends StatementOp[Boolean] {
+    case class  Execute(a: String, b: Array[Int]) extends StatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
     }
-    case class  Execute1(a: String) extends StatementOp[Boolean] {
+    case class  Execute1(a: String, b: Int) extends StatementOp[Boolean] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
+    }
+    case class  Execute2(a: String) extends StatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a))
     }
-    case class  Execute2(a: String, b: Array[Int]) extends StatementOp[Boolean] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
-    }
-    case class  Execute3(a: String, b: Int) extends StatementOp[Boolean] {
+    case class  Execute3(a: String, b: Array[String]) extends StatementOp[Boolean] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.execute(a, b))
     }
     case object ExecuteBatch extends StatementOp[Array[Int]] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeBatch())
     }
-    case object ExecuteLargeBatch extends StatementOp[Array[Long]] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeBatch())
-    }
-    case class  ExecuteLargeUpdate(a: String, b: Int) extends StatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
-    }
-    case class  ExecuteLargeUpdate1(a: String, b: Array[Int]) extends StatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
-    }
-    case class  ExecuteLargeUpdate2(a: String) extends StatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a))
-    }
-    case class  ExecuteLargeUpdate3(a: String, b: Array[String]) extends StatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeLargeUpdate(a, b))
-    }
     case class  ExecuteQuery(a: String) extends StatementOp[ResultSet] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeQuery(a))
     }
-    case class  ExecuteUpdate(a: String, b: Int) extends StatementOp[Int] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
+    case class  ExecuteUpdate(a: String) extends StatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a))
     }
     case class  ExecuteUpdate1(a: String, b: Array[String]) extends StatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
@@ -176,8 +161,8 @@ object statement {
     case class  ExecuteUpdate2(a: String, b: Array[Int]) extends StatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
     }
-    case class  ExecuteUpdate3(a: String) extends StatementOp[Int] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a))
+    case class  ExecuteUpdate3(a: String, b: Int) extends StatementOp[Int] {
+      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.executeUpdate(a, b))
     }
     case object GetConnection extends StatementOp[Connection] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getConnection())
@@ -190,12 +175,6 @@ object statement {
     }
     case object GetGeneratedKeys extends StatementOp[ResultSet] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getGeneratedKeys())
-    }
-    case object GetLargeMaxRows extends StatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeMaxRows())
-    }
-    case object GetLargeUpdateCount extends StatementOp[Long] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getLargeUpdateCount())
     }
     case object GetMaxFieldSize extends StatementOp[Int] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.getMaxFieldSize())
@@ -253,9 +232,6 @@ object statement {
     }
     case class  SetFetchSize(a: Int) extends StatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setFetchSize(a))
-    }
-    case class  SetLargeMaxRows(a: Long) extends StatementOp[Unit] {
-      def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setLargeMaxRows(a))
     }
     case class  SetMaxFieldSize(a: Int) extends StatementOp[Unit] {
       def defaultTransK[M[_]: Monad: Catchable: Capture] = primitive(_.setMaxFieldSize(a))
@@ -369,25 +345,25 @@ object statement {
   /** 
    * @group Constructors (Primitives)
    */
-  def execute(a: String, b: Array[String]): StatementIO[Boolean] =
+  def execute(a: String, b: Array[Int]): StatementIO[Boolean] =
     F.liftF(Execute(a, b))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def execute(a: String): StatementIO[Boolean] =
-    F.liftF(Execute1(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def execute(a: String, b: Array[Int]): StatementIO[Boolean] =
-    F.liftF(Execute2(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def execute(a: String, b: Int): StatementIO[Boolean] =
+    F.liftF(Execute1(a, b))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def execute(a: String): StatementIO[Boolean] =
+    F.liftF(Execute2(a))
+
+  /** 
+   * @group Constructors (Primitives)
+   */
+  def execute(a: String, b: Array[String]): StatementIO[Boolean] =
     F.liftF(Execute3(a, b))
 
   /** 
@@ -399,44 +375,14 @@ object statement {
   /** 
    * @group Constructors (Primitives)
    */
-  val executeLargeBatch: StatementIO[Array[Long]] =
-    F.liftF(ExecuteLargeBatch)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String, b: Int): StatementIO[Long] =
-    F.liftF(ExecuteLargeUpdate(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String, b: Array[Int]): StatementIO[Long] =
-    F.liftF(ExecuteLargeUpdate1(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String): StatementIO[Long] =
-    F.liftF(ExecuteLargeUpdate2(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def executeLargeUpdate(a: String, b: Array[String]): StatementIO[Long] =
-    F.liftF(ExecuteLargeUpdate3(a, b))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
   def executeQuery(a: String): StatementIO[ResultSet] =
     F.liftF(ExecuteQuery(a))
 
   /** 
    * @group Constructors (Primitives)
    */
-  def executeUpdate(a: String, b: Int): StatementIO[Int] =
-    F.liftF(ExecuteUpdate(a, b))
+  def executeUpdate(a: String): StatementIO[Int] =
+    F.liftF(ExecuteUpdate(a))
 
   /** 
    * @group Constructors (Primitives)
@@ -453,8 +399,8 @@ object statement {
   /** 
    * @group Constructors (Primitives)
    */
-  def executeUpdate(a: String): StatementIO[Int] =
-    F.liftF(ExecuteUpdate3(a))
+  def executeUpdate(a: String, b: Int): StatementIO[Int] =
+    F.liftF(ExecuteUpdate3(a, b))
 
   /** 
    * @group Constructors (Primitives)
@@ -479,18 +425,6 @@ object statement {
    */
   val getGeneratedKeys: StatementIO[ResultSet] =
     F.liftF(GetGeneratedKeys)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val getLargeMaxRows: StatementIO[Long] =
-    F.liftF(GetLargeMaxRows)
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  val getLargeUpdateCount: StatementIO[Long] =
-    F.liftF(GetLargeUpdateCount)
 
   /** 
    * @group Constructors (Primitives)
@@ -605,12 +539,6 @@ object statement {
    */
   def setFetchSize(a: Int): StatementIO[Unit] =
     F.liftF(SetFetchSize(a))
-
-  /** 
-   * @group Constructors (Primitives)
-   */
-  def setLargeMaxRows(a: Long): StatementIO[Unit] =
-    F.liftF(SetLargeMaxRows(a))
 
   /** 
    * @group Constructors (Primitives)

--- a/core/src/main/scala/doobie/hi/connection.scala
+++ b/core/src/main/scala/doobie/hi/connection.scala
@@ -42,9 +42,6 @@ import scalaz.syntax.monad._
 object connection {
 
   /** @group Typeclass Instances */
-  implicit val MonadConnectionIO = C.MonadConnectionIO
-
-  /** @group Typeclass Instances */
   implicit val CatchableConnectionIO = C.CatchableConnectionIO
 
   /** @group Lifting */

--- a/core/src/main/scala/doobie/hi/drivermanager.scala
+++ b/core/src/main/scala/doobie/hi/drivermanager.scala
@@ -25,9 +25,6 @@ import scalaz.std.list._
 object drivermanager {
 
   /** @group Typeclass Instances */
-  implicit val MonadDriverManagerIO = DM.MonadDriverManagerIO
-
-  /** @group Typeclass Instances */
   implicit val CatchableDriverManagerIO = DM.CatchableDriverManagerIO
 
   /** @group Lifting */

--- a/core/src/main/scala/doobie/hi/preparedstatement.scala
+++ b/core/src/main/scala/doobie/hi/preparedstatement.scala
@@ -52,9 +52,6 @@ import scalaz.\&/
 object preparedstatement {
 
   /** @group Typeclass Instances */
-  implicit val MonadPreparedStatementIO = PS.MonadPreparedStatementIO
-
-  /** @group Typeclass Instances */
   implicit val CatchablePreparedStatementIO = PS.CatchablePreparedStatementIO
 
   /** @group Execution */

--- a/core/src/main/scala/doobie/hi/preparedstatement.scala
+++ b/core/src/main/scala/doobie/hi/preparedstatement.scala
@@ -69,7 +69,12 @@ object preparedstatement {
 
   /** @group Batching */
   val executeBatch: PreparedStatementIO[List[Int]] =
-    PS.executeBatch.map(_.toList)
+    PS.executeBatch.map(arr =>
+      // `Predef.intArrayOps` is not implicit as of Scala 2.12.0-M3
+      // https://github.com/scala/scala/blob/v2.12.0-M3/src/library/scala/Predef.scala#L336
+      // TODO replace with `_.toList` after it gets back
+      intArrayOps(arr).toList
+    )
 
   /** @group Batching */
   val addBatch: PreparedStatementIO[Unit] =

--- a/core/src/main/scala/doobie/hi/resultset.scala
+++ b/core/src/main/scala/doobie/hi/resultset.scala
@@ -37,9 +37,6 @@ import scalaz.stream.Process
 object resultset {
 
   /** @group Typeclass Instances */
-  implicit val MonadResultSetIO = RS.MonadResultSetIO
-
-  /** @group Typeclass Instances */
   implicit val CatchableResultSetIO = RS.CatchableResultSetIO
 
   /**

--- a/core/src/main/scala/doobie/hi/resultset.scala
+++ b/core/src/main/scala/doobie/hi/resultset.scala
@@ -208,7 +208,7 @@ object resultset {
     * @group Results
     */
   def nel[A: Composite]: ResultSetIO[NonEmptyList[A]] =
-    (getNext[A] |@| list) {
+    (getNext[A] |@| ilist) {
       case (Some(a), as) => NonEmptyList.nel(a, as)
       case (None, _)     => throw UnexpectedEnd
     }

--- a/core/src/main/scala/doobie/hi/statement.scala
+++ b/core/src/main/scala/doobie/hi/statement.scala
@@ -34,9 +34,6 @@ import scalaz.syntax.id._
 object statement {
 
   /** @group Typeclass Instances */
-  implicit val MonadStatementIO = S.MonadStatementIO
-
-  /** @group Typeclass Instances */
   implicit val CatchableStatementIO = S.CatchableStatementIO
 
   /** @group Batching */

--- a/core/src/main/scala/doobie/hi/statement.scala
+++ b/core/src/main/scala/doobie/hi/statement.scala
@@ -46,7 +46,12 @@ object statement {
 
   /** @group Execution */
   val executeBatch: StatementIO[List[Int]] =
-    S.executeBatch.map(_.toList)
+    S.executeBatch.map(arr =>
+      // `Predef.intArrayOps` is not implicit as of Scala 2.12.0-M3
+      // https://github.com/scala/scala/blob/v2.12.0-M3/src/library/scala/Predef.scala#L336
+      // TODO replace with `_.toList` after it gets back
+      intArrayOps(arr).toList
+    )
 
   /** @group Execution */
   def executeQuery[A](sql: String)(k: ResultSetIO[A]): StatementIO[A] =

--- a/core/src/main/scala/doobie/util/analysis.scala
+++ b/core/src/main/scala/doobie/util/analysis.scala
@@ -85,7 +85,7 @@ object analysis {
               |coercible to ${typeName(jdk, n)} according to the JDBC specification or any defined
               |mapping. 
               |Fix this by changing the schema type to 
-              |${jdk.jdbcSource.list.map(_.toString.toUpperCase).mkString(" or ") }; or the
+              |${jdk.jdbcSource.list.map(_.toString.toUpperCase).toList.mkString(" or ") }; or the
               |Scala type to an appropriate ${if (schema.jdbcType == Array) "array" else "object"} 
               |type.
               |""".stripMargin.lines.mkString(" ")
@@ -94,7 +94,7 @@ object analysis {
               |coercible to ${typeName(jdk, n)} according to the JDBC specification or any defined
               |mapping. 
               |Fix this by changing the schema type to 
-              |${jdk.jdbcSource.list.map(_.toString.toUpperCase).mkString(" or ") }, or the
+              |${jdk.jdbcSource.list.map(_.toString.toUpperCase).toList.mkString(" or ") }, or the
               |Scala type to ${ss.mkString(" or ")}.
               |""".stripMargin.lines.mkString(" ")
       }
@@ -107,7 +107,7 @@ object analysis {
           |coercible to ${typeName(jdk, n)}
           |according to the JDBC specification but is not a recommended target type. Fix this by 
           |changing the schema type to 
-          |${jdk.jdbcSource.list.map(_.toString.toUpperCase).mkString(" or ") }; or the
+          |${jdk.jdbcSource.list.map(_.toString.toUpperCase).toList.mkString(" or ") }; or the
           |Scala type to ${Meta.readersOf(schema.jdbcType, schema.vendorTypeName).toList.map(typeName(_, n)).mkString(" or ")}.
           |""".stripMargin.lines.mkString(" ")
   }
@@ -139,7 +139,7 @@ object analysis {
 
     def columnTypeErrors: List[ColumnTypeError] =
       columnAlignment.zipWithIndex.collect {
-        case (Both((j, n1), p), n) if !(j.jdbcSource.list ++ j.fold(_.jdbcSourceSecondary, _ => Nil)).element(p.jdbcType) =>
+        case (Both((j, n1), p), n) if !(j.jdbcSource.list.toList ++ j.fold(_.jdbcSourceSecondary.toList, _ => Nil)).element(p.jdbcType) =>
           ColumnTypeError(n + 1, j, n1, p)
         case (Both((j, n1), p), n) if (p.jdbcType === JavaObject || p.jdbcType == Other) && !j.fold(_ => None, a => Some(a.schemaTypes.head)).element(p.vendorTypeName) =>
           ColumnTypeError(n + 1, j, n1, p)
@@ -147,7 +147,7 @@ object analysis {
 
     def columnTypeWarnings: List[ColumnTypeWarning] =
       columnAlignment.zipWithIndex.collect {
-        case (Both((j, n1), p), n) if j.fold(_.jdbcSourceSecondary, _ => Nil).element(p.jdbcType) =>
+        case (Both((j, n1), p), n) if j.fold(_.jdbcSourceSecondary.toList, _ => Nil).element(p.jdbcType) =>
           ColumnTypeWarning(n + 1, j, n1, p)
       }
 

--- a/core/src/test/scala/doobie/util/catchable.scala
+++ b/core/src/test/scala/doobie/util/catchable.scala
@@ -13,19 +13,19 @@ object catchablespec extends Specification {
     "do nothing on success" in {
       Task.delay(3).attemptSome {
         case _ => 4
-      }.run must_== \/-(3)
+      }.unsafePerformSync must_== \/-(3)
     }
 
     "catch matching throwables" in {
       Task.delay(throw new IllegalArgumentException).attemptSome {
         case ie: IllegalArgumentException => 42
-      }.run must_== -\/(42)
+      }.unsafePerformSync must_== -\/(42)
     }
 
     "ignore non-matching throwables" in {      
       Task.delay(throw new IllegalArgumentException).attemptSome {
         case ise: IllegalStateException => 42
-      }.run must throwA[IllegalArgumentException]
+      }.unsafePerformSync must throwA[IllegalArgumentException]
     }
 
   }
@@ -33,11 +33,11 @@ object catchablespec extends Specification {
   "except" should {
 
     "do nothing on success" in {
-      Task.delay(3).except(t => Task.delay(4)).run must_== 3
+      Task.delay(3).except(t => Task.delay(4)).unsafePerformSync must_== 3
     }
 
     "catch all exceptions" in {
-      Task.delay[Int](Predef.???).except(t => Task.delay(4)).run must_== 4
+      Task.delay[Int](Predef.???).except(t => Task.delay(4)).unsafePerformSync must_== 4
     }
 
   }
@@ -47,19 +47,19 @@ object catchablespec extends Specification {
     "do nothing on success" in {
       Task.delay(3).exceptSome {
         case _ => Task.delay(4)
-      }.run must_== 3
+      }.unsafePerformSync must_== 3
     }
 
     "catch matching throwables" in {
       Task.delay[Int](throw new IllegalArgumentException).exceptSome {
         case ie: IllegalArgumentException => Task.delay(42)
-      }.run must_== 42
+      }.unsafePerformSync must_== 42
     }
 
     "ignore non-matching throwables" in {      
       Task.delay[Int](throw new IllegalArgumentException).exceptSome {
         case ise: IllegalStateException => Task.delay(42)
-      }.run must throwA[IllegalArgumentException]
+      }.unsafePerformSync must throwA[IllegalArgumentException]
     }
 
   }
@@ -68,14 +68,14 @@ object catchablespec extends Specification {
 
     "do nothing on success" in {
       var a = 1
-      Task.delay(42).onException(Task.delay(a += 1)).run 
+      Task.delay(42).onException(Task.delay(a += 1)).unsafePerformSync
       a must_== 1
     }
 
     "perform its effect on exception" in {
       var a = 1
       try {
-        Task.delay[Int](Predef.???).onException(Task.delay(a += 1)).run 
+        Task.delay[Int](Predef.???).onException(Task.delay(a += 1)).unsafePerformSync
         false
       } catch {
         case _: Throwable => a == 2
@@ -88,14 +88,14 @@ object catchablespec extends Specification {
 
     "perform its effect on success" in {
       var a = 1
-      Task.delay(42).ensuring(Task.delay(a += 1)).run 
+      Task.delay(42).ensuring(Task.delay(a += 1)).unsafePerformSync
       a must_== 2
     }
 
     "perform its effect on exception" in {
       var a = 1
       try {
-        Task.delay[Int](Predef.???).ensuring(Task.delay(a += 1)).run 
+        Task.delay[Int](Predef.???).ensuring(Task.delay(a += 1)).unsafePerformSync
         false
       } catch {
         case _: Throwable => a == 2

--- a/core/src/test/scala/doobie/util/catchsql.scala
+++ b/core/src/test/scala/doobie/util/catchsql.scala
@@ -15,17 +15,17 @@ object catchsqlpec extends Specification {
   "attemptSql" should {
 
     "do nothing on success" in {
-      Task.delay(3).attemptSql.run must_== \/-(3)
+      Task.delay(3).attemptSql.unsafePerformSync must_== \/-(3)
     }
 
     "catch SQLException" in {
       val e = new SQLException
-      Task.delay(throw e).attemptSql.run must_== -\/(e)
+      Task.delay(throw e).attemptSql.unsafePerformSync must_== -\/(e)
     }
 
     "ignore non-SQLException" in {      
       val e = new IllegalArgumentException
-      Task.delay(throw e).attemptSql.run must throwA[IllegalArgumentException]
+      Task.delay(throw e).attemptSql.unsafePerformSync must throwA[IllegalArgumentException]
     }
 
   }
@@ -34,17 +34,17 @@ object catchsqlpec extends Specification {
   "attemptSqlState" should {
 
     "do nothing on success" in {
-      Task.delay(3).attemptSqlState.run must_== \/-(3)
+      Task.delay(3).attemptSqlState.unsafePerformSync must_== \/-(3)
     }
 
     "catch SQLException" in {
       val e = new SQLException("", SQLSTATE_FOO.value)
-      Task.delay(throw e).attemptSqlState.run must_== -\/(SQLSTATE_FOO)
+      Task.delay(throw e).attemptSqlState.unsafePerformSync must_== -\/(SQLSTATE_FOO)
     }
 
     "ignore non-SQLException" in {      
       val e = new IllegalArgumentException
-      Task.delay(throw e).attemptSqlState.run must throwA[IllegalArgumentException]
+      Task.delay(throw e).attemptSqlState.unsafePerformSync must throwA[IllegalArgumentException]
     }
 
   }
@@ -55,7 +55,7 @@ object catchsqlpec extends Specification {
       Task.delay(3).attemptSomeSqlState {
         case SQLSTATE_FOO => 42
         case SQLSTATE_BAR        => 66
-      }.run must_== \/-(3)
+      }.unsafePerformSync must_== \/-(3)
     }
 
     "catch SQLException with matching state (1)" in {
@@ -63,7 +63,7 @@ object catchsqlpec extends Specification {
       Task.delay(throw e).attemptSomeSqlState {
         case SQLSTATE_FOO => 42
         case SQLSTATE_BAR        => 66
-      }.run must_== -\/(42)
+      }.unsafePerformSync must_== -\/(42)
     }
 
     "catch SQLException with matching state (2)" in {
@@ -71,21 +71,21 @@ object catchsqlpec extends Specification {
       Task.delay(throw e).attemptSomeSqlState {
         case SQLSTATE_FOO => 42
         case SQLSTATE_BAR        => 66
-      }.run must_== -\/(66)
+      }.unsafePerformSync must_== -\/(66)
     }
 
     "ignore SQLException with non-matching state" in {
       val e = new SQLException("", SQLSTATE_BAR.value)
       Task.delay(throw e).attemptSomeSqlState {
         case SQLSTATE_FOO => 42
-      }.run must throwA[SQLException]
+      }.unsafePerformSync must throwA[SQLException]
     }
 
     "ignore non-SQLException" in {
       val e = new IllegalArgumentException
       Task.delay(throw e).attemptSomeSqlState {
         case SQLSTATE_FOO => 42
-      }.run must throwA[IllegalArgumentException]
+      }.unsafePerformSync must throwA[IllegalArgumentException]
     }
 
   }
@@ -95,17 +95,17 @@ object catchsqlpec extends Specification {
     val rescue = Task.delay(4)
 
     "do nothing on success" in {
-      Task.delay(3).exceptSql(e => rescue).run must_== 3
+      Task.delay(3).exceptSql(e => rescue).unsafePerformSync must_== 3
     }
 
     "catch SQLException" in {
       val e = new SQLException("", SQLSTATE_FOO.value)
-      Task.delay[Int](throw e).exceptSql(e => rescue).run must_== 4
+      Task.delay[Int](throw e).exceptSql(e => rescue).unsafePerformSync must_== 4
     }
 
     "ignore non-SQLException" in {      
       val e = new IllegalArgumentException
-      Task.delay[Int](throw e).exceptSql(e => rescue).run must throwA[IllegalArgumentException]
+      Task.delay[Int](throw e).exceptSql(e => rescue).unsafePerformSync must throwA[IllegalArgumentException]
     }
 
   }
@@ -115,17 +115,17 @@ object catchsqlpec extends Specification {
     val rescue = Task.delay(4)
 
     "do nothing on success" in {
-      Task.delay(3).exceptSqlState(e => rescue).run must_== 3
+      Task.delay(3).exceptSqlState(e => rescue).unsafePerformSync must_== 3
     }
 
     "catch SQLException" in {
       val e = new SQLException("", SQLSTATE_FOO.value)
-      Task.delay[Int](throw e).exceptSqlState(e => rescue).run must_== 4
+      Task.delay[Int](throw e).exceptSqlState(e => rescue).unsafePerformSync must_== 4
     }
 
     "ignore non-SQLException" in {      
       val e = new IllegalArgumentException
-      Task.delay[Int](throw e).exceptSqlState(e => rescue).run must throwA[IllegalArgumentException]
+      Task.delay[Int](throw e).exceptSqlState(e => rescue).unsafePerformSync must throwA[IllegalArgumentException]
     }
 
   }
@@ -135,22 +135,22 @@ object catchsqlpec extends Specification {
     val rescue = Task.delay(4)
 
     "do nothing on success" in {
-      Task.delay(3).exceptSomeSqlState { case _ => rescue }.run must_== 3
+      Task.delay(3).exceptSomeSqlState { case _ => rescue }.unsafePerformSync must_== 3
     }
 
     "catch SQLException with some state" in {
       val e = new SQLException("", SQLSTATE_FOO.value)
-      Task.delay[Int](throw e).exceptSomeSqlState { case SQLSTATE_FOO => rescue }.run must_== 4
+      Task.delay[Int](throw e).exceptSomeSqlState { case SQLSTATE_FOO => rescue }.unsafePerformSync must_== 4
     }
 
     "ignore SQLException with other state" in {
       val e = new SQLException("", SQLSTATE_FOO.value)
-      Task.delay[Int](throw e).exceptSomeSqlState { case SQLSTATE_BAR => rescue }.run must throwA[SQLException]
+      Task.delay[Int](throw e).exceptSomeSqlState { case SQLSTATE_BAR => rescue }.unsafePerformSync must throwA[SQLException]
     }
 
     "ignore non-SQLException" in {      
       val e = new IllegalArgumentException
-      Task.delay[Int](throw e).exceptSomeSqlState { case _ => rescue }.run must throwA[IllegalArgumentException]
+      Task.delay[Int](throw e).exceptSomeSqlState { case _ => rescue }.unsafePerformSync must throwA[IllegalArgumentException]
     }
 
   }
@@ -159,21 +159,21 @@ object catchsqlpec extends Specification {
 
     "do nothing on success" in {
       var a = 1
-      Task.delay(3).onSqlException(Task.delay(a += 1)).attemptRun
+      Task.delay(3).onSqlException(Task.delay(a += 1)).unsafePerformSyncAttempt
       a must_== 1
     }
 
     "perform its effect on SQLException" in {
       var a = 1
       val e = new SQLException("", SQLSTATE_FOO.value)
-      Task.delay[Int](throw e).onSqlException(Task.delay(a += 1)).attemptRun must_== -\/(e)
+      Task.delay[Int](throw e).onSqlException(Task.delay(a += 1)).unsafePerformSyncAttempt must_== -\/(e)
       a must_== 2
     }
 
     "ignore its effect on non-SQLException" in {      
       var a = 1
       val e = new IllegalArgumentException
-      Task.delay[Int](throw e).onSqlException(Task.delay(a += 1)).attemptRun must_== -\/(e)
+      Task.delay[Int](throw e).onSqlException(Task.delay(a += 1)).unsafePerformSyncAttempt must_== -\/(e)
       a must_== 1
     }
 

--- a/core/src/test/scala/doobie/util/query.scala
+++ b/core/src/test/scala/doobie/util/query.scala
@@ -19,121 +19,115 @@ object queryspec extends Specification {
 
   "Query (non-empty)" >> {
     "process" in {
-      q.process("foo").list.transact(xa).run must_=== List(123)
+      q.process("foo").list.transact(xa).unsafePerformSync must_=== List(123)
     }
     "sink" in {
       var x = Array(0)
-      def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)
-      q.process("foo").sink(effect).transact(xa).run
+      def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)      
+      q.process("foo").sink(effect).transact(xa).unsafePerformSync
       x(0) must_=== 123
     }
     "to" in {
-      q.to[List]("foo").transact(xa).run must_=== List(123)
+      q.to[List]("foo").transact(xa).unsafePerformSync must_=== List(123)
     }
     "accumulate" in {
-      q.accumulate[List]("foo").transact(xa).run must_=== List(123)
+      q.accumulate[List]("foo").transact(xa).unsafePerformSync must_=== List(123)
     }
     "unique" in {
-      q.unique("foo").transact(xa).run must_=== 123
+      q.unique("foo").transact(xa).unsafePerformSync must_=== 123
     }
     "option" in {
-      q.option("foo").transact(xa).run must_=== Some(123)
-    }
-    "nel" in {
-      q.nel("foo").transact(xa).run must_=== NonEmptyList(123)
+      q.option("foo").transact(xa).unsafePerformSync must_=== Some(123)
     }
     "map" in {
-      q.map("x" * _).to[List]("foo").transact(xa).run must_=== List("x" * 123)
+      q.map("x" * _).to[List]("foo").transact(xa).unsafePerformSync must_=== List("x" * 123)
     }
     "contramap" in {
-      q.contramap[Int](n => "foo" * n).to[List](1).transact(xa).run must_=== List(123)
+      q.contramap[Int](n => "foo" * n).to[List](1).transact(xa).unsafePerformSync must_=== List(123)
     }
   }
 
   "Query (empty)" >> {
     "process" in {
-      q.process("bar").list.transact(xa).run must_=== Nil
+      q.process("bar").list.transact(xa).unsafePerformSync must_=== Nil
     }
     "sink" in {
       var x = Array(0)
-      def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)
-      q.process("bar").sink(effect).transact(xa).run
+      def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)      
+      q.process("bar").sink(effect).transact(xa).unsafePerformSync
       x(0) must_=== 0
     }
     "to" in {
-      q.to[List]("bar").transact(xa).run must_=== Nil
+      q.to[List]("bar").transact(xa).unsafePerformSync must_=== Nil
     }
     "accumulate" in {
-      q.accumulate[List]("bar").transact(xa).run must_=== Nil
+      q.accumulate[List]("bar").transact(xa).unsafePerformSync must_=== Nil
     }
     "unique" in {
-      q.unique("bar").transact(xa).attemptRun must_=== -\/(invariant.UnexpectedEnd)
+      q.unique("bar").transact(xa).unsafePerformSyncAttempt must_=== -\/(invariant.UnexpectedEnd)
     }
     "option" in {
-      q.option("bar").transact(xa).run must_=== None
-    }
-    "nel" in {
-      q.nel("bar").transact(xa).attemptRun must_=== -\/(invariant.UnexpectedEnd)
+      q.option("bar").transact(xa).unsafePerformSync must_=== None
     }
     "map" in {
-      q.map("x" * _).to[List]("bar").transact(xa).run must_=== Nil
+      q.map("x" * _).to[List]("bar").transact(xa).unsafePerformSync must_=== Nil
     }
     "contramap" in {
-      q.contramap[Int](n => "bar" * n).to[List](1).transact(xa).run must_=== Nil
+      q.contramap[Int](n => "bar" * n).to[List](1).transact(xa).unsafePerformSync must_=== Nil
     }
   }
 
   "Query0 from Query (non-empty)" >> {
     "process" in {
-      q.toQuery0("foo").process.list.transact(xa).run must_=== List(123)
+      q.toQuery0("foo").process.list.transact(xa).unsafePerformSync must_=== List(123)
     }
     "sink" in {
       var x = Array(0)
-      def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)
-      q.toQuery0("foo").process.sink(effect).transact(xa).run
+      def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)      
+      q.toQuery0("foo").process.sink(effect).transact(xa).unsafePerformSync
       x(0) must_=== 123
     }
     "to" in {
-      q.toQuery0("foo").to[List].transact(xa).run must_=== List(123)
+      q.toQuery0("foo").to[List].transact(xa).unsafePerformSync must_=== List(123)
     }
     "accumulate" in {
-      q.toQuery0("foo").accumulate[List].transact(xa).run must_=== List(123)
+      q.toQuery0("foo").accumulate[List].transact(xa).unsafePerformSync must_=== List(123)
     }
     "unique" in {
-      q.toQuery0("foo").unique.transact(xa).run must_=== 123
+      q.toQuery0("foo").unique.transact(xa).unsafePerformSync must_=== 123
     }
     "option" in {
-      q.toQuery0("foo").option.transact(xa).run must_=== Some(123)
+      q.toQuery0("foo").option.transact(xa).unsafePerformSync must_=== Some(123)
     }
     "map" in {
-      q.toQuery0("foo").map(_ * 2).list.transact(xa).run must_=== List(246)
+      q.toQuery0("foo").map(_ * 2).list.transact(xa).unsafePerformSync must_=== List(246)
     }
   }
 
   "Query0 from Query (empty)" >> {
     "process" in {
-      q.toQuery0("bar").process.list.transact(xa).run must_=== Nil
+      q.toQuery0("bar").process.list.transact(xa).unsafePerformSync must_=== Nil
     }
     "sink" in {
       var x = Array(0)
-      def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)
-      q.toQuery0("bar").process.sink(effect).transact(xa).run
+      def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)      
+      q.toQuery0("bar").process.sink(effect).transact(xa).unsafePerformSync
       x(0) must_=== 0
     }
     "to" in {
-      q.toQuery0("bar").to[List].transact(xa).run must_=== Nil
+      q.toQuery0("bar").to[List].transact(xa).unsafePerformSync must_=== Nil
     }
     "accumulate" in {
-      q.toQuery0("bar").accumulate[List].transact(xa).run must_=== Nil
+      q.toQuery0("bar").accumulate[List].transact(xa).unsafePerformSync must_=== Nil
     }
     "unique" in {
-      q.toQuery0("bar").unique.transact(xa).attemptRun must_=== -\/(invariant.UnexpectedEnd)
+      q.toQuery0("bar").unique.transact(xa).unsafePerformSyncAttempt must_=== -\/(invariant.UnexpectedEnd)
     }
     "option" in {
-      q.toQuery0("bar").option.transact(xa).run must_=== None
+      q.toQuery0("bar").option.transact(xa).unsafePerformSync must_=== None
     }
     "map" in {
-      q.toQuery0("bar").map(_ * 2).list.transact(xa).run must_=== Nil
+      q.toQuery0("bar").map(_ * 2).list.transact(xa).unsafePerformSync must_=== Nil
     }
   }
 

--- a/doc/src/main/tut/04-Selecting.md
+++ b/doc/src/main/tut/04-Selecting.md
@@ -38,10 +38,10 @@ For our first query let's aim low and select some country names into a `List`, t
 
 ```tut
 (sql"select name from country"
-  .query[String] // Query0[String]
-  .list          // ConnectionIO[List[String]]
-  .transact(xa)  // Task[List[String]]
-  .run           // List[String]
+  .query[String]     // Query0[String]
+  .list              // ConnectionIO[List[String]]
+  .transact(xa)      // Task[List[String]]
+  .unsafePerformSync // List[String]
   .take(5).foreach(println))
 ```
 
@@ -62,12 +62,12 @@ This is ok, but there's not much point reading all the results from the database
 
 ```tut
 (sql"select name from country"
-  .query[String] // Query0[String]
-  .process       // Process[ConnectionIO, String]
-  .take(5)       // Process[ConnectionIO, String]
-  .list          // ConnectionIO[List[String]]
-  .transact(xa)  // Task[List[String]]
-  .run           // List[String]
+  .query[String]     // Query0[String]
+  .process           // Process[ConnectionIO, String]
+  .take(5)           // Process[ConnectionIO, String]
+  .list              // ConnectionIO[List[String]]
+  .transact(xa)      // Task[List[String]]
+  .unsafePerformSync // List[String]
   .foreach(println))
 ```
 

--- a/doc/src/main/tut/05-Parameterized.md
+++ b/doc/src/main/tut/05-Parameterized.md
@@ -44,7 +44,7 @@ case class Country(code: String, name: String, pop: Int, gnp: Option[Double])
 
 ```tut
 (sql"select code, name, population, gnp from country"
-  .query[Country].process.take(5).quick.run)
+  .query[Country].process.take(5).quick.unsafePerformSync)
 ```
 
 Still works. Ok. 
@@ -62,7 +62,7 @@ def biggerThan(minPop: Int) = sql"""
 And when we run the query ... surprise, it works!
 
 ```tut
-biggerThan(150000000).quick.run // Let's see them all
+biggerThan(150000000).quick.unsafePerformSync // Let's see them all
 ```
 
 So what's going on? It looks like we're just dropping a string literal into our SQL string, but actually we're constructing a proper parameterized `PreparedStatement`, and the `minProp` value is ultimately set via a call to `setInt` (see "Diving Deeper" below).

--- a/doc/src/main/tut/06-Checking.md
+++ b/doc/src/main/tut/06-Checking.md
@@ -60,7 +60,7 @@ def biggerThan(minPop: Short) = sql"""
 Now let's try the `check` method provided by YOLO and see what happens.
 
 ```tut:plain
-biggerThan(0).check.run
+biggerThan(0).check.unsafePerformSync
 ```
 
 Yikes, there are quite a few problems, in several categories. In this case **doobie** found

--- a/doc/src/main/tut/07-Updating.md
+++ b/doc/src/main/tut/07-Updating.md
@@ -48,7 +48,7 @@ val create: Update0 =
 We can compose these and run them together.
 
 ```tut
-(drop.quick *> create.quick).run
+(drop.quick *> create.quick).unsafePerformSync
 ```
 
 

--- a/doc/src/main/tut/08-Error-Handling.md
+++ b/doc/src/main/tut/08-Error-Handling.md
@@ -77,7 +77,7 @@ List(sql"""DROP TABLE IF EXISTS person""",
      sql"""CREATE TABLE person (
              id    SERIAL,
              name  VARCHAR NOT NULL UNIQUE
-           )""").traverse(_.update.quick).void.run
+           )""").traverse(_.update.quick).void.unsafePerformSync
 ```
 
 Alright, let's define a `Person` data type and a way to insert instances.
@@ -95,14 +95,14 @@ def insert(s: String): ConnectionIO[Person] = {
 The first insert will work.
 
 ```tut
-insert("bob").quick.run
+insert("bob").quick.unsafePerformSync
 ```
 
 The second will fail with a unique constraint violation.
 
 ```tut
 try {
-  insert("bob").quick.run
+  insert("bob").quick.unsafePerformSync
 } catch {
   case e: java.sql.SQLException => 
     println(e.getMessage)
@@ -126,7 +126,7 @@ Given this definition we can safely attempt to insert duplicate records and get 
 
 
 ```tut
-safeInsert("bob").quick.run
+safeInsert("bob").quick.unsafePerformSync
 
-safeInsert("steve").quick.run
+safeInsert("steve").quick.unsafePerformSync
 ```

--- a/doc/src/main/tut/10-Custom-Mappings.md
+++ b/doc/src/main/tut/10-Custom-Mappings.md
@@ -111,7 +111,7 @@ Now it compiles as a column value and as a `Composite` that maps to a *single* c
 ```tut
 sql"select * from person where id = $pid"
 Composite[PersonId].length
-sql"select 'podiatry:123'".query[PersonId].quick.run
+sql"select 'podiatry:123'".query[PersonId].quick.unsafePerformSync
 ```
 
 Note that the `Composite` width is now a single column. The rule is: if there exists an instance `Meta[A]` in scope, it will take precedence over any automatic derivation of `Composite[A]`.
@@ -167,13 +167,13 @@ val create =
     )
   """.update.run
 
-(drop *> create).quick.run
+(drop *> create).quick.unsafePerformSync
 ```
 
 Note that our `check` output now knows about the `Json` and `Person` mappings. This is a side-effect of constructing instance above, which isn't a good design. Will revisit this for 0.3.0; this information is only used for diagnostics so it's not critical.
 
 ```tut:plain
-sql"select owner from pet".query[Int].check.run
+sql"select owner from pet".query[Int].check.unsafePerformSync
 ```
 
 And we can now use `Person` as a parameter type and as a column type.
@@ -181,13 +181,13 @@ And we can now use `Person` as a parameter type and as a column type.
 ```tut
 val p = Person("Steve", 10, List("Train", "Ball"))
 (sql"insert into pet (name, owner) values ('Bob', $p)"
-  .update.withUniqueGeneratedKeys[(Int, String, Person)]("id", "name", "owner")).quick.run
+  .update.withUniqueGeneratedKeys[(Int, String, Person)]("id", "name", "owner")).quick.unsafePerformSync
 ```
 
 If we ask for the `owner` column as a string value we can see that it is in fact storing JSON data.
 
 ```tut
-sql"select name, owner from pet".query[(String,String)].quick.run
+sql"select name, owner from pet".query[(String,String)].quick.unsafePerformSync
 ```
 
 ### Composite by Invariant Map
@@ -205,7 +205,7 @@ implicit val Point2DComposite: Composite[Point] =
 And it works!
 
 ```tut
-sql"select 'foo', 12, 42, true".query[(String, Point, Boolean)].unique.quick.run
+sql"select 'foo', 12, 42, true".query[(String, Point, Boolean)].unique.quick.unsafePerformSync
 ```
 
 

--- a/doc/src/main/tut/10-Custom-Mappings.md
+++ b/doc/src/main/tut/10-Custom-Mappings.md
@@ -11,7 +11,7 @@ In this chapter we learn how to use custom `Meta` instances to map arbitrary dat
 The examples in this chapter require the `contrib-postgresql` add-on, as well as the [argonaut](http://argonaut.io/) JSON library, which you can add to your build thus:
 
 ```scala
-libraryDependencies += "io.argonaut" %% "argonaut" % "6.1-M4" // as of date of publication
+libraryDependencies += "io.argonaut" %% "argonaut" % "6.2-M1" // as of date of publication
 ```
 
 In our REPL we have the same setup as before, plus a few extra imports.

--- a/doc/src/main/tut/12-Managing-Connections.md
+++ b/doc/src/main/tut/12-Managing-Connections.md
@@ -72,7 +72,7 @@ val p: Task[Int] = for {
 And running this `Task` gives us the desired result.
 
 ```tut
-p.run
+p.unsafePerformSync
 ```
 
 The returned instance is of type `HikariTransactor`, which provides a `shutdown` method, as well as a `configure` method that provides access to the underlying `HikariDataSource` if additional configuration is required.

--- a/doc/src/main/tut/13-Extensions-PostgreSQL.md
+++ b/doc/src/main/tut/13-Extensions-PostgreSQL.md
@@ -70,7 +70,7 @@ implicit val MyEnumAtom = pgEnum(MyEnum, "myenum")
 ```
 
 ```tut
-sql"select 'foo'::myenum".query[MyEnum.Value].unique.quick.run
+sql"select 'foo'::myenum".query[MyEnum.Value].unique.quick.unsafePerformSync
 ```
 
 It works, but `Enumeration` is terrible so it's unlikely you will want to do this. A better option, perhaps surprisingly, is to map `myenum` to a **Java** `enum` via the `pgJavaEnum` constructor.
@@ -116,7 +116,7 @@ implicit val FoobarAtom: Atom[FooBar] =
 ```
 
 ```tut
-sql"select 'foo'::myenum".query[FooBar].unique.quick.run
+sql"select 'foo'::myenum".query[FooBar].unique.quick.unsafePerformSync
 ```
 
 
@@ -173,17 +173,17 @@ val p = sql"oops".query[String].unique // this won't work
 Some of the recovery combinators demonstrated:
 
 ```tut
-p.attempt.quick.run // attempt provided by Catchable instance
+p.attempt.quick.unsafePerformSync // attempt provided by Catchable instance
 
-p.attemptSqlState.quick.run // this catches only SQL exceptions
+p.attemptSqlState.quick.unsafePerformSync // this catches only SQL exceptions
 
-p.attemptSomeSqlState { case SqlState("42601") => "caught!" } .quick.run // catch it
+p.attemptSomeSqlState { case SqlState("42601") => "caught!" } .quick.unsafePerformSync // catch it
 
-p.attemptSomeSqlState { case sqlstate.class42.SYNTAX_ERROR => "caught!" } .quick.run // same, w/constant
+p.attemptSomeSqlState { case sqlstate.class42.SYNTAX_ERROR => "caught!" } .quick.unsafePerformSync // same, w/constant
 
-p.exceptSomeSqlState { case sqlstate.class42.SYNTAX_ERROR => "caught!".point[ConnectionIO] } .quick.run // recover
+p.exceptSomeSqlState { case sqlstate.class42.SYNTAX_ERROR => "caught!".point[ConnectionIO] } .quick.unsafePerformSync // recover
 
-p.onSyntaxError("caught!".point[ConnectionIO]).quick.run // using recovery combinator
+p.onSyntaxError("caught!".point[ConnectionIO]).quick.unsafePerformSync // using recovery combinator
 ```
 
 

--- a/doc/src/main/tut/15-FAQ.md
+++ b/doc/src/main/tut/15-FAQ.md
@@ -31,8 +31,8 @@ Interpolated parameters are replaced with `?` placeholders, so if you need to as
 
 ```tut
 val s = "foo"
-sql"select $s".query[String].check.run
-sql"select $s :: char".query[String].check.run
+sql"select $s".query[String].check.unsafePerformSync
+sql"select $s :: char".query[String].check.unsafePerformSync
 ```
 
 ### How do I do several things in the same transaction?
@@ -61,14 +61,14 @@ def cities(code: Code, asc: Boolean): Query0[City] = {
 We can check the resulting `Query0` as expected.
 
 ```tut:plain
-cities(Code("USA"), true).check.run
+cities(Code("USA"), true).check.unsafePerformSync
 ```
 
 And it works!
 
 ```tut
-cities(Code("USA"), true).process.take(5).quick.run
-cities(Code("USA"), false).process.take(5).quick.run
+cities(Code("USA"), true).process.take(5).quick.unsafePerformSync
+cities(Code("USA"), false).process.take(5).quick.unsafePerformSync
 ```
 
 ### How do I handle outer joins?
@@ -94,7 +94,7 @@ val join: Query0[(Country, Option[City])] =
 Some examples, filtered for size.
 
 ```tut
-join.process.filter(_._1.name.startsWith("United")).quick.run
+join.process.filter(_._1.name.startsWith("United")).quick.unsafePerformSync
 ```
 
 ### How do I resolve `error: Could not find or construct Param[...]`?

--- a/example/src/main/scala/example/HiUsage.scala
+++ b/example/src/main/scala/example/HiUsage.scala
@@ -17,7 +17,7 @@ object HiUsage {
   // Program entry point
   def main(args: Array[String]): Unit = {
     val db = DriverManagerTransactor[Task]("org.postgresql.Driver", "jdbc:postgresql:world", "postgres", "")
-    example.transact(db).run
+    example.transact(db).unsafePerformSync
   }
 
   // An example action. Streams results to stdout

--- a/example/src/main/scala/example/HikariExample.scala
+++ b/example/src/main/scala/example/HikariExample.scala
@@ -15,6 +15,6 @@ object HikariExample {
     } yield ()
 
   def main(args: Array[String]) =
-    tmain.run
+    tmain.unsafePerformSync
 
 }

--- a/example/src/main/scala/example/PostgresLargeObject.scala
+++ b/example/src/main/scala/example/PostgresLargeObject.scala
@@ -29,7 +29,7 @@ object PostgresLargeObject {
     }
 
   def main(args: Array[String]): Unit = 
-    task.run
+    task.unsafePerformSync
 
 }
 

--- a/example/src/main/scala/example/PostgresNotify.scala
+++ b/example/src/main/scala/example/PostgresNotify.scala
@@ -54,6 +54,6 @@ object PostgresNotify {
       .sink(s => HC.delay(Console.println(s)))
       .transact(xa)
       .void
-      .run
+      .unsafePerformSync
 
 }

--- a/example/src/main/scala/example/PostgresPoint.scala
+++ b/example/src/main/scala/example/PostgresPoint.scala
@@ -23,7 +23,7 @@ object PostgresPoint extends App {
 
   // Point is now a perfectly cromulent input/output type
   def q = sql"select '(1, 2)'::point".query[Point]
-  val a = q.list.transact(xa).run
+  val a = q.list.transact(xa).unsafePerformSync
   Console.println(a) // List(Point(1.0,2.0))
 
   // Just to be clear; the Composite instance has width 1, not 2

--- a/example/src/main/scala/example/postgrescopymanager.scala
+++ b/example/src/main/scala/example/postgrescopymanager.scala
@@ -67,7 +67,7 @@ object postgrescopymanager {
       }
 
     def main(args: Array[String]): Unit =
-      task.run
+      task.unsafePerformSync
   }
 
 
@@ -132,7 +132,7 @@ object postgrescopymanager {
       PHC.pgGetCopyAPI(progIn *> progOut).transact(xa)
 
     def main(args: Array[String]): Unit =
-      task.run
+      task.unsafePerformSync
   }
 
 
@@ -169,7 +169,7 @@ object postgrescopymanager {
             .intersperse("\n")
             .map(stringToByteVector)
             .to(copyInSink(copyIn))
-            .run.run // side-effect is re-captured in CopyManagerIO
+            .run.unsafePerformSync // side-effect is re-captured in CopyManagerIO
         }
       }
 
@@ -186,7 +186,7 @@ object postgrescopymanager {
             }
             .map(_.toString)
             .to(io.stdOutLines)
-            .run.run // side-effect is re-captured in CopyManagerIO
+            .run.unsafePerformSync // side-effect is re-captured in CopyManagerIO
         }
       }
 
@@ -194,7 +194,7 @@ object postgrescopymanager {
       PHC.pgGetCopyAPI(progIn *> progOut).transact(xa)
 
     def main(args: Array[String]): Unit =
-      task.run
+      task.unsafePerformSync
   }
 
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url(
     url("http://dl.bintray.com/content/tpolecat/sbt-plugin-releases"))(
         Resolver.ivyStylePatterns)
 
-addSbtPlugin("org.tpolecat"      % "tut-plugin"   % "0.4.0")
+addSbtPlugin("org.tpolecat"      % "tut-plugin"   % "0.4.2")
 addSbtPlugin("com.eed3si9n"      % "sbt-unidoc"   % "0.3.1")
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"      % "1.0.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release"  % "1.0.0")


### PR DESCRIPTION
Use `bracket` instead of `eval` with inner `onComplete`.

One concern is that ` onHalt { _.asHalt }` is [generally recommended against](https://github.com/functional-streams-for-scala/fs2/wiki/0.8#terminated-removal), but I just took it for now as this one is also used in [scalaz-stream's own resource combinator](https://github.com/functional-streams-for-scala/fs2/blob/release/0.8/src/main/scala/scalaz/stream/io.scala#L152).