### PR TITLE
add NonEmptyList `.nel` support to RS, Query, Query0, docs

### DIFF
--- a/core/src/main/scala/doobie/hi/resultset.scala
+++ b/core/src/main/scala/doobie/hi/resultset.scala
@@ -210,7 +210,7 @@ object resultset {
     * @throws `UnexpectedEnd` if there is not at least one row remaining
     * @group Results
     */
-  def getNel[A: Composite]: ResultSetIO[NonEmptyList[A]] =
+  def nel[A: Composite]: ResultSetIO[NonEmptyList[A]] =
     (getNext[A] |@| list) {
       case (Some(a), as) => NonEmptyList.nel(a, as)
       case (None, _)     => throw UnexpectedEnd

--- a/core/src/main/scala/doobie/hi/resultset.scala
+++ b/core/src/main/scala/doobie/hi/resultset.scala
@@ -25,7 +25,7 @@ import scala.collection.JavaConverters._
 import scala.collection.generic.CanBuildFrom
 import scala.Predef.intArrayOps
 
-import scalaz.{ Monad, MonadPlus, IList }
+import scalaz.{ Monad, MonadPlus, IList, NonEmptyList }
 import scalaz.syntax.id._
 import scalaz.syntax.monadPlus._
 import scalaz.stream.Process
@@ -203,6 +203,17 @@ object resultset {
       case (a @ Some(_), false) => a
       case (Some(a), true)      => throw UnexpectedContinuation
       case (None, _)            => None
+    }
+
+  /**
+    * Consumes the remainder of the resultset, but verifies that there is at least one row remaining.
+    * @throws `UnexpectedEnd` if there is not at least one row remaining
+    * @group Results
+    */
+  def getNel[A: Composite]: ResultSetIO[NonEmptyList[A]] =
+    (getNext[A] |@| list) {
+      case (Some(a), as) => NonEmptyList.nel(a, as)
+      case (None, _)     => throw UnexpectedEnd
     }
 
   /** 

--- a/core/src/main/scala/doobie/util/query.scala
+++ b/core/src/main/scala/doobie/util/query.scala
@@ -107,7 +107,7 @@ object query {
       * @group Results
       */
     def nel(a: A): ConnectionIO[NonEmptyList[B]] =
-      HC.prepareStatement(sql)(HPS.set(ai(a)) *> HPS.executeQuery(HRS.getNel[O])).map(_.map(ob))
+      HC.prepareStatement(sql)(HPS.set(ai(a)) *> HPS.executeQuery(HRS.nel[O])).map(_.map(ob))
 
     /** @group Transformations */
     def map[C](f: B => C): Query[A, C] =

--- a/core/src/test/scala/doobie/util/query.scala
+++ b/core/src/test/scala/doobie/util/query.scala
@@ -39,6 +39,9 @@ object queryspec extends Specification {
   	"option" in {
   		q.option("foo").transact(xa).run must_=== Some(123)
   	}
+		"nel" in {
+			q.nel("foo").transact(xa).run must_=== NonEmptyList(123)
+		}
   	"map" in {
   		q.map("x" * _).to[List]("foo").transact(xa).run must_=== List("x" * 123)
   	}
@@ -69,6 +72,9 @@ object queryspec extends Specification {
   	"option" in {
   		q.option("bar").transact(xa).run must_=== None
   	}
+		"nel" in {
+			q.nel("bar").transact(xa).attemptRun must_=== -\/(invariant.UnexpectedEnd)
+		}
   	"map" in {
   		q.map("x" * _).to[List]("bar").transact(xa).run must_=== Nil
   	}

--- a/core/src/test/scala/doobie/util/query.scala
+++ b/core/src/test/scala/doobie/util/query.scala
@@ -18,120 +18,120 @@ object queryspec extends Specification {
   val q = Query[String,Int]("select 123 where ? = 'foo'", None)
 
   "Query (non-empty)" >> {
-  	"process" in {
-  		q.process("foo").list.transact(xa).run must_=== List(123)
-  	}
-  	"sink" in {
-  		var x = Array(0)
-  		def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)  		
-  		q.process("foo").sink(effect).transact(xa).run
-  		x(0) must_=== 123
-  	}
-  	"to" in {
-  		q.to[List]("foo").transact(xa).run must_=== List(123)
-  	}
-  	"accumulate" in {
-  		q.accumulate[List]("foo").transact(xa).run must_=== List(123)
-  	}
-  	"unique" in {
-  		q.unique("foo").transact(xa).run must_=== 123
-  	}
-  	"option" in {
-  		q.option("foo").transact(xa).run must_=== Some(123)
-  	}
-		"nel" in {
-			q.nel("foo").transact(xa).run must_=== NonEmptyList(123)
-		}
-  	"map" in {
-  		q.map("x" * _).to[List]("foo").transact(xa).run must_=== List("x" * 123)
-  	}
-  	"contramap" in {
-  		q.contramap[Int](n => "foo" * n).to[List](1).transact(xa).run must_=== List(123)
-  	}
+    "process" in {
+      q.process("foo").list.transact(xa).run must_=== List(123)
+    }
+    "sink" in {
+      var x = Array(0)
+      def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)
+      q.process("foo").sink(effect).transact(xa).run
+      x(0) must_=== 123
+    }
+    "to" in {
+      q.to[List]("foo").transact(xa).run must_=== List(123)
+    }
+    "accumulate" in {
+      q.accumulate[List]("foo").transact(xa).run must_=== List(123)
+    }
+    "unique" in {
+      q.unique("foo").transact(xa).run must_=== 123
+    }
+    "option" in {
+      q.option("foo").transact(xa).run must_=== Some(123)
+    }
+    "nel" in {
+      q.nel("foo").transact(xa).run must_=== NonEmptyList(123)
+    }
+    "map" in {
+      q.map("x" * _).to[List]("foo").transact(xa).run must_=== List("x" * 123)
+    }
+    "contramap" in {
+      q.contramap[Int](n => "foo" * n).to[List](1).transact(xa).run must_=== List(123)
+    }
   }
 
   "Query (empty)" >> {
-  	"process" in {
-  		q.process("bar").list.transact(xa).run must_=== Nil
-  	}
-  	"sink" in {
-  		var x = Array(0)
-  		def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)  		
-  		q.process("bar").sink(effect).transact(xa).run
-  		x(0) must_=== 0
-  	}
-  	"to" in {
-  		q.to[List]("bar").transact(xa).run must_=== Nil
-  	}
-  	"accumulate" in {
-  		q.accumulate[List]("bar").transact(xa).run must_=== Nil
-  	}
-  	"unique" in {
-  		q.unique("bar").transact(xa).attemptRun must_=== -\/(invariant.UnexpectedEnd)
-  	}
-  	"option" in {
-  		q.option("bar").transact(xa).run must_=== None
-  	}
-		"nel" in {
-			q.nel("bar").transact(xa).attemptRun must_=== -\/(invariant.UnexpectedEnd)
-		}
-  	"map" in {
-  		q.map("x" * _).to[List]("bar").transact(xa).run must_=== Nil
-  	}
-  	"contramap" in {
-  		q.contramap[Int](n => "bar" * n).to[List](1).transact(xa).run must_=== Nil
-  	}
+    "process" in {
+      q.process("bar").list.transact(xa).run must_=== Nil
+    }
+    "sink" in {
+      var x = Array(0)
+      def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)
+      q.process("bar").sink(effect).transact(xa).run
+      x(0) must_=== 0
+    }
+    "to" in {
+      q.to[List]("bar").transact(xa).run must_=== Nil
+    }
+    "accumulate" in {
+      q.accumulate[List]("bar").transact(xa).run must_=== Nil
+    }
+    "unique" in {
+      q.unique("bar").transact(xa).attemptRun must_=== -\/(invariant.UnexpectedEnd)
+    }
+    "option" in {
+      q.option("bar").transact(xa).run must_=== None
+    }
+    "nel" in {
+      q.nel("bar").transact(xa).attemptRun must_=== -\/(invariant.UnexpectedEnd)
+    }
+    "map" in {
+      q.map("x" * _).to[List]("bar").transact(xa).run must_=== Nil
+    }
+    "contramap" in {
+      q.contramap[Int](n => "bar" * n).to[List](1).transact(xa).run must_=== Nil
+    }
   }
 
   "Query0 from Query (non-empty)" >> {
-  	"process" in {
-  		q.toQuery0("foo").process.list.transact(xa).run must_=== List(123)
-  	}
-  	"sink" in {
-  		var x = Array(0)
-  		def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)  		
-  		q.toQuery0("foo").process.sink(effect).transact(xa).run
-  		x(0) must_=== 123
-  	}
-  	"to" in {
-  		q.toQuery0("foo").to[List].transact(xa).run must_=== List(123)
-  	}
-  	"accumulate" in {
-  		q.toQuery0("foo").accumulate[List].transact(xa).run must_=== List(123)
-  	}
-  	"unique" in {
-  		q.toQuery0("foo").unique.transact(xa).run must_=== 123
-  	}
-  	"option" in {
-  		q.toQuery0("foo").option.transact(xa).run must_=== Some(123)
-  	}
-  	"map" in {
-  		q.toQuery0("foo").map(_ * 2).list.transact(xa).run must_=== List(246)
-  	}
+    "process" in {
+      q.toQuery0("foo").process.list.transact(xa).run must_=== List(123)
+    }
+    "sink" in {
+      var x = Array(0)
+      def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)
+      q.toQuery0("foo").process.sink(effect).transact(xa).run
+      x(0) must_=== 123
+    }
+    "to" in {
+      q.toQuery0("foo").to[List].transact(xa).run must_=== List(123)
+    }
+    "accumulate" in {
+      q.toQuery0("foo").accumulate[List].transact(xa).run must_=== List(123)
+    }
+    "unique" in {
+      q.toQuery0("foo").unique.transact(xa).run must_=== 123
+    }
+    "option" in {
+      q.toQuery0("foo").option.transact(xa).run must_=== Some(123)
+    }
+    "map" in {
+      q.toQuery0("foo").map(_ * 2).list.transact(xa).run must_=== List(246)
+    }
   }
 
   "Query0 from Query (empty)" >> {
-  	"process" in {
-  		q.toQuery0("bar").process.list.transact(xa).run must_=== Nil
-  	}
-  	"sink" in {
-  		var x = Array(0)
-  		def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)  		
-  		q.toQuery0("bar").process.sink(effect).transact(xa).run
-  		x(0) must_=== 0
-  	}
-  	"to" in {
-  		q.toQuery0("bar").to[List].transact(xa).run must_=== Nil
-  	}
-  	"accumulate" in {
-  		q.toQuery0("bar").accumulate[List].transact(xa).run must_=== Nil
-  	}
-  	"unique" in {
-  		q.toQuery0("bar").unique.transact(xa).attemptRun must_=== -\/(invariant.UnexpectedEnd)
-  	}
-  	"option" in {
-  		q.toQuery0("bar").option.transact(xa).run must_=== None
-  	}
+    "process" in {
+      q.toQuery0("bar").process.list.transact(xa).run must_=== Nil
+    }
+    "sink" in {
+      var x = Array(0)
+      def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)
+      q.toQuery0("bar").process.sink(effect).transact(xa).run
+      x(0) must_=== 0
+    }
+    "to" in {
+      q.toQuery0("bar").to[List].transact(xa).run must_=== Nil
+    }
+    "accumulate" in {
+      q.toQuery0("bar").accumulate[List].transact(xa).run must_=== Nil
+    }
+    "unique" in {
+      q.toQuery0("bar").unique.transact(xa).attemptRun must_=== -\/(invariant.UnexpectedEnd)
+    }
+    "option" in {
+      q.toQuery0("bar").option.transact(xa).run must_=== None
+    }
     "map" in {
       q.toQuery0("bar").map(_ * 2).list.transact(xa).run must_=== Nil
     }

