### PR TITLE
add result type to imports.freeMonadC

### DIFF
--- a/core/src/main/scala/doobie/imports.scala
+++ b/core/src/main/scala/doobie/imports.scala
@@ -126,7 +126,7 @@ object imports extends ToDoobieCatchSqlOps with ToDoobieCatchableOps {
    * Free monad derivation with correct shape to derive an instance for `Free[Coyoneda[F, ?], ?]`.
    * @group Hacks
    */
-  implicit def freeMonadC[FT[_[_], _], F[_]](implicit ev: Functor[FT[F, ?]]) =
+  implicit def freeMonadC[FT[_[_], _], F[_]](implicit ev: Functor[FT[F, ?]]): Monad[Free[FT[F,?], ?]] =
     Free.freeMonad[FT[F,?]]
 
   /**


### PR DESCRIPTION
I had copied `freeMonadC` and `unapplyMMFA` into my own project, but they wouldn't work for me until I added the result type to `freeMonadC`.  Thought you might want it here too, for good measure.