### PR TITLE
wip: new transactor design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This will be a **major release** with **breaking changes** to come.
 Special thanks to **@guersam** for updating the build and all the dependencies; this was nontrivial.
 
 - **doobie** artifacts now include OSGi headers.
-- Added `.nel` handlers for reading result sets that are expected to be no-empty.
+- Added `.nel` handlers for reading result sets that are expected to be non-empty.
 
 Upgrades:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file summarizes **notable** changes for each release, but does not describe
 
 This will be a **major release** with **breaking changes** to come. 
 
-Special thanks to **@guerasm** for updating the build and all the dependencies; this was nontrivial.
+Special thanks to **@guersam** for updating the build and all the dependencies; this was nontrivial.
 
 - **doobie** artifacts now include OSGi headers.
 - Added `.nel` handlers for reading result sets that are expected to be no-empty.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 This file summarizes **notable** changes for each release, but does not describe internal changes unless they are particularly exciting. For complete details please see the corresponding [milestones](https://github.com/tpolecat/doobie/milestones?state=closed) and their associated issues.
 
+### <a name="0.3.0-M1"></a>New and Noteworthy for Version 0.3.0-M1
+
+This will be a **major release** with **breaking changes** to come. 
+
+Special thanks to **@guerasm** for updating the build and all the dependencies; this was nontrivial.
+
+- **doobie** artifacts now include OSGi headers.
+- Added `.nel` handlers for reading result sets that are expected to be no-empty.
+
+Upgrades:
+
+- Updated to Scala 2.11.8 and 2.12.0-M3
+- Updated to shapeless 2.3.0
+- Updated to scalaz 7.2.0
+- Updated to scalaz-stream 0.8a
+
 ### <a name="0.2.3"></a>New and Noteworthy for Version 0.2.3
 
 This release includes more performance work and some usability improvements, as well as documentation improvements here and there. This release should be source-compatible for most users, but is **not** binary compatible with 0.2.2 or any other release. Let me know if you run into source compatibilty problems. Special thanks to **@mdmoss** for build improvements, **@fommil** and **@non** for help with Sonatype, and everyone else for your continued interest and contributions!

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Join the chat at https://gitter.im/tpolecat/doobie](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/tpolecat/doobie?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Maven Central](https://img.shields.io/maven-central/v/org.tpolecat/doobie-core_2.11.svg)](https://maven-badges.herokuapp.com/maven-central/org.tpolecat/doobie-core_2.11)
 
+> **NOTE** this is an active development branch. Document is not necessarily up to date and unannounced breaking changes should be expected. For stable releases please switch to `series/0.2.x`.
+
 **doobie** is a pure functional JDBC layer for Scala. It is not an ORM, nor is it a relational algebra; it just provides a principled way to construct programs (and higher-level libraries) that use JDBC. **doobie** introduces very few new abstractions; if you are familiar with basic `scalaz` typeclasses like `Functor` and `Monad` you should have no trouble here.
 
 For common use cases **doobie** provides a minimal but expressive high-level API:
@@ -11,7 +13,7 @@ For common use cases **doobie** provides a minimal but expressive high-level API
 ```scala
 import doobie.imports._, scalaz.effect.IO
 
-val xa = DriverManagerTransactor[IO](
+val xa = DriverManagerTransactor(
   "org.postgresql.Driver", "jdbc:postgresql:world", "postgres", ""
 )
 
@@ -22,7 +24,7 @@ def find(n: String): ConnectionIO[Option[Country]] =
 
 // And then
 
-scala> find("France").transact(xa).unsafePerformIO
+scala> find("France").transact[IO](xa).unsafePerformIO
 res0: Option[Country] = Some(Country(FRA,France,59225700))
 ```
 
@@ -30,16 +32,16 @@ res0: Option[Country] = Some(Country(FRA,France,59225700))
 
 ## Quick Start
 
-The current release is **0.2.3**, which works on Scala **2.10.5** and **2.11** with
+The current milestone is **0.3.0-M1**, which works on Scala **2.10.5**, **2.11**, and **2.12** with
 
-- scalaz 7.1
-- scalaz-stream 0.7.2a ← **important:** later versions are *not* compatible (yet)
-- shapeless 2.2
+- scalaz 7.2
+- scalaz-stream 0.8a
+- shapeless 2.3
 
 You should expect minor breaking changes for at least the next few versions, although these will be documented and kept to a minimum. To use **doobie** you need to add the following to your `build.sbt`.
 
 ```scala
-libraryDependencies += "org.tpolecat" %% "doobie-core" % "0.2.3"
+libraryDependencies += "org.tpolecat" %% "doobie-core" % "0.3.0-M1"
 ```
 
 If you are using Scala 2.10.5 you must also add the paradise compiler plugin.
@@ -59,7 +61,7 @@ See the [**book of doobie**](http://tpolecat.github.io/doobie-0.2.3/00-index.htm
 
 ## Documentation and Support
 
-- See the [**changelog**](https://github.com/tpolecat/doobie/blob/master/CHANGELOG.md#0.2.3) for an overview of changes in this and previous versions.
+- See the [**changelog**](https://github.com/tpolecat/doobie/blob/master/CHANGELOG.md#0.3.0-M1) for an overview of changes in this and previous versions.
 - Behold the [**book of doobie**](http://tpolecat.github.io/doobie-0.2.3/00-index.html) ← start here
 - The [**scaladoc**](http://tpolecat.github.io/doc/doobie/0.2.3/api/index.html) will be handy once you get your feet wet.
 - There is also the source. If you're here you know where to look. Check the examples.
@@ -68,11 +70,12 @@ See the [**book of doobie**](http://tpolecat.github.io/doobie-0.2.3/00-index.htm
 
 ## Presentations, Blog Posts, etc.
 
-Listed newest first. If you have given a presentation or have written a blog post on **doobie**, let me know and I'll add it to this list.
+Listed newest first. If you have given a presentation or have written a blog post that includes **doobie**, let me know and I'll add it to this list.
 
-- [Programs as Values: JDBC Programming with doobie](https://www.youtube.com/watch?v=M5MF6M7FHPo) Scala by the Bay, 2015 ([slides](http://tpolecat.github.io/assets/sbtb-slides.pdf))
+- [The Functional Web Stack](https://t.co/rYH42gs2AU) by Gary Coady - Dublin Scala Users Group, April 2016
+- [End to End and On The Level](https://www.youtube.com/watch?v=lMW_yMkxX4Q&list=PL_5uJkfWNxdkQd7FbN1whrTOsJPMgHgLg&index=2) by Dave Gurnell - Typelevel Summit, Philadelphia, March 2016
+- [Programs as Values: JDBC Programming with doobie](https://www.youtube.com/watch?v=M5MF6M7FHPo) by Rob Norris - Scala by the Bay, 2015 - [slides](http://tpolecat.github.io/assets/sbtb-slides.pdf)
 - [Typechecking SQL in Slick and doobie](http://underscore.io/blog/posts/2015/05/28/typechecking-sql.html) by Richard Dallaway
-- [DB to JSON with a Microservice](http://da_terry.bitbucket.org/slides/presentation-scalasyd-functional-jdbc-http/#/) by Da Terry (code [here](https://bitbucket.org/da_terry/scalasyd-doobie-http4s)).
-
+- [DB to JSON with a Microservice](http://da_terry.bitbucket.org/slides/presentation-scalasyd-functional-jdbc-http/#/) by Da Terry - [code](https://bitbucket.org/da_terry/scalasyd-doobie-http4s)
 
 

--- a/bench/src/main/scala/doobie/bench/bench.scala
+++ b/bench/src/main/scala/doobie/bench/bench.scala
@@ -8,7 +8,7 @@ import scalaz.concurrent.Task
 /** Rough benchmark based on non/jawn */
 object bench {
 
-  val xa = DriverManagerTransactor[Task]("org.postgresql.Driver", "jdbc:postgresql:world", "postgres", "")
+  val xa = DriverManagerTransactor("org.postgresql.Driver", "jdbc:postgresql:world", "postgres", "")
 
   // Baseline hand-written JDBC code
   def jdbcBench(n: Int): Int = {
@@ -47,7 +47,7 @@ object bench {
       .query[(String,String,String)]
       .process
       .list
-      .transact(xa)
+      .transact[Task](xa)
       .map(_.length)
       .unsafePerformSync
 
@@ -56,7 +56,7 @@ object bench {
     sql"select a.name, b.name, c.name from country a, country b, country c limit $n"
       .query[(String,String,String)]
       .list
-      .transact(xa)
+      .transact[Task](xa)
       .map(_.length)
       .unsafePerformSync
 
@@ -65,7 +65,7 @@ object bench {
     sql"select a.name, b.name, c.name from country a, country b, country c limit $n"
       .query[(String,String,String)]
       .vector
-      .transact(xa)
+      .transact[Task](xa)
       .map(_.length)
       .unsafePerformSync
 
@@ -75,7 +75,7 @@ object bench {
       HPS.executeQuery {
         HRS.ilist[(String, String, String)]
       }
-    } .transact(xa)
+    } .transact[Task](xa)
       .map(_.length)
       .unsafePerformSync
 

--- a/contrib/h2/src/main/scala/doobie/contrib/h2/H2Transactor.scala
+++ b/contrib/h2/src/main/scala/doobie/contrib/h2/H2Transactor.scala
@@ -4,8 +4,7 @@ import doobie.imports._
 
 import org.h2.jdbcx.JdbcConnectionPool
 
-import scalaz.{ Catchable, Monad }
-import scalaz.Lens
+import scalaz.{ Catchable, Monad, Lens }
 
 /** Module for a `Transactor` backed by an H2 `JdbcConnectionPool`. */
 object h2transactor {
@@ -45,7 +44,7 @@ object h2transactor {
   }
 
   /* JdbcConnectionPool is a Connector for any effect-capturing M. */
-  implicit def jdbcConnectionPool[M[_]: Monad: Catchable: Capture]: Connector[M, JdbcConnectionPool] =
+  implicit def jdbcConnectionPoolConnector[M[_]: Monad: Catchable: Capture]: Connector[M, JdbcConnectionPool] =
     Connector.instance(ds => Capture[M].apply(ds.getConnection))
 
   @deprecated("Use H2XA instead.", "0.3.0") type H2Transactor = H2XA

--- a/contrib/h2/src/test/scala/doobie/contrib/h2/h2types.scala
+++ b/contrib/h2/src/test/scala/doobie/contrib/h2/h2types.scala
@@ -15,7 +15,7 @@ import scalaz.{ Maybe, \/- }
 // Establish that we can read various types. It's not very comprehensive as a test, bit it's a start.
 object h2typesspec extends Specification {
 
-  val xa = DriverManagerTransactor[Task](
+  val xa = DriverManagerTransactor(
     "org.h2.Driver",
     "jdbc:h2:mem:ch3;DB_CLOSE_DELAY=-1",
     "sa", ""
@@ -31,19 +31,19 @@ object h2typesspec extends Specification {
   def testInOut[A](col: String, a: A)(implicit m: Meta[A]) =
     s"Mapping for $col as ${m.scalaType}" >> {
       s"write+read $col as ${m.scalaType}" in {
-        inOut(col, a).transact(xa).unsafePerformSyncAttempt must_== \/-(a)
+        inOut(col, a).transact[Task](xa).unsafePerformSyncAttempt must_== \/-(a)
       }
       s"write+read $col as Option[${m.scalaType}] (Some)" in {
-        inOut[Option[A]](col, Some(a)).transact(xa).unsafePerformSyncAttempt must_== \/-(Some(a))
+        inOut[Option[A]](col, Some(a)).transact[Task](xa).unsafePerformSyncAttempt must_== \/-(Some(a))
       }
       s"write+read $col as Option[${m.scalaType}] (None)" in {
-        inOut[Option[A]](col, None).transact(xa).unsafePerformSyncAttempt must_== \/-(None)
+        inOut[Option[A]](col, None).transact[Task](xa).unsafePerformSyncAttempt must_== \/-(None)
       }
       s"write+read $col as Maybe[${m.scalaType}] (Just)" in {
-        inOut[Maybe[A]](col, Maybe.just(a)).transact(xa).unsafePerformSyncAttempt must_== \/-(Maybe.Just(a))
+        inOut[Maybe[A]](col, Maybe.just(a)).transact[Task](xa).unsafePerformSyncAttempt must_== \/-(Maybe.Just(a))
       }
       s"write+read $col as Maybe[${m.scalaType}] (Empty)" in {
-        inOut[Maybe[A]](col, Maybe.empty[A]).transact(xa).unsafePerformSyncAttempt must_== \/-(Maybe.Empty())
+        inOut[Maybe[A]](col, Maybe.empty[A]).transact[Task](xa).unsafePerformSyncAttempt must_== \/-(Maybe.Empty())
       }
     }
 
@@ -74,15 +74,15 @@ object h2typesspec extends Specification {
 
   "Mapping for Boolean" should {
     "pass query analysis for unascribed 'true'" in {
-      val a = sql"select true".query[Boolean].analysis.transact(xa).unsafePerformSync
+      val a = sql"select true".query[Boolean].analysis.transact[Task](xa).unsafePerformSync
       a.alignmentErrors must_== Nil
     }
     "pass query analysis for ascribed BIT" in {
-      val a = sql"select true::BIT".query[Boolean].analysis.transact(xa).unsafePerformSync
+      val a = sql"select true::BIT".query[Boolean].analysis.transact[Task](xa).unsafePerformSync
       a.alignmentErrors must_== Nil
     }
     "pass query analysis for ascribed BOOLEAN" in {
-      val a = sql"select true::BIT".query[Boolean].analysis.transact(xa).unsafePerformSync
+      val a = sql"select true::BIT".query[Boolean].analysis.transact[Task](xa).unsafePerformSync
       a.alignmentErrors must_== Nil
     }
   }

--- a/contrib/hikari/src/main/scala/doobie/contrib/hikari/HikariTransactor.scala
+++ b/contrib/hikari/src/main/scala/doobie/contrib/hikari/HikariTransactor.scala
@@ -3,38 +3,29 @@ package doobie.contrib.hikari
 import com.zaxxer.hikari.HikariDataSource
 import doobie.imports._
 
-import scalaz.{ Catchable, Monad }
-import scalaz.syntax.id._
+import scalaz.{ Catchable, Monad, Lens }
 import scalaz.syntax.monad._
 
 object hikaritransactor {
 
-  /** A `Transactor` backed by a `HikariDataSource`. */
-  final class HikariTransactor[M[_]: Monad : Catchable : Capture] private (ds: HikariDataSource) extends Transactor[M] {
+  final class HikariXA private (private val xa: LiftXA, private val ds: HikariDataSource) {
     
-    protected val connect = Capture[M].apply(ds.getConnection)
-
-    /** A program that shuts down this `HikariTransactor`. */
-    val shutdown: M[Unit] = Capture[M].apply(ds.shutdown)
+    /** A program that shuts down this `HikariXA`. */
+    def shutdown[M[_]: Capture]: M[Unit] = Capture[M].apply(ds.shutdown)
 
     /** Constructs a program that configures the underlying `HikariDataSource`. */
-    def configure(f: HikariDataSource => M[Unit]): M[Unit] = f(ds)
+    def configure[M[_]: Capture](f: HikariDataSource => M[Unit]): M[Unit] = f(ds)
 
   }
 
-  object HikariTransactor {
+  object HikariXA {
     
-    /** Constructs a program that yields an unconfigured `HikariTransactor`. */
-    def initial[M[_]: Monad : Catchable: Capture]: M[HikariTransactor[M]] = 
-      Capture[M].apply(new HikariTransactor(new HikariDataSource))
+    /** Constructs a program that yields an unconfigured `HikariXA`. */
+    def initial[M[_]: Monad : Catchable: Capture]: M[HikariXA] = 
+      Capture[M].apply(new HikariXA(LiftXA.default, new HikariDataSource))
 
-    /** Constructs a program that yields a `HikariTransactor` configured with the given info. */
-    @deprecated("doesn't load driver properly; will go away in 0.2.2; use 4-arg version", "0.2.1")
-    def apply[M[_]: Monad : Catchable : Capture](url: String, user: String, pass: String): M[HikariTransactor[M]] =
-      apply("java.lang.String", url, user, pass)
-
-    /** Constructs a program that yields a `HikariTransactor` configured with the given info. */
-    def apply[M[_]: Monad : Catchable : Capture](driverClassName: String, url: String, user: String, pass: String): M[HikariTransactor[M]] =
+    /** Constructs a program that yields a `HikariXA` configured with the given info. */
+    def apply[M[_]: Monad : Catchable : Capture](driverClassName: String, url: String, user: String, pass: String): M[HikariXA] =
       for {
         _ <- Capture[M].apply(Class.forName(driverClassName))
         t <- initial[M]
@@ -45,6 +36,18 @@ object hikaritransactor {
         })
       } yield t
 
+    /* HikariXA is a Transactor for any effect-capturing M. */
+    implicit def jdbcConnectionPool[M[_]: Monad: Catchable](implicit c: Capture[M]): Transactor[M, HikariXA] =
+      Transactor.instance[M, HikariXA](Lens.lensu((a, b) => new HikariXA(b, a.ds), _.xa), h2 => c(h2.ds.getConnection))
+
   }
+
+
+  /* JdbcConnectionPool is a Connector for any effect-capturing M. */
+  implicit def hikariDataSourceConnector[M[_]: Monad: Catchable: Capture]: Connector[M, HikariDataSource] =
+    Connector.instance(ds => Capture[M].apply(ds.getConnection))
+
+  @deprecated("Use HikariXA instead.", "0.3.0") type HikariTransactor = HikariXA
+  @deprecated("Use HikariXA instead.", "0.3.0") val  HikariTransactor = HikariXA
 
 }

--- a/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgcopy.scala
+++ b/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgcopy.scala
@@ -11,7 +11,7 @@ import scalaz._, Scalaz._, scalaz.concurrent.Task
 
 object pgcopyspec extends Specification {
 
-  val xa = DriverManagerTransactor[Task](
+  val xa = DriverManagerTransactor(
     "org.postgresql.Driver",
     "jdbc:postgresql:world",
     "postgres", ""
@@ -46,7 +46,7 @@ object pgcopyspec extends Specification {
           _   <- PHC.pgGetCopyAPI(PFCM.copyOut(query, out))
         } yield new String(out.toByteArray, "UTF-8")
 
-      prog.transact(xa).unsafePerformSync must_== fixture
+      prog.transact[Task](xa).unsafePerformSync must_== fixture
 
     }
     

--- a/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pglargeobject.scala
+++ b/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pglargeobject.scala
@@ -12,7 +12,7 @@ import scalaz._, Scalaz._, scalaz.concurrent.Task
 
 object pglargeobjectspec extends Specification with FileEquality {
 
-  val xa = DriverManagerTransactor[Task](
+  val xa = DriverManagerTransactor(
     "org.postgresql.Driver",
     "jdbc:postgresql:world",
     "postgres", ""
@@ -26,7 +26,7 @@ object pglargeobjectspec extends Specification with FileEquality {
       val prog = PHLOM.createLOFromFile(1024 * 16, in) >>= { oid =>
         PHLOM.createFileFromLO(1024 * 16, oid, out) >> PHLOM.delete(oid)
       }
-      PHC.pgGetLargeObjectAPI(prog).transact(xa).unsafePerformSync
+      PHC.pgGetLargeObjectAPI(prog).transact[Task](xa).unsafePerformSync
       filesEqual(in, out)
     }
 

--- a/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgnotify.scala
+++ b/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgnotify.scala
@@ -12,7 +12,7 @@ object pgnotifyspec extends Specification {
 
   import FC.{commit, delay}
 
-  val xa = DriverManagerTransactor[Task](
+  val xa = DriverManagerTransactor(
     "org.postgresql.Driver",
     "jdbc:postgresql:world",
     "postgres", ""
@@ -22,9 +22,9 @@ object pgnotifyspec extends Specification {
   def listen[A](channel: String, notify: ConnectionIO[A]): Task[List[PGNotification]] =
     (PHC.pgListen(channel) >> commit >>
      delay { Thread.sleep(50) } >>
-     Capture[ConnectionIO].apply(notify.transact(xa).unsafePerformSync) >>
+     Capture[ConnectionIO].apply(notify.transact[Task](xa).unsafePerformSync) >>
      delay { Thread.sleep(50) } >>
-     PHC.pgGetNotifications).transact(xa)
+     PHC.pgGetNotifications).transact[Task](xa)
 
   "LISTEN/NOTIFY" should {
 

--- a/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgtypes.scala
+++ b/contrib/postgresql/src/test/scala/doobie/contrib/postgresql/pgtypes.scala
@@ -18,7 +18,7 @@ import scalaz.{ Maybe, \/- }
 // Establish that we can write and read various types.
 object pgtypesspec extends Specification {
 
-  val xa = DriverManagerTransactor[Task](
+  val xa = DriverManagerTransactor(
     "org.postgresql.Driver",
     "jdbc:postgresql:world",
     "postgres", ""
@@ -33,26 +33,26 @@ object pgtypesspec extends Specification {
   def testInOut[A](col: String, a: A)(implicit m: Meta[A]) =
     s"Mapping for $col as ${m.scalaType}" >> {
       s"write+read $col as ${m.scalaType}" in {
-        inOut(col, a).transact(xa).unsafePerformSyncAttempt must_== \/-(a)
+        inOut(col, a).transact[Task](xa).unsafePerformSyncAttempt must_== \/-(a)
       }
       s"write+read $col as Option[${m.scalaType}] (Some)" in {
-        inOut[Option[A]](col, Some(a)).transact(xa).unsafePerformSyncAttempt must_== \/-(Some(a))
+        inOut[Option[A]](col, Some(a)).transact[Task](xa).unsafePerformSyncAttempt must_== \/-(Some(a))
       }
       s"write+read $col as Option[${m.scalaType}] (None)" in {
-        inOut[Option[A]](col, None).transact(xa).unsafePerformSyncAttempt must_== \/-(None)
+        inOut[Option[A]](col, None).transact[Task](xa).unsafePerformSyncAttempt must_== \/-(None)
       }
       s"write+read $col as Maybe[${m.scalaType}] (Just)" in {
-        inOut[Maybe[A]](col, Maybe.just(a)).transact(xa).unsafePerformSyncAttempt must_== \/-(Maybe.Just(a))
+        inOut[Maybe[A]](col, Maybe.just(a)).transact[Task](xa).unsafePerformSyncAttempt must_== \/-(Maybe.Just(a))
       }
       s"write+read $col as Maybe[${m.scalaType}] (Empty)" in {
-        inOut[Maybe[A]](col, Maybe.empty[A]).transact(xa).unsafePerformSyncAttempt must_== \/-(Maybe.Empty())
+        inOut[Maybe[A]](col, Maybe.empty[A]).transact[Task](xa).unsafePerformSyncAttempt must_== \/-(Maybe.Empty())
       }
     }
 
   def testInOutNN[A](col: String, a: A)(implicit m: Atom[A]) =
     s"Mapping for $col as ${m.meta._1.scalaType}" >> {
       s"write+read $col as ${m.meta._1.scalaType}" in {
-        inOut(col, a).transact(xa).unsafePerformSyncAttempt must_== \/-(a)
+        inOut(col, a).transact[Task](xa).unsafePerformSyncAttempt must_== \/-(a)
       }
     }
 

--- a/contrib/specs2/src/main/scala/doobie/contrib/specs2/specs2.scala
+++ b/contrib/specs2/src/main/scala/doobie/contrib/specs2/specs2.scala
@@ -2,9 +2,7 @@ package doobie.contrib.specs2
 
 import doobie.free.connection.ConnectionIO
 
-import doobie.util.transactor._
-import doobie.util.query._
-import doobie.util.update._
+import doobie.imports._
 import doobie.util.analysis._
 import doobie.util.pretty._
 
@@ -21,14 +19,16 @@ import scalaz._, Scalaz._
  * Module with a mix-in trait for specifications that enables checking of doobie `Query` and `Update` values.
  * {{{
  * // An example specification, taken from the examples project.
- * object AnalysisTestSpec extends Specification with AnalysisSpec {
+ * object AnalysisTestSpec extends Specification with AnalysisSpec[DriverManagerTransactor] {
  *
  *   // The transactor to use for the tests.
- *   val transactor = DriverManagerTransactor[Task](
+ *   val transactor = DriverManagerTransactor(
  *     "org.postgresql.Driver", 
  *     "jdbc:postgresql:world", 
  *     "postgres", ""
  *   )
+ *
+ *   val ev = implicitly
  *
  *   // Now just mention the queries. Arguments are not used.
  *   check(MyDaoModule.findByNameAndAge(null, 0))
@@ -39,9 +39,11 @@ import scalaz._, Scalaz._
  */
 object analysisspec {
 
-  trait AnalysisSpec { this: Specification =>
+  trait AnalysisSpec[T] { this: Specification =>
 
-    def transactor: Transactor[Task]
+    def transactor: T
+
+    implicit def ev: Transactor[Task, T]
 
     def check[A, B](q: Query[A, B])(implicit A: TypeTag[A], B: TypeTag[B]) =
       checkAnalysis(s"Query[${typeName(A)}, ${typeName(B)}]", q.stackFrame, q.sql, q.analysis)
@@ -60,7 +62,7 @@ object analysisspec {
 
     private def checkAnalysis(typeName: String, stackFrame: Option[StackTraceElement], sql: String, analysis: ConnectionIO[Analysis]) =
       s"$typeName defined at ${loc(stackFrame)}\n${sql.lines.map(s => "  " + s.trim).filterNot(_.isEmpty).mkString("\n")}" >> {
-        transactor.trans(analysis).unsafePerformSyncAttempt match {
+        analysis.transact[Task](transactor).unsafePerformSyncAttempt match {
           case -\/(e) => Fragments("SQL Compiles and Typechecks" in failure(formatError(e.getMessage)))
           case \/-(a) => Fragments("SQL Compiles and Typechecks" in ok)
             Fragments.foreach(a.paramDescriptions)  { case (s, es) => s in assertEmpty(es, stackFrame) }

--- a/core/src/main/scala/doobie/imports.scala
+++ b/core/src/main/scala/doobie/imports.scala
@@ -78,7 +78,11 @@ object imports extends ToDoobieCatchSqlOps with ToDoobieCatchableOps {
 
   /** @group Syntax */
   implicit def toMoreConnectionIOOps[A](ma: ConnectionIO[A]) =
-    new doobie.syntax.connectionio.MoreConnectionIOOps(ma)
+    new doobie.util.connector.ConnectionIOConnectorOps(ma)
+
+  /** @group Syntax */
+  implicit def toEvenMoreConnectionIOOps[A](ma: ConnectionIO[A]) =
+    new doobie.util.transactor.ConnectionIOTransactorOps(ma)
 
   /** @group Type Aliases */      type Meta[A] = doobie.util.meta.Meta[A]
   /** @group Companion Aliases */ val  Meta    = doobie.util.meta.Meta
@@ -110,10 +114,12 @@ object imports extends ToDoobieCatchSqlOps with ToDoobieCatchableOps {
   /** @group Type Aliases */      type Param[A] = doobie.syntax.string.Param[A]
   /** @group Companion Aliases */ val  Param    = doobie.syntax.string.Param
 
-  /** @group Type Aliases */ type Transactor[M[_]] = doobie.util.transactor.Transactor[M]
+  /** @group Type Aliases */ type Transactor[M[_], A] = doobie.util.transactor.Transactor[M, A]
 
-  /** @group Companion Aliases */ val DriverManagerTransactor = doobie.util.transactor.DriverManagerTransactor
-  /** @group Companion Aliases */ val DataSourceTransactor = doobie.util.transactor.DataSourceTransactor
+  /** @group Type Aliases */ type DriverManagerTransactor = doobie.util.drivermanager.DriverManagerXA
+  /** @group Companion Aliases */ val DriverManagerTransactor = doobie.util.drivermanager.DriverManagerXA
+
+  // /** @group Companion Aliases */ val DataSourceTransactor = doobie.util.transactor.DataSourceTransactor
 
 
   /** @group Typeclass Instances */

--- a/core/src/main/scala/doobie/imports.scala
+++ b/core/src/main/scala/doobie/imports.scala
@@ -114,10 +114,17 @@ object imports extends ToDoobieCatchSqlOps with ToDoobieCatchableOps {
   /** @group Type Aliases */      type Param[A] = doobie.syntax.string.Param[A]
   /** @group Companion Aliases */ val  Param    = doobie.syntax.string.Param
 
-  /** @group Type Aliases */ type Transactor[M[_], A] = doobie.util.transactor.Transactor[M, A]
+  /** @group Type Aliases */      type Transactor[M[_], A] = doobie.util.transactor.Transactor[M, A]
+  /** @group Companion Aliases */ val  Transactor = doobie.util.transactor.Transactor
 
-  /** @group Type Aliases */ type DriverManagerTransactor = doobie.util.drivermanager.DriverManagerXA
-  /** @group Companion Aliases */ val DriverManagerTransactor = doobie.util.drivermanager.DriverManagerXA
+  /** @group Type Aliases */      type Connector[M[_], A] = doobie.util.connector.Connector[M, A]
+  /** @group Companion Aliases */ val  Connector = doobie.util.connector.Connector
+
+  /** @group Type Aliases */      type DriverManagerTransactor = doobie.util.drivermanager.DriverManagerXA
+  /** @group Companion Aliases */ val  DriverManagerTransactor = doobie.util.drivermanager.DriverManagerXA
+
+  /** @group Type Aliases */      type LiftXA = doobie.util.liftxa.LiftXA
+  /** @group Companion Aliases */ val  LiftXA = doobie.util.liftxa.LiftXA
 
   // /** @group Companion Aliases */ val DataSourceTransactor = doobie.util.transactor.DataSourceTransactor
 

--- a/core/src/main/scala/doobie/imports.scala
+++ b/core/src/main/scala/doobie/imports.scala
@@ -84,6 +84,10 @@ object imports extends ToDoobieCatchSqlOps with ToDoobieCatchableOps {
   implicit def toEvenMoreConnectionIOOps[A](ma: ConnectionIO[A]) =
     new doobie.syntax.connectionio.ConnectionIOTransactorOps(ma)
 
+  /** @group Syntax */
+  implicit def toTransactorOps[A](a: A) =
+    new doobie.syntax.transactor.TransactorOps(a)
+
   /** @group Type Aliases */      type Meta[A] = doobie.util.meta.Meta[A]
   /** @group Companion Aliases */ val  Meta    = doobie.util.meta.Meta
 
@@ -126,7 +130,8 @@ object imports extends ToDoobieCatchSqlOps with ToDoobieCatchableOps {
   /** @group Type Aliases */      type LiftXA = doobie.util.liftxa.LiftXA
   /** @group Companion Aliases */ val  LiftXA = doobie.util.liftxa.LiftXA
 
-  // /** @group Companion Aliases */ val DataSourceTransactor = doobie.util.transactor.DataSourceTransactor
+  /** @group Type Aliases */      type DataSourceTransactor = doobie.util.datasource.DataSourceTransactor
+  /** @group Companion Aliases */ val  DataSourceTransactor = doobie.util.datasource.DataSourceTransactor
 
 
   /** @group Typeclass Instances */

--- a/core/src/main/scala/doobie/imports.scala
+++ b/core/src/main/scala/doobie/imports.scala
@@ -78,11 +78,11 @@ object imports extends ToDoobieCatchSqlOps with ToDoobieCatchableOps {
 
   /** @group Syntax */
   implicit def toMoreConnectionIOOps[A](ma: ConnectionIO[A]) =
-    new doobie.util.connector.ConnectionIOConnectorOps(ma)
+    new doobie.syntax.connectionio.ConnectionIOConnectorOps(ma)
 
   /** @group Syntax */
   implicit def toEvenMoreConnectionIOOps[A](ma: ConnectionIO[A]) =
-    new doobie.util.transactor.ConnectionIOTransactorOps(ma)
+    new doobie.syntax.connectionio.ConnectionIOTransactorOps(ma)
 
   /** @group Type Aliases */      type Meta[A] = doobie.util.meta.Meta[A]
   /** @group Companion Aliases */ val  Meta    = doobie.util.meta.Meta

--- a/core/src/main/scala/doobie/syntax/connectionio.scala
+++ b/core/src/main/scala/doobie/syntax/connectionio.scala
@@ -2,12 +2,40 @@ package doobie.syntax
 
 import doobie.free.connection.ConnectionIO
 import doobie.util.transactor.Transactor
+import doobie.util.connector.Connector
 
 object connectionio {
 
-  // implicit class MoreConnectionIOOps[A](ma: ConnectionIO[A]) {
-  //   def transact[M[_]](xa: Transactor[M]): M[A] =
-  //     xa.trans(ma)
-  // }
+  implicit class ConnectionIOConnectorOps[A](ma: ConnectionIO[A]) {
+
+    class Helper[M[_]] {
+      def apply[T](t: T)(implicit ev1: Connector[M, T]): M[A] =
+        Connector.trans(t).apply(ma)
+    }
+
+    /** 
+     * Interpret this program unmodified, into effect-capturing target monad `M`, running on a 
+     * dedicated `Connection`.
+     */
+    def connect[M[_]] = new Helper[M]
+
+  }
+
+
+  /** Syntax that adds `Transactor` operations to `ConnectionIO`. */
+  implicit class ConnectionIOTransactorOps[A](ma: ConnectionIO[A]) {
+
+    final class Helper[M[_]] {
+      def apply[T](t: T)(implicit ev1: Transactor[M, T]): M[A] =
+        Connector.trans(t).apply(Transactor.safe(t)(ma))
+    }
+
+    /** 
+     * Interpret this program configured with transaction logic as defined by the `Transactor`'s
+     * `LiftXA`, into effect-capturing target monad `M`, running on a dedicated `Connection`. 
+     */
+    def transact[M[_]] = new Helper[M]
+
+  }
 
 }

--- a/core/src/main/scala/doobie/syntax/connectionio.scala
+++ b/core/src/main/scala/doobie/syntax/connectionio.scala
@@ -27,7 +27,7 @@ object connectionio {
 
     final class Helper[M[_]] {
       def apply[T](t: T)(implicit ev1: Transactor[M, T]): M[A] =
-        Connector.trans(t).apply(Transactor.safe(t)(ma))
+        Transactor.safeTrans(t).apply(ma)
     }
 
     /** 

--- a/core/src/main/scala/doobie/syntax/connectionio.scala
+++ b/core/src/main/scala/doobie/syntax/connectionio.scala
@@ -5,9 +5,9 @@ import doobie.util.transactor.Transactor
 
 object connectionio {
 
-  implicit class MoreConnectionIOOps[A](ma: ConnectionIO[A]) {
-    def transact[M[_]](xa: Transactor[M]): M[A] =
-      xa.trans(ma)
-  }
+  // implicit class MoreConnectionIOOps[A](ma: ConnectionIO[A]) {
+  //   def transact[M[_]](xa: Transactor[M]): M[A] =
+  //     xa.trans(ma)
+  // }
 
 }

--- a/core/src/main/scala/doobie/syntax/process.scala
+++ b/core/src/main/scala/doobie/syntax/process.scala
@@ -24,8 +24,8 @@ object process {
     def sink(f: A => F[Unit]): F[Unit] =     
       fa.to(doobie.util.process.sink(f)).run
 
-    def transact[M[_]](xa: Transactor[M])(implicit ev: Process[F, A] =:= Process[ConnectionIO, A]): Process[M, A] =
-      xa.transP(fa)
+    // def transact[M[_]](xa: Transactor[M])(implicit ev: Process[F, A] =:= Process[ConnectionIO, A]): Process[M, A] =
+    //   xa.transP(fa)
 
   }
 

--- a/core/src/main/scala/doobie/syntax/process.scala
+++ b/core/src/main/scala/doobie/syntax/process.scala
@@ -24,8 +24,16 @@ object process {
     def sink(f: A => F[Unit]): F[Unit] =     
       fa.to(doobie.util.process.sink(f)).run
 
-    // def transact[M[_]](xa: Transactor[M])(implicit ev: Process[F, A] =:= Process[ConnectionIO, A]): Process[M, A] =
-    //   xa.transP(fa)
+    def transact[M[_]]: TransactPartiallyApplied[M] =
+      new TransactPartiallyApplied[M]
+
+    class TransactPartiallyApplied[M[_]] {
+      def apply[T](t: T)(
+        implicit ev0: Process[F, A] =:= Process[ConnectionIO, A],
+                 ev1: Transactor[M, T]
+      ): Process[M, A] =
+        Transactor.safeTransP(t).apply(fa)
+    }
 
   }
 

--- a/core/src/main/scala/doobie/syntax/transactor.scala
+++ b/core/src/main/scala/doobie/syntax/transactor.scala
@@ -1,0 +1,13 @@
+package doobie.syntax
+
+import doobie.util.transactor.Transactor
+import doobie.util.yolo.Yolo
+
+object transactor {
+
+  class TransactorOps[A](a: A) {
+    def yolo[M[_]](implicit ev: Transactor[M, A]): Yolo[M, A] =
+      new Yolo(a)
+  }
+
+}

--- a/core/src/main/scala/doobie/util/connection.scala
+++ b/core/src/main/scala/doobie/util/connection.scala
@@ -1,0 +1,15 @@
+package doobie.util
+
+import doobie.util.capture.Capture
+import doobie.util.connector.Connector
+
+import scalaz.{ Monad, Catchable }
+
+import java.sql.Connection
+
+object connection {
+
+  implicit def connectionConnector[M[_]: Monad: Capture: Catchable]: Connector[M, Connection] =
+    Connector.instance(Monad[M].point(_))
+
+}

--- a/core/src/main/scala/doobie/util/connection.scala
+++ b/core/src/main/scala/doobie/util/connection.scala
@@ -7,8 +7,10 @@ import scalaz.{ Monad, Catchable }
 
 import java.sql.Connection
 
+/** Typeclass instances for `java.sql.Connection`. */
 object connection {
 
+  /** @group Typeclass Instances */
   implicit def connectionConnector[M[_]: Monad: Capture: Catchable]: Connector[M, Connection] =
     Connector.instance(Monad[M].point(_))
 

--- a/core/src/main/scala/doobie/util/connector.scala
+++ b/core/src/main/scala/doobie/util/connector.scala
@@ -51,29 +51,6 @@ object connector {
           }
       }
 
-    /** A raw `DataSource` is a `Connector`. */
-    implicit def dataSourceConnector[M[_]: Monad: Capture: Catchable]: Connector[M, javax.sql.DataSource] =
-      instance(ds => Capture[M].apply(ds.getConnection))
-
-    /** A raw `Connection` is a `Connector`. */
-    implicit def connectionConnector[M[_]: Monad: Capture: Catchable]: Connector[M, Connection] =
-      instance(_.point[M])
-
-  }
-
-  implicit class ConnectionIOConnectorOps[A](ma: ConnectionIO[A]) {
-
-    class Helper[M[_]] {
-      def apply[T](t: T)(implicit ev1: Connector[M, T]): M[A] =
-        Connector.trans(t).apply(ma)
-    }
-
-    /** 
-     * Interpret this program unmodified, into effect-capturing target monad `M`, running on a 
-     * dedicated `Connection`.
-     */
-    def connect[M[_]] = new Helper[M]
-
   }
 
 }

--- a/core/src/main/scala/doobie/util/connector.scala
+++ b/core/src/main/scala/doobie/util/connector.scala
@@ -1,0 +1,173 @@
+package doobie.util
+
+import doobie.imports.{ Capture, ConnectionIO, toDoobieCatchableOps, toProcessOps, HC, FC }
+import doobie.imports.HC.delay
+
+import doobie.hi.connection.ProcessConnectionIOOps // TODO: add to imports module
+
+import scalaz.{ Monad, Catchable, Kleisli, ~>, @>, |-->, Lens }
+import scalaz.syntax.monad._
+import scalaz.stream.Process
+import scalaz.stream.Process.{ eval, eval_, halt }
+
+import java.sql.Connection
+
+object connector {
+
+  /** 
+   * Configuration for a connector; these actions are used by a connector's `safe` method to take
+   * an existing `ConnectionIO` and equip it to execute as a transaction.
+   */ 
+  final case class Config(
+    before:  ConnectionIO[Unit],
+    oops:    ConnectionIO[Unit],
+    after:   ConnectionIO[Unit],
+    always:  ConnectionIO[Unit]
+  )
+  object Config {
+
+    val default = Config(
+      FC.setAutoCommit(false),
+      FC.rollback,
+      FC.commit,
+      FC.close
+    )
+
+    // Lenses
+    val before: Config @> ConnectionIO[Unit] = Lens.lensu((a, b) => a.copy(before = b), _.before)
+    val oops:   Config @> ConnectionIO[Unit] = Lens.lensu((a, b) => a.copy(oops   = b), _.oops)
+    val after:  Config @> ConnectionIO[Unit] = Lens.lensu((a, b) => a.copy(after  = b), _.after)
+    val always: Config @> ConnectionIO[Unit] = Lens.lensu((a, b) => a.copy(always = b), _.always)
+
+  }
+
+  /** 
+   * Typeclass for data types that can carry a `Config` and can provide a `Connection` in any given
+   * effect-capturing monad.
+   */
+  trait Connector[T] {
+    def config: T @> Config
+    def connect[M[_]: Monad: Capture: Catchable](xa: T): M[Connection]
+  }
+
+  object Connector {
+
+    // Lenses
+    def config[T](implicit ev: Connector[T]) = ev.config
+    def before[T: Connector] = config[T] >=> Config.before
+    def oops  [T: Connector] = config[T] >=> Config.oops
+    def after [T: Connector] = config[T] >=> Config.after
+    def always[T: Connector] = config[T] >=> Config.always
+
+    /** Program yielding a Connection in the given monad. */
+    def connect[M[_]: Monad: Catchable: Capture, T](t: T)(implicit ev: Connector[T]): M[Connection] =
+      ev.connect[M](t)
+
+    /** Wrap a `ConnectionIO` in before/after/oops/always logic. */
+    def safe[T: Connector, A](t: T)(ma: ConnectionIO[A]): ConnectionIO[A] =
+      (before[T].get(t) *> ma <* after[T].get(t)) onException oops[T].get(t) ensuring always[T].get(t)
+
+    /** Wrap a `Process[ConnectionIO, ?]` in before/after/oops/always logic. */
+    def safeP[T: Connector, A](t: T)(pa: Process[ConnectionIO, A]): Process[ConnectionIO, A] =
+      (eval_(before[T].get(t)) ++ pa ++ eval_(after[T].get(t))) onFailure { e => 
+        eval_(oops[T].get(t)) ++ eval_(delay(throw e)) 
+      } onComplete eval_(always[T].get(t))
+
+    /** Natural transformation to target monad `M`. */
+    def trans[M[_]: Monad: Catchable: Capture, T: Connector](t: T): (ConnectionIO ~> M) =
+      new (ConnectionIO ~> M) {        
+        def apply[A](ma: ConnectionIO[A]) = 
+          connect(t) >>= ma.transK[M]      
+      }
+
+    /** Natural transformation to an equivalent process over target monad `M`. */
+    def transP[M[_]: Monad: Catchable: Capture, T: Connector](t: T): (Process[ConnectionIO, ?] ~> Process[M, ?]) =
+      new (Process[ConnectionIO, ?] ~> Process[M, ?]) {
+        def apply[A](pa: Process[ConnectionIO, A]) = 
+          eval(connect(t)) >>= pa.trans[M]    
+      }
+
+  }
+
+  /** Syntax for `Connector`s. */
+  implicit class ConnectorOps[T: Connector](t: T) {
+
+    // Stores
+    def before = Connector.before[T].apply(t)
+    def oops   = Connector.oops[T].apply(t)
+    def after  = Connector.after[T].apply(t)
+    def always = Connector.always[T].apply(t)
+
+    /** Wrap a `ConnectionIO` in before/after/oops/always logic. */
+    def safe[A](ma: ConnectionIO[A]): ConnectionIO[A] =
+      Connector.safe(t)(ma)
+
+    /** Natural transformation to target monad `M`. */
+    def trans[M[_]: Monad: Catchable: Capture]: (ConnectionIO ~> M) = 
+      Connector.trans(t)
+
+    /** Natural transformation to an equivalent process over target monad `M`. */
+    def transP[M[_]: Monad: Catchable: Capture]: (Process[ConnectionIO, ?] ~> Process[M, ?]) =
+      Connector.transP(t)
+
+  }
+
+  /** Syntax that adds `Connector` operations to `ConnectionIO`. */
+  implicit class ConnectionIOConnectorOps[A](ma: ConnectionIO[A]) {
+
+    final class Helper[M[_]](safe: Boolean) {
+      def apply[T: Connector](t: T)(implicit ev1: Monad[M], ev2: Capture[M], ev3: Catchable[M]) =
+        t.trans.apply(if (safe) t.safe(ma) else ma)
+    }
+
+    /** 
+     * Interpret this program unmodified, into effect-capturing target monad `M`, running on a 
+     * dedicated `Connection`.
+     */
+    def connect[M[_]]  = new Helper[M](false)
+
+    /** 
+     * Interpret this program configured with transaction logic as defined by the connector's
+     * `Config`, into effect-capturing target monad `M`, running on a dedicated `Connection`. 
+     */
+    def transact[M[_]] = new Helper[M](true)
+
+  }
+
+
+
+  // Driver manager
+
+  import doobie.free.{ drivermanager => HDM }
+  import HDM.DriverManagerIO
+
+  case class DriverManagerConnector(config: Config, connect: DriverManagerIO[Connection])
+
+  object DriverManagerConnector {
+
+    implicit object Instance extends Connector[DriverManagerConnector] {
+      def config: DriverManagerConnector @> Config = 
+        Lens.lensu((a, b) => a.copy(config = b), _.config)
+      def connect[M[_]: Monad: Capture: Catchable](xa: DriverManagerConnector): M[Connection] =
+        xa.connect.trans[M]
+    }
+
+    private def create(driver: String, conn: DriverManagerIO[Connection]): DriverManagerConnector =
+      DriverManagerConnector(Config.default, HDM.delay(Class.forName(driver)) *> conn)
+
+    def apply(driver: String, url: String): DriverManagerConnector =
+      create(driver, HDM.getConnection(url))
+
+    def apply(driver: String, url: String, user: String, pass: String): DriverManagerConnector =
+      create(driver, HDM.getConnection(url, user, pass))
+
+    def apply(driver: String, url: String, info: java.util.Properties): DriverManagerConnector =
+      create(driver, HDM.getConnection(url, info))
+
+  }
+
+
+
+}
+
+

--- a/core/src/main/scala/doobie/util/connector.scala
+++ b/core/src/main/scala/doobie/util/connector.scala
@@ -1,172 +1,80 @@
 package doobie.util
 
-import doobie.imports.{ Capture, ConnectionIO, toDoobieCatchableOps, toProcessOps, HC, FC }
-import doobie.imports.HC.delay
+import doobie.util.capture.Capture
+import doobie.free.connection.ConnectionIO
+import doobie.hi.connection.ProcessConnectionIOOps
 
-import doobie.hi.connection.ProcessConnectionIOOps // TODO: add to imports module
-
-import scalaz.{ Monad, Catchable, Kleisli, ~>, @>, |-->, Lens }
+import scalaz.{ Monad, Catchable, ~> }
 import scalaz.syntax.monad._
 import scalaz.stream.Process
-import scalaz.stream.Process.{ eval, eval_, halt }
+import scalaz.stream.Process.eval
 
 import java.sql.Connection
 
 object connector {
 
   /** 
-   * Configuration for a connector; these actions are used by a connector's `safe` method to take
-   * an existing `ConnectionIO` and equip it to execute as a transaction.
-   */ 
-  final case class Config(
-    before:  ConnectionIO[Unit],
-    oops:    ConnectionIO[Unit],
-    after:   ConnectionIO[Unit],
-    always:  ConnectionIO[Unit]
-  )
-  object Config {
-
-    val default = Config(
-      FC.setAutoCommit(false),
-      FC.rollback,
-      FC.commit,
-      FC.close
-    )
-
-    // Lenses
-    val before: Config @> ConnectionIO[Unit] = Lens.lensu((a, b) => a.copy(before = b), _.before)
-    val oops:   Config @> ConnectionIO[Unit] = Lens.lensu((a, b) => a.copy(oops   = b), _.oops)
-    val after:  Config @> ConnectionIO[Unit] = Lens.lensu((a, b) => a.copy(after  = b), _.after)
-    val always: Config @> ConnectionIO[Unit] = Lens.lensu((a, b) => a.copy(always = b), _.always)
-
-  }
-
-  /** 
-   * Typeclass for data types that can carry a `Config` and can provide a `Connection` in any given
-   * effect-capturing monad.
+   * Typeclass for data types that can provide `Connection`s in some context `M`, giving rise to
+   * natural transformations from `ConnectionIO` and its `Process` type to their twins in `M`.
    */
-  trait Connector[T] {
-    def config: T @> Config
-    def connect[M[_]: Monad: Capture: Catchable](xa: T): M[Connection]
+  trait Connector[M[_], A] {
+    def connect(a:A): M[Connection]
+    def trans(a: A): ConnectionIO ~> M
+    def transP(a: A): Process[ConnectionIO, ?] ~> Process[M, ?]
   }
 
   object Connector {
 
-    // Lenses
-    def config[T](implicit ev: Connector[T]) = ev.config
-    def before[T: Connector] = config[T] >=> Config.before
-    def oops  [T: Connector] = config[T] >=> Config.oops
-    def after [T: Connector] = config[T] >=> Config.after
-    def always[T: Connector] = config[T] >=> Config.always
-
-    /** Program yielding a Connection in the given monad. */
-    def connect[M[_]: Monad: Catchable: Capture, T](t: T)(implicit ev: Connector[T]): M[Connection] =
-      ev.connect[M](t)
-
-    /** Wrap a `ConnectionIO` in before/after/oops/always logic. */
-    def safe[T: Connector, A](t: T)(ma: ConnectionIO[A]): ConnectionIO[A] =
-      (before[T].get(t) *> ma <* after[T].get(t)) onException oops[T].get(t) ensuring always[T].get(t)
-
-    /** Wrap a `Process[ConnectionIO, ?]` in before/after/oops/always logic. */
-    def safeP[T: Connector, A](t: T)(pa: Process[ConnectionIO, A]): Process[ConnectionIO, A] =
-      (eval_(before[T].get(t)) ++ pa ++ eval_(after[T].get(t))) onFailure { e => 
-        eval_(oops[T].get(t)) ++ eval_(delay(throw e)) 
-      } onComplete eval_(always[T].get(t))
+    /** Program yielding a Connection in the given effect-capturing monad. */
+    def connect[M[_], T](t: T)(implicit ev: Connector[M, T]): M[Connection] =
+      ev.connect(t)
 
     /** Natural transformation to target monad `M`. */
-    def trans[M[_]: Monad: Catchable: Capture, T: Connector](t: T): (ConnectionIO ~> M) =
-      new (ConnectionIO ~> M) {        
-        def apply[A](ma: ConnectionIO[A]) = 
-          connect(t) >>= ma.transK[M]      
-      }
+    def trans[M[_], T](t: T)(implicit ev: Connector[M, T]): (ConnectionIO ~> M) =
+      ev.trans(t)
 
     /** Natural transformation to an equivalent process over target monad `M`. */
-    def transP[M[_]: Monad: Catchable: Capture, T: Connector](t: T): (Process[ConnectionIO, ?] ~> Process[M, ?]) =
-      new (Process[ConnectionIO, ?] ~> Process[M, ?]) {
-        def apply[A](pa: Process[ConnectionIO, A]) = 
-          eval(connect(t)) >>= pa.trans[M]    
+    def transP[M[_], T](t: T)(implicit ev: Connector[M, T]): (Process[ConnectionIO, ?] ~> Process[M, ?]) =
+      ev.transP(t)
+
+    /** Construct a default instance, given some constraints on M. */
+    def instance[M[_]: Monad: Capture: Catchable, A](f: A => M[Connection]): Connector[M, A] =
+      new Connector[M, A] {
+        def connect(a: A): M[Connection] = f(a)
+        def trans(a: A): ConnectionIO ~> M =
+          new (ConnectionIO ~> M) {        
+            def apply[B](ma: ConnectionIO[B]) = connect(a) >>= ma.transK[M]      
+          }
+        def transP(a: A): Process[ConnectionIO, ?] ~> Process[M, ?] =
+          new (Process[ConnectionIO, ?] ~> Process[M, ?]) {
+            def apply[B](pa: Process[ConnectionIO, B]) = eval(connect(a)) >>= pa.trans[M]    
+          }
       }
+
+    /** A raw `DataSource` is a `Connector`. */
+    implicit def dataSourceConnector[M[_]: Monad: Capture: Catchable]: Connector[M, javax.sql.DataSource] =
+      instance(ds => Capture[M].apply(ds.getConnection))
+
+    /** A raw `Connection` is a `Connector`. */
+    implicit def connectionConnector[M[_]: Monad: Capture: Catchable]: Connector[M, Connection] =
+      instance(_.point[M])
 
   }
 
-  /** Syntax for `Connector`s. */
-  implicit class ConnectorOps[T: Connector](t: T) {
-
-    // Stores
-    def before = Connector.before[T].apply(t)
-    def oops   = Connector.oops[T].apply(t)
-    def after  = Connector.after[T].apply(t)
-    def always = Connector.always[T].apply(t)
-
-    /** Wrap a `ConnectionIO` in before/after/oops/always logic. */
-    def safe[A](ma: ConnectionIO[A]): ConnectionIO[A] =
-      Connector.safe(t)(ma)
-
-    /** Natural transformation to target monad `M`. */
-    def trans[M[_]: Monad: Catchable: Capture]: (ConnectionIO ~> M) = 
-      Connector.trans(t)
-
-    /** Natural transformation to an equivalent process over target monad `M`. */
-    def transP[M[_]: Monad: Catchable: Capture]: (Process[ConnectionIO, ?] ~> Process[M, ?]) =
-      Connector.transP(t)
-
-  }
-
-  /** Syntax that adds `Connector` operations to `ConnectionIO`. */
   implicit class ConnectionIOConnectorOps[A](ma: ConnectionIO[A]) {
 
-    final class Helper[M[_]](safe: Boolean) {
-      def apply[T: Connector](t: T)(implicit ev1: Monad[M], ev2: Capture[M], ev3: Catchable[M]) =
-        t.trans.apply(if (safe) t.safe(ma) else ma)
+    class Helper[M[_]] {
+      def apply[T](t: T)(implicit ev1: Connector[M, T]): M[A] =
+        Connector.trans(t).apply(ma)
     }
 
     /** 
      * Interpret this program unmodified, into effect-capturing target monad `M`, running on a 
      * dedicated `Connection`.
      */
-    def connect[M[_]]  = new Helper[M](false)
-
-    /** 
-     * Interpret this program configured with transaction logic as defined by the connector's
-     * `Config`, into effect-capturing target monad `M`, running on a dedicated `Connection`. 
-     */
-    def transact[M[_]] = new Helper[M](true)
+    def connect[M[_]] = new Helper[M]
 
   }
-
-
-
-  // Driver manager
-
-  import doobie.free.{ drivermanager => HDM }
-  import HDM.DriverManagerIO
-
-  case class DriverManagerConnector(config: Config, connect: DriverManagerIO[Connection])
-
-  object DriverManagerConnector {
-
-    implicit object Instance extends Connector[DriverManagerConnector] {
-      def config: DriverManagerConnector @> Config = 
-        Lens.lensu((a, b) => a.copy(config = b), _.config)
-      def connect[M[_]: Monad: Capture: Catchable](xa: DriverManagerConnector): M[Connection] =
-        xa.connect.trans[M]
-    }
-
-    private def create(driver: String, conn: DriverManagerIO[Connection]): DriverManagerConnector =
-      DriverManagerConnector(Config.default, HDM.delay(Class.forName(driver)) *> conn)
-
-    def apply(driver: String, url: String): DriverManagerConnector =
-      create(driver, HDM.getConnection(url))
-
-    def apply(driver: String, url: String, user: String, pass: String): DriverManagerConnector =
-      create(driver, HDM.getConnection(url, user, pass))
-
-    def apply(driver: String, url: String, info: java.util.Properties): DriverManagerConnector =
-      create(driver, HDM.getConnection(url, info))
-
-  }
-
-
 
 }
 

--- a/core/src/main/scala/doobie/util/datasource.scala
+++ b/core/src/main/scala/doobie/util/datasource.scala
@@ -1,0 +1,28 @@
+package doobie.util
+
+import doobie.util.capture.Capture
+import doobie.util.liftxa.LiftXA
+import doobie.util.connector.Connector
+import doobie.util.transactor.Transactor
+
+import scalaz.{ Monad, Catchable, Lens }
+
+import javax.sql.DataSource
+
+object datasource {
+
+  final case class DataSourceXA(xa: LiftXA, ds: DataSource)
+  object DataSourceXA {
+
+    def apply(ds: DataSource): DataSourceXA =
+      apply(LiftXA.default, ds)
+
+    implicit def instance[M[_]: Monad: Capture: Catchable]: Transactor[M, DataSourceXA] =
+      Transactor.instance(Lens.lensu((a, b) => a.copy(xa = b), _.xa), xa => Capture[M].apply(xa.ds.getConnection))
+
+  }
+
+  implicit def dataSourceConnector[M[_]: Monad: Capture: Catchable]: Connector[M, DataSource] =
+    Connector.instance(ds => Capture[M].apply(ds.getConnection))
+
+}

--- a/core/src/main/scala/doobie/util/datasource.scala
+++ b/core/src/main/scala/doobie/util/datasource.scala
@@ -11,7 +11,11 @@ import javax.sql.DataSource
 
 object datasource {
 
-  final case class DataSourceXA(xa: LiftXA, ds: DataSource)
+  final case class DataSourceXA(xa: LiftXA, ds: DataSource) {
+    def configure[M[_]](f: DataSource => M[Unit]) =
+      f(ds)
+  }
+
   object DataSourceXA {
 
     def apply(ds: DataSource): DataSourceXA =
@@ -24,5 +28,9 @@ object datasource {
 
   implicit def dataSourceConnector[M[_]: Monad: Capture: Catchable]: Connector[M, DataSource] =
     Connector.instance(ds => Capture[M].apply(ds.getConnection))
+
+  @deprecated("Use DataSourceXA", "0.3.0") type DataSourceTransactor = DataSourceXA
+  @deprecated("Use DataSourceXA", "0.3.0") val  DataSourceTransactor = DataSourceXA
+
 
 }

--- a/core/src/main/scala/doobie/util/drivermanager.scala
+++ b/core/src/main/scala/doobie/util/drivermanager.scala
@@ -1,0 +1,36 @@
+package doobie.util
+
+import doobie.free.drivermanager.{ DriverManagerIO, delay, getConnection }
+import doobie.util.capture.Capture
+import doobie.util.liftxa.LiftXA
+import doobie.util.transactor.Transactor
+
+import scalaz.{ Monad, Catchable, Lens }
+import scalaz.syntax.apply._
+
+import java.sql.Connection
+
+object drivermanager {
+
+  final case class DriverManagerXA(xa: LiftXA, dmio: DriverManagerIO[Connection])
+
+  object DriverManagerXA {
+
+    private def create(driver: String, connect: DriverManagerIO[Connection]): DriverManagerXA =
+      DriverManagerXA(LiftXA.default, delay(Class.forName(driver)) *> connect)
+
+    def apply(driver: String, url: String): DriverManagerXA =
+      create(driver, getConnection(url))
+
+    def apply(driver: String, url: String, user: String, pass: String): DriverManagerXA =
+      create(driver, getConnection(url, user, pass))
+
+    def apply(driver: String, url: String, info: java.util.Properties): DriverManagerXA =
+      create(driver, getConnection(url, info))
+
+    implicit def instance[M[_]: Monad: Capture: Catchable]: Transactor[M, DriverManagerXA] =
+      Transactor.instance(Lens.lensu((a, b) => a.copy(xa = b), _.xa), _.dmio.trans[M])
+
+  }
+
+}

--- a/core/src/main/scala/doobie/util/liftxa.scala
+++ b/core/src/main/scala/doobie/util/liftxa.scala
@@ -1,0 +1,55 @@
+package doobie.util
+
+import doobie.imports.{ ConnectionIO, FC, toDoobieCatchableOps }
+import doobie.imports.HC.delay
+
+import scalaz.syntax.monad._
+import scalaz.stream.Process
+import scalaz.stream.Process.eval_
+
+object liftxa {
+
+  /**
+   * A data type that can lift an ordinary `ConnectionIO` or `Process` thereof into one with 
+   * transactional handling. The `default` instance provided on the companion object is suitable for
+   * most applications.
+   * @param before an action to prepare the `Connection`
+   * @param oops an action to run if the main action fails with an exception
+   * @param after an action to run on success
+   * @param always a clean up action to run in all cases
+   */
+  final case class LiftXA(
+    before:  ConnectionIO[Unit],
+    oops:    ConnectionIO[Unit],
+    after:   ConnectionIO[Unit],
+    always:  ConnectionIO[Unit]
+  ) {
+
+    /** Wrap a `ConnectionIO` in before/after/oops/always logic. */
+    def safe[A](ma: ConnectionIO[A]): ConnectionIO[A] =
+      (before *> ma <* after) onException oops ensuring always
+
+    /** Wrap a `Process[ConnectionIO, ?]` in before/after/oops/always logic. */
+    def safeP[A](pa: Process[ConnectionIO, A]): Process[ConnectionIO, A] =
+      (eval_(before) ++ pa ++ eval_(after)) onFailure { e => 
+        eval_(oops) ++ eval_(delay(throw e)) 
+      } onComplete eval_(always)
+
+  }
+  object LiftXA {
+
+    /** 
+     * A default instance of `LiftXA` with the following common semantics: `autoCommit` is set to 
+     * false; the transaction is rolled back on an exception and committed on success; and it is 
+     * closed in all cases.
+     */
+    val default = LiftXA(
+      FC.setAutoCommit(false),
+      FC.rollback,
+      FC.commit,
+      FC.close
+    )
+
+  }
+
+}

--- a/core/src/main/scala/doobie/util/transactor.scala
+++ b/core/src/main/scala/doobie/util/transactor.scala
@@ -3,7 +3,7 @@ package doobie.util
 import doobie.util.capture.Capture
 import doobie.free.connection.ConnectionIO
 import doobie.util.liftxa.LiftXA
-import doobie.util.connector.{ Connector, ConnectionIOConnectorOps }
+import doobie.util.connector.Connector
 import doobie.util.yolo.Yolo
 import doobie.hi.connection.ProcessConnectionIOOps
 
@@ -51,21 +51,5 @@ object transactor {
       liftXA.get(t).safeP(pa)
 
   }
-
-  /** Syntax that adds `Transactor` operations to `ConnectionIO`. */
-  implicit class ConnectionIOTransactorOps[A](ma: ConnectionIO[A]) {
-
-    final class Helper[M[_]] {
-      def apply[T](t: T)(implicit ev1: Transactor[M, T]): M[A] =
-        Connector.trans(t).apply(Transactor.safe(t)(ma))
-    }
-
-    /** 
-     * Interpret this program configured with transaction logic as defined by the `Transactor`'s
-     * `LiftXA`, into effect-capturing target monad `M`, running on a dedicated `Connection`. 
-     */
-    def transact[M[_]] = new Helper[M]
-
-  }
-
+  
 }

--- a/core/src/main/scala/doobie/util/transactor.scala
+++ b/core/src/main/scala/doobie/util/transactor.scala
@@ -23,6 +23,9 @@ object transactor {
 
   object Transactor {
 
+    def apply[M[_], A](implicit ev: Transactor[M, A]): Transactor[M, A] =
+      ev
+
     /** A default instance, given some constraints on M. */
     def instance[M[_]: Monad: Capture: Catchable, A](lens: A @> LiftXA, f: A => M[Connection]): Transactor[M, A] = {
       val c = Connector.instance[M, A](f)

--- a/core/src/main/scala/doobie/util/transactor.scala
+++ b/core/src/main/scala/doobie/util/transactor.scala
@@ -1,132 +1,70 @@
 package doobie.util
 
-          
-import doobie.free.connection.{ ConnectionIO, setAutoCommit, commit, rollback, close, delay }
+import doobie.util.capture.Capture
+import doobie.free.connection.ConnectionIO
+import doobie.util.liftxa.LiftXA
+import doobie.util.connector.{ Connector, ConnectionIOConnectorOps }
+import doobie.util.yolo.Yolo
 import doobie.hi.connection.ProcessConnectionIOOps
-import doobie.syntax.catchable.ToDoobieCatchableOps._
-import doobie.syntax.process._
-import doobie.util.capture._
-import doobie.util.query._
-import doobie.util.update._
-import doobie.util.yolo._
 
+import scalaz.{ Monad, Catchable, @>, ~>, Lens }
 import scalaz.syntax.monad._
 import scalaz.stream.Process
-import scalaz.stream.Process. { eval, eval_, halt }
-
-import scalaz.{ Monad, Catchable, Kleisli, ~> }
-import scalaz.stream.Process
+import scalaz.stream.Process.eval
 
 import java.sql.Connection
 
-import javax.sql.DataSource
-
-/**
- * Module defining `Transactor`, which abstracts over connection providers and gives natural 
- * trasformations `ConnectionIO ~> M` and `Process[ConnectionIO, ?] ~> Process[M, ?]` for target 
- * monad `M`. By default the resulting computation will be executed on a new connection with 
- * `autoCommit` off; will be committed on normal completionand rolled back if an exception escapes; 
- * and in all cases the connection will be released properly.
- *
- * This module also provides default implementations backed by `DriverManager` and `DataSouce`. 
- */
 object transactor {
 
-  abstract class Transactor[M[_]: Monad: Catchable: Capture] {
+  /** Specialization of `Connection` for data types that also carry a replaceable `LiftXA`. */
+  trait Transactor[M[_], A] extends Connector[M, A] {
+    def liftXA: A @> LiftXA
+  }
 
-    /** Action preparing the connection; default is `setAutoCommit(false)`. */
-    protected def before = setAutoCommit(false)
+  object Transactor {
 
-    /** Action in case of failure; default is `rollback`. */
-    protected def oops = rollback       
-
-    /** Action in case of success; default is `commit`. */
-    protected def after = commit            
-
-    /** Cleanup action run in all cases; default is `close`. */
-    protected def always = close   
-
-    @deprecated("will go away in 0.2.2; use trans", "0.2.1")
-    def transact[A](ma: ConnectionIO[A]): M[A] = trans(ma)
-
-    @deprecated("will go away in 0.2.2; use transP", "0.2.1")
-    def transact[A](pa: Process[ConnectionIO, A]): Process[M, A] = transP(pa)
-
-    /** Minimal implementation must provide a connection. */
-    protected def connect: M[Connection] 
-
-    /** Unethical syntax for use in the REPL. */
-    lazy val yolo = new Yolo(this)
-
-    /** Natural transformation to target monad `M`. */
-    object trans extends (ConnectionIO ~> M) {
-  
-      private def safe[A](ma: ConnectionIO[A]): ConnectionIO[A] =
-        (before *> ma <* after) onException oops ensuring always
-
-      def apply[A](ma: ConnectionIO[A]) = 
-        connect >>= safe(ma).transK[M]
-
-    }
-
-    /** Natural transformation to an equivalent process over target monad `M`. */
-    object transP extends (({ type l[a] = Process[ConnectionIO, a] })#l ~> ({ type l[a] = Process[M, a] })#l) {
-
-      // Convert a ConnectionIO[Unit] to an empty effectful process
-      private implicit class VoidProcessOps(ma: ConnectionIO[Unit]) {
-        def p: Process[ConnectionIO, Nothing] = eval(ma) *> halt
+    /** A default instance, given constraints on M. */
+    def instance[M[_]: Monad: Capture: Catchable, A](lens: A @> LiftXA, f: A => M[Connection]): Transactor[M, A] =
+      new Transactor[M, A] {
+        def liftXA = lens
+        def connect(a: A): M[Connection] = f(a)
+        def trans(a: A): ConnectionIO ~> M =
+          new (ConnectionIO ~> M) {        
+            def apply[B](ma: ConnectionIO[B]) = connect(a) >>= ma.transK[M]      
+          }
+        def transP(a: A): Process[ConnectionIO, ?] ~> Process[M, ?] =
+          new (Process[ConnectionIO, ?] ~> Process[M, ?]) {
+            def apply[B](pa: Process[ConnectionIO, B]) = eval(connect(a)) >>= pa.trans[M]    
+          }
       }
 
-      private def safe[A](pa: Process[ConnectionIO, A]): Process[ConnectionIO, A] =
-        (before.p ++ pa ++ after.p) onFailure { e => oops.p ++ eval_(delay(throw e)) } onComplete always.p
+    /** Retrieve the `liftXA` lens. */
+    def liftXA[M[_], T](implicit ev: Transactor[M, T]): T @> LiftXA = 
+      ev.liftXA
 
-      def apply[A](pa: Process[ConnectionIO, A]) = 
-        eval(connect) >>= safe(pa).trans[M]
+    /** Wrap a `ConnectionIO` in before/after/oops/always logic. */
+    def safe[M[_], T, A](t: T)(ma: ConnectionIO[A])(implicit ev: Transactor[M, T]): ConnectionIO[A] =
+      liftXA.get(t).safe(ma)
 
+    /** Wrap a `Process[ConnectionIO, ?]` in before/after/oops/always logic. */
+    def safeP[M[_], T, A](t: T)(pa: Process[ConnectionIO, A])(implicit ev: Transactor[M, T]): Process[ConnectionIO, A] =
+      liftXA.get(t).safeP(pa)
+
+  }
+
+  /** Syntax that adds `Transactor` operations to `ConnectionIO`. */
+  implicit class ConnectionIOTransactorOps[A](ma: ConnectionIO[A]) {
+
+    final class Helper[M[_]] {
+      def apply[T](t: T)(implicit ev1: Transactor[M, T]): M[A] =
+        Connector.trans(t).apply(Transactor.safe(t)(ma))
     }
 
-  }
-
-  /** `Transactor` wrapping `java.sql.DriverManager`. */
-  object DriverManagerTransactor {
-    import doobie.free.drivermanager.{ delay, getConnection, DriverManagerIO }
-
-    def create[M[_]: Monad: Catchable: Capture](driver: String, conn: DriverManagerIO[Connection]): Transactor[M] =
-      new Transactor[M] {
-        val connect: M[Connection] =
-          (delay(Class.forName(driver)) *> conn).trans[M]
-      }
-
-    def apply[M[_]: Monad: Catchable: Capture](driver: String, url: String): Transactor[M] =
-      create(driver, getConnection(url))
-
-    def apply[M[_]: Monad: Catchable: Capture](driver: String, url: String, user: String, pass: String): Transactor[M] =
-      create(driver, getConnection(url, user, pass))
-
-    def apply[M[_]: Monad: Catchable: Capture](driver: String, url: String, info: java.util.Properties): Transactor[M] =
-      create(driver, getConnection(url, info))
-
-  }
-
-  /** `Transactor` wrapping an existing `DataSource`. */
-  abstract class DataSourceTransactor[M[_]: Monad: Catchable: Capture, D <: DataSource] private extends Transactor[M] {
-    def configure[A](f: D => M[A]): M[A]
-  }
-
-  /** `Transactor` wrapping an existing `DataSource`. */
-  object DataSourceTransactor {
-  
-    // So we can specify M and infer D.
-    class DataSourceTransactorCtor[M[_]] {
-      def apply[D <: DataSource](ds: D)(implicit e0: Monad[M], e1: Catchable[M], e2: Capture[M]): DataSourceTransactor[M ,D] =
-        new DataSourceTransactor[M, D] {
-          def configure[A](f: D => M[A]): M[A] = f(ds)
-          val connect = e2.apply(ds.getConnection)
-        }
-    }
-
-    /** Type-curried constructor: construct a new instance via `DataSourceTransactor[M](ds)`. */
-    def apply[M[_]] = new DataSourceTransactorCtor[M]
+    /** 
+     * Interpret this program configured with transaction logic as defined by the `Transactor`'s
+     * `LiftXA`, into effect-capturing target monad `M`, running on a dedicated `Connection`. 
+     */
+    def transact[M[_]] = new Helper[M]
 
   }
 

--- a/core/src/main/scala/doobie/util/yolo.scala
+++ b/core/src/main/scala/doobie/util/yolo.scala
@@ -25,7 +25,7 @@ import Predef._
 /** Module for implicit syntax useful in REPL session. */
 object yolo {
 
-  class Yolo[M[_]: Monad: Catchable: Capture](xa: Transactor[M]) {
+  class Yolo[M[_], T](xa: T)(implicit ev: Transactor[M, T]) {
 
     private def out(s: String): ConnectionIO[Unit] =
       delay(Console.println(s"${Console.BLUE}  $s${Console.RESET}"))
@@ -33,7 +33,7 @@ object yolo {
     implicit class Query0YoloOps[A](q: Query0[A]) {
 
       def quick: M[Unit] =
-        q.sink(a => out(a.toString)).transact(xa)
+        q.sink(a => out(a.toString)).transact[M](xa)
 
       def check: M[Unit] =
         doCheck(q.analysis)

--- a/core/src/test/scala/doobie/util/query.scala
+++ b/core/src/test/scala/doobie/util/query.scala
@@ -9,7 +9,7 @@ import Predef._
 
 object queryspec extends Specification {
 
-  val xa = DriverManagerTransactor[Task](
+  val xa = DriverManagerTransactor(
     "org.h2.Driver",
     "jdbc:h2:mem:queryspec;DB_CLOSE_DELAY=-1",
     "sa", ""
@@ -18,6 +18,7 @@ object queryspec extends Specification {
   val q = Query[String,Int]("select 123 where ? = 'foo'", None)
 
   "Query (non-empty)" >> {
+<<<<<<< HEAD
     "process" in {
       q.process("foo").list.transact(xa).unsafePerformSync must_=== List(123)
     }
@@ -128,6 +129,118 @@ object queryspec extends Specification {
     }
     "map" in {
       q.toQuery0("bar").map(_ * 2).list.transact(xa).unsafePerformSync must_=== Nil
+=======
+  	"process" in {
+  		q.process("foo").list.transact[Task](xa).run must_=== List(123)
+  	}
+  	"sink" in {
+  		var x = Array(0)
+  		def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)  		
+  		q.process("foo").sink(effect).transact[Task](xa).run
+  		x(0) must_=== 123
+  	}
+  	"to" in {
+  		q.to[List]("foo").transact[Task](xa).run must_=== List(123)
+  	}
+  	"accumulate" in {
+  		q.accumulate[List]("foo").transact[Task](xa).run must_=== List(123)
+  	}
+  	"unique" in {
+  		q.unique("foo").transact[Task](xa).run must_=== 123
+  	}
+  	"option" in {
+  		q.option("foo").transact[Task](xa).run must_=== Some(123)
+  	}
+  	"map" in {
+  		q.map("x" * _).to[List]("foo").transact[Task](xa).run must_=== List("x" * 123)
+  	}
+  	"contramap" in {
+  		q.contramap[Int](n => "foo" * n).to[List](1).transact[Task](xa).run must_=== List(123)
+  	}
+  }
+
+  "Query (empty)" >> {
+  	"process" in {
+  		q.process("bar").list.transact[Task](xa).run must_=== Nil
+  	}
+  	"sink" in {
+  		var x = Array(0)
+  		def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)  		
+  		q.process("bar").sink(effect).transact[Task](xa).run
+  		x(0) must_=== 0
+  	}
+  	"to" in {
+  		q.to[List]("bar").transact[Task](xa).run must_=== Nil
+  	}
+  	"accumulate" in {
+  		q.accumulate[List]("bar").transact[Task](xa).run must_=== Nil
+  	}
+  	"unique" in {
+  		q.unique("bar").transact[Task](xa).attemptRun must_=== -\/(invariant.UnexpectedEnd)
+  	}
+  	"option" in {
+  		q.option("bar").transact[Task](xa).run must_=== None
+  	}
+  	"map" in {
+  		q.map("x" * _).to[List]("bar").transact[Task](xa).run must_=== Nil
+  	}
+  	"contramap" in {
+  		q.contramap[Int](n => "bar" * n).to[List](1).transact[Task](xa).run must_=== Nil
+  	}
+  }
+
+  "Query0 from Query (non-empty)" >> {
+  	"process" in {
+  		q.toQuery0("foo").process.list.transact[Task](xa).run must_=== List(123)
+  	}
+  	"sink" in {
+  		var x = Array(0)
+  		def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)  		
+  		q.toQuery0("foo").process.sink(effect).transact[Task](xa).run
+  		x(0) must_=== 123
+  	}
+  	"to" in {
+  		q.toQuery0("foo").to[List].transact[Task](xa).run must_=== List(123)
+  	}
+  	"accumulate" in {
+  		q.toQuery0("foo").accumulate[List].transact[Task](xa).run must_=== List(123)
+  	}
+  	"unique" in {
+  		q.toQuery0("foo").unique.transact[Task](xa).run must_=== 123
+  	}
+  	"option" in {
+  		q.toQuery0("foo").option.transact[Task](xa).run must_=== Some(123)
+  	}
+  	"map" in {
+  		q.toQuery0("foo").map(_ * 2).list.transact[Task](xa).run must_=== List(246)
+  	}
+  }
+
+  "Query0 from Query (empty)" >> {
+  	"process" in {
+  		q.toQuery0("bar").process.list.transact[Task](xa).run must_=== Nil
+  	}
+  	"sink" in {
+  		var x = Array(0)
+  		def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)  		
+  		q.toQuery0("bar").process.sink(effect).transact[Task](xa).run
+  		x(0) must_=== 0
+  	}
+  	"to" in {
+  		q.toQuery0("bar").to[List].transact[Task](xa).run must_=== Nil
+  	}
+  	"accumulate" in {
+  		q.toQuery0("bar").accumulate[List].transact[Task](xa).run must_=== Nil
+  	}
+  	"unique" in {
+  		q.toQuery0("bar").unique.transact[Task](xa).attemptRun must_=== -\/(invariant.UnexpectedEnd)
+  	}
+  	"option" in {
+  		q.toQuery0("bar").option.transact[Task](xa).run must_=== None
+  	}
+    "map" in {
+      q.toQuery0("bar").map(_ * 2).list.transact[Task](xa).run must_=== Nil
+>>>>>>> got core compiling with new transactor setup
     }
   }
 

--- a/core/src/test/scala/doobie/util/query.scala
+++ b/core/src/test/scala/doobie/util/query.scala
@@ -18,229 +18,116 @@ object queryspec extends Specification {
   val q = Query[String,Int]("select 123 where ? = 'foo'", None)
 
   "Query (non-empty)" >> {
-<<<<<<< HEAD
-    "process" in {
-      q.process("foo").list.transact(xa).unsafePerformSync must_=== List(123)
-    }
-    "sink" in {
-      var x = Array(0)
-      def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)      
-      q.process("foo").sink(effect).transact(xa).unsafePerformSync
-      x(0) must_=== 123
-    }
-    "to" in {
-      q.to[List]("foo").transact(xa).unsafePerformSync must_=== List(123)
-    }
-    "accumulate" in {
-      q.accumulate[List]("foo").transact(xa).unsafePerformSync must_=== List(123)
-    }
-    "unique" in {
-      q.unique("foo").transact(xa).unsafePerformSync must_=== 123
-    }
-    "option" in {
-      q.option("foo").transact(xa).unsafePerformSync must_=== Some(123)
-    }
-    "map" in {
-      q.map("x" * _).to[List]("foo").transact(xa).unsafePerformSync must_=== List("x" * 123)
-    }
-    "contramap" in {
-      q.contramap[Int](n => "foo" * n).to[List](1).transact(xa).unsafePerformSync must_=== List(123)
-    }
-  }
-
-  "Query (empty)" >> {
-    "process" in {
-      q.process("bar").list.transact(xa).unsafePerformSync must_=== Nil
-    }
-    "sink" in {
-      var x = Array(0)
-      def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)      
-      q.process("bar").sink(effect).transact(xa).unsafePerformSync
-      x(0) must_=== 0
-    }
-    "to" in {
-      q.to[List]("bar").transact(xa).unsafePerformSync must_=== Nil
-    }
-    "accumulate" in {
-      q.accumulate[List]("bar").transact(xa).unsafePerformSync must_=== Nil
-    }
-    "unique" in {
-      q.unique("bar").transact(xa).unsafePerformSyncAttempt must_=== -\/(invariant.UnexpectedEnd)
-    }
-    "option" in {
-      q.option("bar").transact(xa).unsafePerformSync must_=== None
-    }
-    "map" in {
-      q.map("x" * _).to[List]("bar").transact(xa).unsafePerformSync must_=== Nil
-    }
-    "contramap" in {
-      q.contramap[Int](n => "bar" * n).to[List](1).transact(xa).unsafePerformSync must_=== Nil
-    }
-  }
-
-  "Query0 from Query (non-empty)" >> {
-    "process" in {
-      q.toQuery0("foo").process.list.transact(xa).unsafePerformSync must_=== List(123)
-    }
-    "sink" in {
-      var x = Array(0)
-      def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)      
-      q.toQuery0("foo").process.sink(effect).transact(xa).unsafePerformSync
-      x(0) must_=== 123
-    }
-    "to" in {
-      q.toQuery0("foo").to[List].transact(xa).unsafePerformSync must_=== List(123)
-    }
-    "accumulate" in {
-      q.toQuery0("foo").accumulate[List].transact(xa).unsafePerformSync must_=== List(123)
-    }
-    "unique" in {
-      q.toQuery0("foo").unique.transact(xa).unsafePerformSync must_=== 123
-    }
-    "option" in {
-      q.toQuery0("foo").option.transact(xa).unsafePerformSync must_=== Some(123)
-    }
-    "map" in {
-      q.toQuery0("foo").map(_ * 2).list.transact(xa).unsafePerformSync must_=== List(246)
-    }
-  }
-
-  "Query0 from Query (empty)" >> {
-    "process" in {
-      q.toQuery0("bar").process.list.transact(xa).unsafePerformSync must_=== Nil
-    }
-    "sink" in {
-      var x = Array(0)
-      def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)      
-      q.toQuery0("bar").process.sink(effect).transact(xa).unsafePerformSync
-      x(0) must_=== 0
-    }
-    "to" in {
-      q.toQuery0("bar").to[List].transact(xa).unsafePerformSync must_=== Nil
-    }
-    "accumulate" in {
-      q.toQuery0("bar").accumulate[List].transact(xa).unsafePerformSync must_=== Nil
-    }
-    "unique" in {
-      q.toQuery0("bar").unique.transact(xa).unsafePerformSyncAttempt must_=== -\/(invariant.UnexpectedEnd)
-    }
-    "option" in {
-      q.toQuery0("bar").option.transact(xa).unsafePerformSync must_=== None
-    }
-    "map" in {
-      q.toQuery0("bar").map(_ * 2).list.transact(xa).unsafePerformSync must_=== Nil
-=======
   	"process" in {
-  		q.process("foo").list.transact[Task](xa).run must_=== List(123)
+  		q.process("foo").list.transact[Task](xa).unsafePerformSync must_=== List(123)
   	}
   	"sink" in {
   		var x = Array(0)
   		def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)  		
-  		q.process("foo").sink(effect).transact[Task](xa).run
+  		q.process("foo").sink(effect).transact[Task](xa).unsafePerformSync
   		x(0) must_=== 123
   	}
   	"to" in {
-  		q.to[List]("foo").transact[Task](xa).run must_=== List(123)
+  		q.to[List]("foo").transact[Task](xa).unsafePerformSync must_=== List(123)
   	}
   	"accumulate" in {
-  		q.accumulate[List]("foo").transact[Task](xa).run must_=== List(123)
+  		q.accumulate[List]("foo").transact[Task](xa).unsafePerformSync must_=== List(123)
   	}
   	"unique" in {
-  		q.unique("foo").transact[Task](xa).run must_=== 123
+  		q.unique("foo").transact[Task](xa).unsafePerformSync must_=== 123
   	}
   	"option" in {
-  		q.option("foo").transact[Task](xa).run must_=== Some(123)
+  		q.option("foo").transact[Task](xa).unsafePerformSync must_=== Some(123)
   	}
   	"map" in {
-  		q.map("x" * _).to[List]("foo").transact[Task](xa).run must_=== List("x" * 123)
+  		q.map("x" * _).to[List]("foo").transact[Task](xa).unsafePerformSync must_=== List("x" * 123)
   	}
   	"contramap" in {
-  		q.contramap[Int](n => "foo" * n).to[List](1).transact[Task](xa).run must_=== List(123)
+  		q.contramap[Int](n => "foo" * n).to[List](1).transact[Task](xa).unsafePerformSync must_=== List(123)
   	}
   }
 
   "Query (empty)" >> {
   	"process" in {
-  		q.process("bar").list.transact[Task](xa).run must_=== Nil
+  		q.process("bar").list.transact[Task](xa).unsafePerformSync must_=== Nil
   	}
   	"sink" in {
   		var x = Array(0)
   		def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)  		
-  		q.process("bar").sink(effect).transact[Task](xa).run
+  		q.process("bar").sink(effect).transact[Task](xa).unsafePerformSync
   		x(0) must_=== 0
   	}
   	"to" in {
-  		q.to[List]("bar").transact[Task](xa).run must_=== Nil
+  		q.to[List]("bar").transact[Task](xa).unsafePerformSync must_=== Nil
   	}
   	"accumulate" in {
-  		q.accumulate[List]("bar").transact[Task](xa).run must_=== Nil
+  		q.accumulate[List]("bar").transact[Task](xa).unsafePerformSync must_=== Nil
   	}
   	"unique" in {
-  		q.unique("bar").transact[Task](xa).attemptRun must_=== -\/(invariant.UnexpectedEnd)
+  		q.unique("bar").transact[Task](xa).unsafePerformSyncAttempt must_=== -\/(invariant.UnexpectedEnd)
   	}
   	"option" in {
-  		q.option("bar").transact[Task](xa).run must_=== None
+  		q.option("bar").transact[Task](xa).unsafePerformSync must_=== None
   	}
   	"map" in {
-  		q.map("x" * _).to[List]("bar").transact[Task](xa).run must_=== Nil
+  		q.map("x" * _).to[List]("bar").transact[Task](xa).unsafePerformSync must_=== Nil
   	}
   	"contramap" in {
-  		q.contramap[Int](n => "bar" * n).to[List](1).transact[Task](xa).run must_=== Nil
+  		q.contramap[Int](n => "bar" * n).to[List](1).transact[Task](xa).unsafePerformSync must_=== Nil
   	}
   }
 
   "Query0 from Query (non-empty)" >> {
   	"process" in {
-  		q.toQuery0("foo").process.list.transact[Task](xa).run must_=== List(123)
+  		q.toQuery0("foo").process.list.transact[Task](xa).unsafePerformSync must_=== List(123)
   	}
   	"sink" in {
   		var x = Array(0)
   		def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)  		
-  		q.toQuery0("foo").process.sink(effect).transact[Task](xa).run
+  		q.toQuery0("foo").process.sink(effect).transact[Task](xa).unsafePerformSync
   		x(0) must_=== 123
   	}
   	"to" in {
-  		q.toQuery0("foo").to[List].transact[Task](xa).run must_=== List(123)
+  		q.toQuery0("foo").to[List].transact[Task](xa).unsafePerformSync must_=== List(123)
   	}
   	"accumulate" in {
-  		q.toQuery0("foo").accumulate[List].transact[Task](xa).run must_=== List(123)
+  		q.toQuery0("foo").accumulate[List].transact[Task](xa).unsafePerformSync must_=== List(123)
   	}
   	"unique" in {
-  		q.toQuery0("foo").unique.transact[Task](xa).run must_=== 123
+  		q.toQuery0("foo").unique.transact[Task](xa).unsafePerformSync must_=== 123
   	}
   	"option" in {
-  		q.toQuery0("foo").option.transact[Task](xa).run must_=== Some(123)
+  		q.toQuery0("foo").option.transact[Task](xa).unsafePerformSync must_=== Some(123)
   	}
   	"map" in {
-  		q.toQuery0("foo").map(_ * 2).list.transact[Task](xa).run must_=== List(246)
+  		q.toQuery0("foo").map(_ * 2).list.transact[Task](xa).unsafePerformSync must_=== List(246)
   	}
   }
 
   "Query0 from Query (empty)" >> {
   	"process" in {
-  		q.toQuery0("bar").process.list.transact[Task](xa).run must_=== Nil
+  		q.toQuery0("bar").process.list.transact[Task](xa).unsafePerformSync must_=== Nil
   	}
   	"sink" in {
   		var x = Array(0)
   		def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)  		
-  		q.toQuery0("bar").process.sink(effect).transact[Task](xa).run
+  		q.toQuery0("bar").process.sink(effect).transact[Task](xa).unsafePerformSync
   		x(0) must_=== 0
   	}
   	"to" in {
-  		q.toQuery0("bar").to[List].transact[Task](xa).run must_=== Nil
+  		q.toQuery0("bar").to[List].transact[Task](xa).unsafePerformSync must_=== Nil
   	}
   	"accumulate" in {
-  		q.toQuery0("bar").accumulate[List].transact[Task](xa).run must_=== Nil
+  		q.toQuery0("bar").accumulate[List].transact[Task](xa).unsafePerformSync must_=== Nil
   	}
   	"unique" in {
-  		q.toQuery0("bar").unique.transact[Task](xa).attemptRun must_=== -\/(invariant.UnexpectedEnd)
+  		q.toQuery0("bar").unique.transact[Task](xa).unsafePerformSyncAttempt must_=== -\/(invariant.UnexpectedEnd)
   	}
   	"option" in {
-  		q.toQuery0("bar").option.transact[Task](xa).run must_=== None
+  		q.toQuery0("bar").option.transact[Task](xa).unsafePerformSync must_=== None
   	}
     "map" in {
-      q.toQuery0("bar").map(_ * 2).list.transact[Task](xa).run must_=== Nil
->>>>>>> got core compiling with new transactor setup
+      q.toQuery0("bar").map(_ * 2).list.transact[Task](xa).unsafePerformSync must_=== Nil
     }
   }
 

--- a/core/src/test/scala/doobie/util/query.scala
+++ b/core/src/test/scala/doobie/util/query.scala
@@ -18,114 +18,114 @@ object queryspec extends Specification {
   val q = Query[String,Int]("select 123 where ? = 'foo'", None)
 
   "Query (non-empty)" >> {
-  	"process" in {
-  		q.process("foo").list.transact[Task](xa).unsafePerformSync must_=== List(123)
-  	}
-  	"sink" in {
-  		var x = Array(0)
-  		def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)  		
-  		q.process("foo").sink(effect).transact[Task](xa).unsafePerformSync
-  		x(0) must_=== 123
-  	}
-  	"to" in {
-  		q.to[List]("foo").transact[Task](xa).unsafePerformSync must_=== List(123)
-  	}
-  	"accumulate" in {
-  		q.accumulate[List]("foo").transact[Task](xa).unsafePerformSync must_=== List(123)
-  	}
-  	"unique" in {
-  		q.unique("foo").transact[Task](xa).unsafePerformSync must_=== 123
-  	}
-  	"option" in {
-  		q.option("foo").transact[Task](xa).unsafePerformSync must_=== Some(123)
-  	}
-  	"map" in {
-  		q.map("x" * _).to[List]("foo").transact[Task](xa).unsafePerformSync must_=== List("x" * 123)
-  	}
-  	"contramap" in {
-  		q.contramap[Int](n => "foo" * n).to[List](1).transact[Task](xa).unsafePerformSync must_=== List(123)
-  	}
+    "process" in {
+      q.process("foo").list.transact[Task](xa).unsafePerformSync must_=== List(123)
+    }
+    "sink" in {
+      var x = Array(0)
+      def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)     
+      q.process("foo").sink(effect).transact[Task](xa).unsafePerformSync
+      x(0) must_=== 123
+    }
+    "to" in {
+      q.to[List]("foo").transact[Task](xa).unsafePerformSync must_=== List(123)
+    }
+    "accumulate" in {
+      q.accumulate[List]("foo").transact[Task](xa).unsafePerformSync must_=== List(123)
+    }
+    "unique" in {
+      q.unique("foo").transact[Task](xa).unsafePerformSync must_=== 123
+    }
+    "option" in {
+      q.option("foo").transact[Task](xa).unsafePerformSync must_=== Some(123)
+    }
+    "map" in {
+      q.map("x" * _).to[List]("foo").transact[Task](xa).unsafePerformSync must_=== List("x" * 123)
+    }
+    "contramap" in {
+      q.contramap[Int](n => "foo" * n).to[List](1).transact[Task](xa).unsafePerformSync must_=== List(123)
+    }
   }
 
   "Query (empty)" >> {
-  	"process" in {
-  		q.process("bar").list.transact[Task](xa).unsafePerformSync must_=== Nil
-  	}
-  	"sink" in {
-  		var x = Array(0)
-  		def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)  		
-  		q.process("bar").sink(effect).transact[Task](xa).unsafePerformSync
-  		x(0) must_=== 0
-  	}
-  	"to" in {
-  		q.to[List]("bar").transact[Task](xa).unsafePerformSync must_=== Nil
-  	}
-  	"accumulate" in {
-  		q.accumulate[List]("bar").transact[Task](xa).unsafePerformSync must_=== Nil
-  	}
-  	"unique" in {
-  		q.unique("bar").transact[Task](xa).unsafePerformSyncAttempt must_=== -\/(invariant.UnexpectedEnd)
-  	}
-  	"option" in {
-  		q.option("bar").transact[Task](xa).unsafePerformSync must_=== None
-  	}
-  	"map" in {
-  		q.map("x" * _).to[List]("bar").transact[Task](xa).unsafePerformSync must_=== Nil
-  	}
-  	"contramap" in {
-  		q.contramap[Int](n => "bar" * n).to[List](1).transact[Task](xa).unsafePerformSync must_=== Nil
-  	}
+    "process" in {
+      q.process("bar").list.transact[Task](xa).unsafePerformSync must_=== Nil
+    }
+    "sink" in {
+      var x = Array(0)
+      def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)     
+      q.process("bar").sink(effect).transact[Task](xa).unsafePerformSync
+      x(0) must_=== 0
+    }
+    "to" in {
+      q.to[List]("bar").transact[Task](xa).unsafePerformSync must_=== Nil
+    }
+    "accumulate" in {
+      q.accumulate[List]("bar").transact[Task](xa).unsafePerformSync must_=== Nil
+    }
+    "unique" in {
+      q.unique("bar").transact[Task](xa).unsafePerformSyncAttempt must_=== -\/(invariant.UnexpectedEnd)
+    }
+    "option" in {
+      q.option("bar").transact[Task](xa).unsafePerformSync must_=== None
+    }
+    "map" in {
+      q.map("x" * _).to[List]("bar").transact[Task](xa).unsafePerformSync must_=== Nil
+    }
+    "contramap" in {
+      q.contramap[Int](n => "bar" * n).to[List](1).transact[Task](xa).unsafePerformSync must_=== Nil
+    }
   }
 
   "Query0 from Query (non-empty)" >> {
-  	"process" in {
-  		q.toQuery0("foo").process.list.transact[Task](xa).unsafePerformSync must_=== List(123)
-  	}
-  	"sink" in {
-  		var x = Array(0)
-  		def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)  		
-  		q.toQuery0("foo").process.sink(effect).transact[Task](xa).unsafePerformSync
-  		x(0) must_=== 123
-  	}
-  	"to" in {
-  		q.toQuery0("foo").to[List].transact[Task](xa).unsafePerformSync must_=== List(123)
-  	}
-  	"accumulate" in {
-  		q.toQuery0("foo").accumulate[List].transact[Task](xa).unsafePerformSync must_=== List(123)
-  	}
-  	"unique" in {
-  		q.toQuery0("foo").unique.transact[Task](xa).unsafePerformSync must_=== 123
-  	}
-  	"option" in {
-  		q.toQuery0("foo").option.transact[Task](xa).unsafePerformSync must_=== Some(123)
-  	}
-  	"map" in {
-  		q.toQuery0("foo").map(_ * 2).list.transact[Task](xa).unsafePerformSync must_=== List(246)
-  	}
+    "process" in {
+      q.toQuery0("foo").process.list.transact[Task](xa).unsafePerformSync must_=== List(123)
+    }
+    "sink" in {
+      var x = Array(0)
+      def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)     
+      q.toQuery0("foo").process.sink(effect).transact[Task](xa).unsafePerformSync
+      x(0) must_=== 123
+    }
+    "to" in {
+      q.toQuery0("foo").to[List].transact[Task](xa).unsafePerformSync must_=== List(123)
+    }
+    "accumulate" in {
+      q.toQuery0("foo").accumulate[List].transact[Task](xa).unsafePerformSync must_=== List(123)
+    }
+    "unique" in {
+      q.toQuery0("foo").unique.transact[Task](xa).unsafePerformSync must_=== 123
+    }
+    "option" in {
+      q.toQuery0("foo").option.transact[Task](xa).unsafePerformSync must_=== Some(123)
+    }
+    "map" in {
+      q.toQuery0("foo").map(_ * 2).list.transact[Task](xa).unsafePerformSync must_=== List(246)
+    }
   }
 
   "Query0 from Query (empty)" >> {
-  	"process" in {
-  		q.toQuery0("bar").process.list.transact[Task](xa).unsafePerformSync must_=== Nil
-  	}
-  	"sink" in {
-  		var x = Array(0)
-  		def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)  		
-  		q.toQuery0("bar").process.sink(effect).transact[Task](xa).unsafePerformSync
-  		x(0) must_=== 0
-  	}
-  	"to" in {
-  		q.toQuery0("bar").to[List].transact[Task](xa).unsafePerformSync must_=== Nil
-  	}
-  	"accumulate" in {
-  		q.toQuery0("bar").accumulate[List].transact[Task](xa).unsafePerformSync must_=== Nil
-  	}
-  	"unique" in {
-  		q.toQuery0("bar").unique.transact[Task](xa).unsafePerformSyncAttempt must_=== -\/(invariant.UnexpectedEnd)
-  	}
-  	"option" in {
-  		q.toQuery0("bar").option.transact[Task](xa).unsafePerformSync must_=== None
-  	}
+    "process" in {
+      q.toQuery0("bar").process.list.transact[Task](xa).unsafePerformSync must_=== Nil
+    }
+    "sink" in {
+      var x = Array(0)
+      def effect(n: Int): ConnectionIO[Unit] = HC.delay(x(0) = n)     
+      q.toQuery0("bar").process.sink(effect).transact[Task](xa).unsafePerformSync
+      x(0) must_=== 0
+    }
+    "to" in {
+      q.toQuery0("bar").to[List].transact[Task](xa).unsafePerformSync must_=== Nil
+    }
+    "accumulate" in {
+      q.toQuery0("bar").accumulate[List].transact[Task](xa).unsafePerformSync must_=== Nil
+    }
+    "unique" in {
+      q.toQuery0("bar").unique.transact[Task](xa).unsafePerformSyncAttempt must_=== -\/(invariant.UnexpectedEnd)
+    }
+    "option" in {
+      q.toQuery0("bar").option.transact[Task](xa).unsafePerformSync must_=== None
+    }
     "map" in {
       q.toQuery0("bar").map(_ * 2).list.transact[Task](xa).unsafePerformSync must_=== Nil
     }

--- a/core/src/test/scala/doobie/util/yolo.scala
+++ b/core/src/test/scala/doobie/util/yolo.scala
@@ -11,7 +11,7 @@ object yolospec extends Specification {
   "YOLO checks" should {
     "compile for Query, Query0, Update, Update0" in {
       lazy val dontRun = {
-        val y = new Yolo[Task](null); import y._
+        val y = new Yolo[Task, DriverManagerTransactor](null); import y._
         (null : Query0[Int]).check
         (null : Query[Int, Int]).check
         Update0("", None).check

--- a/doc/src/main/tut/03-Connecting.md
+++ b/doc/src/main/tut/03-Connecting.md
@@ -29,7 +29,7 @@ val program1 = 42.point[ConnectionIO]
 This is a perfectly respectable **doobie** program, but we can't run it as-is; we need a `Connection` first. There are several ways to do this, but here let's use a `Transactor`.
 
 ```tut:silent
-val xa = DriverManagerTransactor[Task](
+val xa = DriverManagerTransactor(
   "org.postgresql.Driver", "jdbc:postgresql:world", "postgres", ""
 )
 ```
@@ -41,7 +41,7 @@ The `DriverManagerTransactor` simply delegates to the `java.sql.DriverManager` t
 Right, so let's do this.
 
 ```tut
-val task = program1.transact(xa)
+val task = program1.transact[Task](xa)
 task.unsafePerformSync
 ```
 
@@ -57,7 +57,7 @@ Let's use the `sql` string interpolator to construct a query that asks the *data
 
 ```tut
 val program2 = sql"select 42".query[Int].unique
-val task2 = program2.transact(xa)
+val task2 = program2.transact[Task](xa)
 task2.unsafePerformSync
 ```
 
@@ -79,7 +79,7 @@ val program3 =
 And behold!
 
 ```tut
-program3.transact(xa).unsafePerformSync
+program3.transact[Task](xa).unsafePerformSync
 ```
 
 The astute among you will note that we don't actually need a monad to do this; an applicative functor is all we need here. So we could also write `program3` as:
@@ -95,13 +95,13 @@ val program3a = {
 And lo, it was good:
 
 ```tut
-program3a.transact(xa).unsafePerformSync
+program3a.transact[Task](xa).unsafePerformSync
 ```
 
 And of course this composition can continue indefinitely.
 
 ```tut
-program3a.replicateM(5).transact(xa).unsafePerformSync.foreach(println)
+program3a.replicateM(5).transact[Task](xa).unsafePerformSync.foreach(println)
 ```
 
 

--- a/doc/src/main/tut/05-Parameterized.md
+++ b/doc/src/main/tut/05-Parameterized.md
@@ -15,11 +15,11 @@ import doobie.imports._
 import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 
-val xa = DriverManagerTransactor[Task](
+val xa = DriverManagerTransactor(
   "org.postgresql.Driver", "jdbc:postgresql:world", "postgres", ""
 )
 
-import xa.yolo._
+val y = xa.yolo[Task]; import y._
 ```
 
 We're still playing with the `country` table, shown here for reference.

--- a/doc/src/main/tut/06-Checking.md
+++ b/doc/src/main/tut/06-Checking.md
@@ -19,11 +19,11 @@ import doobie.imports._
 import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 
-val xa = DriverManagerTransactor[Task](
+val xa = DriverManagerTransactor(
   "org.postgresql.Driver", "jdbc:postgresql:world", "postgres", ""
 )
 
-import xa.yolo._
+val y = xa.yolo[Task]; import y._
 ```
 
 And again, we're playing with the `country` table, shown here for reference.

--- a/doc/src/main/tut/07-Updating.md
+++ b/doc/src/main/tut/07-Updating.md
@@ -16,11 +16,11 @@ import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 import scalaz.stream.Process
 
-val xa = DriverManagerTransactor[Task](
+val xa = DriverManagerTransactor(
   "org.postgresql.Driver", "jdbc:postgresql:world", "postgres", ""
 )
 
-import xa.yolo._
+val y = xa.yolo[Task]; import y._
 ```
 
 ### Data Definition

--- a/doc/src/main/tut/08-Error-Handling.md
+++ b/doc/src/main/tut/08-Error-Handling.md
@@ -13,11 +13,11 @@ import doobie.imports._
 import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 
-val xa = DriverManagerTransactor[Task](
+val xa = DriverManagerTransactor(
   "org.postgresql.Driver", "jdbc:postgresql:world", "postgres", ""
 )
 
-import xa.yolo._
+val y = xa.yolo[Task]; import y._
 ```
 
 ### About Exceptions

--- a/doc/src/main/tut/09-Arrays.md
+++ b/doc/src/main/tut/09-Arrays.md
@@ -16,11 +16,11 @@ import doobie.contrib.postgresql.pgtypes._
 import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 
-val xa = DriverManagerTransactor[Task](
+val xa = DriverManagerTransactor(
   "org.postgresql.Driver", "jdbc:postgresql:world", "postgres", ""
 )
 
-import xa.yolo._
+val y = xa.yolo[Task]; import y._
 ```
 
 ### Reading and Writing Arrays

--- a/doc/src/main/tut/10-Custom-Mappings.md
+++ b/doc/src/main/tut/10-Custom-Mappings.md
@@ -25,11 +25,11 @@ import scala.reflect.runtime.universe.TypeTag
 import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 
-val xa = DriverManagerTransactor[Task](
+val xa = DriverManagerTransactor(
   "org.postgresql.Driver", "jdbc:postgresql:world", "postgres", ""
 )
 
-import xa.yolo._
+val y = xa.yolo[Task]; import y._
 ```
 
 ### Meta, Atom, and Composite

--- a/doc/src/main/tut/11-Unit-Testing.md
+++ b/doc/src/main/tut/11-Unit-Testing.md
@@ -19,7 +19,7 @@ import doobie.imports._
 import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 
-val xa = DriverManagerTransactor[Task](
+val xa = DriverManagerTransactor(
   "org.postgresql.Driver", "jdbc:postgresql:world", "postgres", ""
 )
 ```
@@ -67,11 +67,13 @@ Our unit test needs to extend `AnalysisSpec` and must define a `Transactor[Task]
 import doobie.contrib.specs2.analysisspec.AnalysisSpec
 import org.specs2.mutable.Specification
 
-object AnalysisTestSpec extends Specification with AnalysisSpec {
+object AnalysisTestSpec extends Specification with AnalysisSpec[DriverManagerTransactor] {
 
-  val transactor = DriverManagerTransactor[Task](
+  val transactor = DriverManagerTransactor(
     "org.postgresql.Driver", "jdbc:postgresql:world", "postgres", ""
   )
+
+  val ev = Transactor[Task, DriverManagerTransactor]
 
   check(trivial)
   check(biggerThan(0))

--- a/doc/src/main/tut/12-Managing-Connections.md
+++ b/doc/src/main/tut/12-Managing-Connections.md
@@ -45,7 +45,7 @@ However, for experimentation as described in this book (and for situations where
 class and a connect URL. Normally you will also pass a user/password (the API provides several variants matching the `DriverManager` static API).
 
 ```tut:silent
-val xa = DriverManagerTransactor[Task](
+val xa = DriverManagerTransactor(
   "org.postgresql.Driver", // fully-qualified driver class name
   "jdbc:postgresql:world", // connect URL
   "jimmy",                 // user
@@ -64,8 +64,8 @@ val q = sql"select 42".query[Int].unique
 
 val p: Task[Int] = for {
   xa <- HikariTransactor[Task]("org.postgresql.Driver", "jdbc:postgresql:world", "postgres", "")
-  _  <- xa.configure(hx => Task.delay( /* do something with hx */ ()))
-  a  <- q.transact(xa) ensuring xa.shutdown
+  _  <- xa.configure[Task](hx => Task.delay( /* do something with hx */ ()))
+  a  <- q.transact[Task](xa) ensuring xa.shutdown[Task]
 } yield a
 ```
 
@@ -84,11 +84,11 @@ If your application exposes an existing `javax.sql.DataSource` you can use it di
 ```tut:silent
 val ds: javax.sql.DataSource = null // pretending
 
-val xa = DataSourceTransactor[Task](ds)
+val xa = DataSourceTransactor(ds)
 
 val p: Task[Int] = for {
-  _  <- xa.configure(ds => Task.delay( /* do something with ds */ ()))
-  a  <- q.transact(xa)
+  _  <- xa.configure[Task](ds => Task.delay( /* do something with ds */ ()))
+  a  <- q.transact[Task](xa)
 } yield a
 
 ```

--- a/doc/src/main/tut/13-Extensions-PostgreSQL.md
+++ b/doc/src/main/tut/13-Extensions-PostgreSQL.md
@@ -21,11 +21,11 @@ import doobie.imports._
 import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 
-val xa = DriverManagerTransactor[Task](
+val xa = DriverManagerTransactor(
   "org.postgresql.Driver", "jdbc:postgresql:world", "postgres", ""
 )
 
-import xa.yolo._
+val y = xa.yolo[Task]; import y._
 ```
 
 **doobie** adds support for a large number of extended types that are not supported directly by JDBC. All mappings are provided in the `pgtypes` module.

--- a/doc/src/main/tut/14-Extensions-H2.md
+++ b/doc/src/main/tut/14-Extensions-H2.md
@@ -45,7 +45,7 @@ val q = sql"select 42".query[Int].unique
 
 for {
   xa <- H2Transactor[Task]("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", "sa", "")
-  _  <- xa.setMaxConnections(10) // and other ops; see scaladoc or source
-  a  <- q.transact(xa)
+  _  <- xa.setMaxConnections[Task](10) // and other ops; see scaladoc or source
+  a  <- q.transact[Task](xa)
 } yield a
 ```

--- a/doc/src/main/tut/15-FAQ.md
+++ b/doc/src/main/tut/15-FAQ.md
@@ -14,11 +14,11 @@ import scalaz._, Scalaz._
 import scalaz.concurrent.Task
 import shapeless._
 
-val xa = DriverManagerTransactor[Task](
+val xa = DriverManagerTransactor(
   "org.postgresql.Driver", "jdbc:postgresql:world", "postgres", ""
 )
 
-import xa.yolo._
+val y = xa.yolo[Task]; import y._
 ```
 
 ### How do I do an `IN` clause?

--- a/example/src/main/scala/example/AnalysisTest.scala
+++ b/example/src/main/scala/example/AnalysisTest.scala
@@ -57,8 +57,5 @@ object AnalysisTest {
       UPDATE COUNTRY SET NAME = 'foo' WHERE CODE = 'bkah'
     """.update
 
-  val xa: Transactor[Task] = 
-    DriverManagerTransactor[Task]("org.postgresql.Driver", "jdbc:postgresql:world", "postgres", "")
-
 }
 

--- a/example/src/main/scala/example/FirstExample.scala
+++ b/example/src/main/scala/example/FirstExample.scala
@@ -58,9 +58,9 @@ object FirstExample extends SafeApp {
 
   // Entry point for SafeApp
   override def runc: IO[Unit] = {
-    val db = DriverManagerTransactor[IO]("org.h2.Driver", "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", "sa", "")
+    val db = DriverManagerTransactor("org.h2.Driver", "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", "sa", "")
     for {
-      a <- examples.transact(db).attempt
+      a <- examples.transact[IO](db).attempt
       _ <- IO.putStrLn(a.toString)
     } yield ()
   }

--- a/example/src/main/scala/example/HiUsage.scala
+++ b/example/src/main/scala/example/HiUsage.scala
@@ -16,8 +16,8 @@ object HiUsage {
   
   // Program entry point
   def main(args: Array[String]): Unit = {
-    val db = DriverManagerTransactor[Task]("org.postgresql.Driver", "jdbc:postgresql:world", "postgres", "")
-    example.transact(db).unsafePerformSync
+    val db = DriverManagerTransactor("org.postgresql.Driver", "jdbc:postgresql:world", "postgres", "")
+    example.transact[Task](db).unsafePerformSync
   }
 
   // An example action. Streams results to stdout

--- a/example/src/main/scala/example/HikariExample.scala
+++ b/example/src/main/scala/example/HikariExample.scala
@@ -9,9 +9,9 @@ object HikariExample {
 
   def tmain: Task[Unit] = 
     for {
-      xa <- HikariTransactor[Task]("org.h2.Driver", "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", "sa", "")
-      _  <- FirstExample.examples.transact(xa)
-      _  <- xa.shutdown
+      xa <- HikariXA[Task]("org.h2.Driver", "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", "sa", "")
+      _  <- FirstExample.examples.transact[Task](xa)
+      _  <- xa.shutdown[Task]
     } yield ()
 
   def main(args: Array[String]) =

--- a/example/src/main/scala/example/PostgresLargeObject.scala
+++ b/example/src/main/scala/example/PostgresLargeObject.scala
@@ -13,7 +13,7 @@ import scalaz._, Scalaz._, scalaz.concurrent.Task
  */
 object PostgresLargeObject {
 
-  val xa: Transactor[Task] = 
+  val xa = 
     DriverManagerTransactor("org.postgresql.Driver", "jdbc:postgresql:world", "postgres", "")
 
   val prog: LargeObjectManagerIO[Long] =
@@ -24,7 +24,7 @@ object PostgresLargeObject {
     } yield oid
 
   val task: Task[Unit] =
-    PHC.pgGetLargeObjectAPI(prog).transact(xa) >>= { oid => 
+    PHC.pgGetLargeObjectAPI(prog).transact[Task](xa) >>= { oid => 
       Task.delay(Console.println("oid was " + oid))
     }
 

--- a/example/src/main/scala/example/PostgresNotify.scala
+++ b/example/src/main/scala/example/PostgresNotify.scala
@@ -40,7 +40,7 @@ object PostgresNotify {
     } yield n).onComplete(eval_(pgUnlisten(channel) *> HC.commit))
 
   /** A transactor that knows how to connect to a PostgreSQL database. */
-  val xa: Transactor[Task] = 
+  val xa = 
     DriverManagerTransactor("org.postgresql.Driver", "jdbc:postgresql:world", "postgres", "")
 
   /** 
@@ -52,7 +52,7 @@ object PostgresNotify {
       .map(n => s"${n.getPID} ${n.getName} ${n.getParameter}")
       .take(5)
       .sink(s => HC.delay(Console.println(s)))
-      .transact(xa)
+      .transact[Task](xa)
       .void
       .unsafePerformSync
 

--- a/example/src/main/scala/example/PostgresPoint.scala
+++ b/example/src/main/scala/example/PostgresPoint.scala
@@ -10,7 +10,7 @@ import scalaz.concurrent.Task
 
 object PostgresPoint extends App {
 
-  val xa = DriverManagerTransactor[Task]("org.postgresql.Driver", "jdbc:postgresql:world", "postgres", "")
+  val xa = DriverManagerTransactor("org.postgresql.Driver", "jdbc:postgresql:world", "postgres", "")
 
   // A custom Point type with a Meta instance xmapped from the PostgreSQL native type (which
   // would be weird to use directly in a data model). Note that the presence of this `Meta`
@@ -23,7 +23,7 @@ object PostgresPoint extends App {
 
   // Point is now a perfectly cromulent input/output type
   def q = sql"select '(1, 2)'::point".query[Point]
-  val a = q.list.transact(xa).unsafePerformSync
+  val a = q.list.transact[Task](xa).unsafePerformSync
   Console.println(a) // List(Point(1.0,2.0))
 
   // Just to be clear; the Composite instance has width 1, not 2

--- a/example/src/main/scala/example/postgrescopymanager.scala
+++ b/example/src/main/scala/example/postgrescopymanager.scala
@@ -39,7 +39,7 @@ object postgrescopymanager {
     ).intercalate("|")
 
 
-  lazy val xa: Transactor[Task] =
+  lazy val xa =
     DriverManagerTransactor("org.postgresql.Driver", "jdbc:postgresql:world", "postgres", "")
 
   object inputstream {
@@ -62,7 +62,7 @@ object postgrescopymanager {
       )
 
     val task: Task[Unit] =
-      PHC.pgGetCopyAPI(prog(citiesProcess)).transact(xa) >>= { count =>
+      PHC.pgGetCopyAPI(prog(citiesProcess)).transact[Task](xa) >>= { count =>
         Task.delay(Console.println(s"$count records inserted"))
       }
 
@@ -129,7 +129,7 @@ object postgrescopymanager {
       }
 
     val task: Task[Unit] =
-      PHC.pgGetCopyAPI(progIn *> progOut).transact(xa)
+      PHC.pgGetCopyAPI(progIn *> progOut).transact[Task](xa)
 
     def main(args: Array[String]): Unit =
       task.unsafePerformSync
@@ -191,7 +191,7 @@ object postgrescopymanager {
       }
 
     val task: Task[Unit] =
-      PHC.pgGetCopyAPI(progIn *> progOut).transact(xa)
+      PHC.pgGetCopyAPI(progIn *> progOut).transact[Task](xa)
 
     def main(args: Array[String]): Unit =
       task.unsafePerformSync

--- a/example/src/test/scala/doobie/AnalysisTestSpec.scala
+++ b/example/src/test/scala/doobie/AnalysisTestSpec.scala
@@ -7,8 +7,9 @@ import org.specs2.mutable.Specification
 
 import scalaz.concurrent.Task
 
-object AnalysisTestSpec extends Specification with AnalysisSpec {
-  val transactor = DriverManagerTransactor[Task]("org.postgresql.Driver", "jdbc:postgresql:world", "postgres", "")
+object AnalysisTestSpec extends Specification with AnalysisSpec[DriverManagerTransactor] {
+  val transactor = DriverManagerTransactor("org.postgresql.Driver", "jdbc:postgresql:world", "postgres", "")
+  val ev: Transactor[Task, DriverManagerTransactor] = implicitly
   // Commented tests fail!
   // check(AnalysisTest.speakerQuery(null, 0))
   check(AnalysisTest.speakerQuery2)


### PR DESCRIPTION
This is work in progress on series/0.3.x that turns `Transactor` into a multi-parameter typeclass (with a weaker `Connector` superclass). The goal is to get rid of subclassing as a means of abstraction and allow direct use of existing types as connection/transaction arbiters without wrapping.

- `Connector[M, A]` witnesses that a value of type `A` can construct an `M[Connection]` and gives rise to `ConnectionIO ~> M` *without* transaction semantics. This lets you run a `ConnectionIO` on a raw `Connection` without a transaction, or hop onto an existing connection managed by some other service.
- `Transactor[M, A]` is a refinement of `Connector[M, A]` that provides "safe" versions of the natural transformations defined by `Connector` that wrap a `ConnectionIO` program in transactional semantics as defined by a *pluggable* `LiftXA`. This provides the same functionality as in the `0.2.x` series but allows the user to manipulate the transactional structure, which currently requires a custom implementation.

User-level changes are:
- Current `Transactor` implementations go away but source-level stubs will allow most code to continue to compile. Anything with a declared type of `Transactor[M]` will need a new ascribed type.
- Calls to `.transact(xa)` become `transact[M](xa)` for some supported `M` like `Task` or `IO`.
- Constructing a `Yolo` from a transactor requires a type argument now, so `import xa.yolo._` must now be written in two steps: `val y = xa.yolo[IO]; import y._` due to stable identifier requirement for imports.

Task list:
- [x] core
- [x] h2
- [x] hikari
- [x] postgres
- [x] specs2
- [x] examples
- [x] bench
- [ ] docs
  - [x] get compiling
  - [ ] edit for transactor updates
  - [ ] publish book draft
  - [ ] publish scaladoc
- [x] bring readme and changelog up to date