--- a/doc/src/main/tut/04-Selecting.md
+++ b/doc/src/main/tut/04-Selecting.md
@@ -54,6 +54,7 @@ Let's break this down a bit.
   - `.accumulate[M[_]: MonadPlus]` which accumulates to a universally quantified monoid `M`. This works with many scalaz collections, as well as standard library collections with `MonadPlus` instances.
   - `.unique` which returns a single value, raising an exception if there is not exactly one row returned.
   - `.option` which returns an `Option`, raising an exception if there is more than one row returned.
+  - `.nel` which returns an `NonEmptyList`, raising an exception if there are no rows returned.
   - See the Scaladoc for `Query0` for more information on these and other methods.
 - The rest is familar; `transact(xa)` yields a `Task[List[String]]` which we run, giving us a normal Scala `List[String]` that we print out.
 


### PR DESCRIPTION
What do you think about this, to convert the following sort of construction (and its accompanying warning):

```scala
implicit class toNelUnsafe[F[_] : Functor, A](fa: F[List[A]]) {
  def toNelUnsafe: F[NonEmptyList[A]] = fa map {
    case a :: as => NonEmptyList.nel(a, as) // not total
  }
}

def getItems(orderId: OrderId): ConnectionIO[NonEmptyList[ItemId]] =
  sql"""
    SELECT item_id FROM order_contents WHERE order_id = $orderId
  """.query[ItemId].list.toNelUnsafe
```

into 

```scala
def getItems(orderId: OrderId): ConnectionIO[NonEmptyList[ItemId]] =
  sql"""
    SELECT item_id FROM order_contents WHERE order_id = $orderId
  """.query[ItemId].nel // safe!
```

P.S. Some whitespace changes got caught up in the first commit too, despite having carefully reverted them once; I converted some legacy tabs to spaces in the second commit.

P.P.S. Sorry for all the edits, if they triggered multiple emails.