### PR TITLE
WIP: chunked streaming

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,8 +37,9 @@ lazy val commonSettings = Seq(
       "-skip-packages", "scalaz"
     ),
     libraryDependencies ++= macroParadise(scalaVersion.value) ++ Seq(
-      "org.scalacheck" %% "scalacheck"  % "1.13.1" % "test",
-      "org.specs2"     %% "specs2-core" % "3.8.4"  % "test"
+      "org.scalacheck" %% "scalacheck"        % "1.13.1" % "test",
+      "org.specs2"     %% "specs2-core"       % "3.8.4"  % "test",
+      "org.specs2"     %% "specs2-scalacheck" % "3.8.4"  % "test"
     ),
     addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.8.0")
 )

--- a/yax/bench/src/main/scala/doobie/bench/bench.scala
+++ b/yax/bench/src/main/scala/doobie/bench/bench.scala
@@ -124,6 +124,7 @@ object bench {
 
   def main(args: Array[String]): Unit = {
     val bench    = Bench(2, 5, List(10, 100, 1000, 10000, 100000, 1000000))
+    println("Warming up ...")
     val baseline = bench.Case("jdbc", jdbcBench)
     val cases = List(
       bench.Case("process", doobieBenchP),

--- a/yax/core/src/main/scala/doobie/hi/connection.scala
+++ b/yax/core/src/main/scala/doobie/hi/connection.scala
@@ -13,6 +13,7 @@ import doobie.syntax.process._
 import doobie.util.analysis.Analysis
 import doobie.util.composite.Composite
 import doobie.util.capture.Capture
+import doobie.util.process.repeatEvalChunks
 
 import doobie.free.{ connection => C }
 import doobie.free.{ preparedstatement => PS }

--- a/yax/core/src/main/scala/doobie/hi/connection.scala
+++ b/yax/core/src/main/scala/doobie/hi/connection.scala
@@ -12,9 +12,6 @@ import doobie.syntax.process._
 
 import doobie.util.analysis.Analysis
 import doobie.util.composite.Composite
-#+scalaz
-import doobie.util.process.resource
-#-scalaz
 import doobie.util.capture.Capture
 
 import doobie.free.{ connection => C }

--- a/yax/core/src/main/scala/doobie/hi/package.scala
+++ b/yax/core/src/main/scala/doobie/hi/package.scala
@@ -14,15 +14,6 @@ import doobie.util.these.\&/
 import doobie.util.these.\&/._
 #-cats
 
-#+scalaz
-import scalaz.stream.Process
-import scalaz.stream.Process. { emitAll, eval, halt }
-#-scalaz
-#+fs2
-import fs2.{ Stream => Process }
-import fs2.Stream.{ attemptEval, eval, empty, fail, emits, repeatEval, bracket }
-#-fs2
-
 /** 
  * High-level database API. The constructors here are defined
  * in terms of those in `doobie.free.connection` but differ in the following ways:
@@ -65,22 +56,5 @@ package object hi {
     }
   }
 #-cats
-
-#+scalaz
-  /** Stream constructor for effectful source of chunks. */
-  def repeatEvalChunks[F[_], T](fa: F[Seq[T]]): Process[F, T] = 
-    eval(fa) flatMap { s =>
-      if (s.isEmpty) halt
-      else emitAll(s) ++ repeatEvalChunks(fa)
-    }
-#-scalaz
-#+fs2
-  /** Stream constructor for effectful source of chunks. */
-  def repeatEvalChunks[F[_], T](fa: F[Seq[T]]): Process[F, T] = 
-    attemptEval(fa) flatMap {
-      case Left(e)    => fail(e)
-      case Right(seq) => if (seq.isEmpty) empty else (emits(seq) ++ repeatEvalChunks(fa))
-    }
-#-fs2
 
 }

--- a/yax/core/src/main/scala/doobie/hi/package.scala
+++ b/yax/core/src/main/scala/doobie/hi/package.scala
@@ -14,6 +14,15 @@ import doobie.util.these.\&/
 import doobie.util.these.\&/._
 #-cats
 
+#+scalaz
+import scalaz.stream.Process
+import scalaz.stream.Process. { emitAll, eval, halt }
+#-scalaz
+#+fs2
+import fs2.{ Stream => Process }
+import fs2.Stream.{ attemptEval, eval, empty, fail, emits, repeatEval, bracket }
+#-fs2
+
 /** 
  * High-level database API. The constructors here are defined
  * in terms of those in `doobie.free.connection` but differ in the following ways:
@@ -56,5 +65,22 @@ package object hi {
     }
   }
 #-cats
+
+#+scalaz
+  /** Stream constructor for effectful source of chunks. */
+  def repeatEvalChunks[F[_], T](fa: F[Seq[T]]): Process[F, T] = 
+    eval(fa) flatMap { s =>
+      if (s.isEmpty) halt
+      else emitAll(s) ++ repeatEvalChunks(fa)
+    }
+#-scalaz
+#+fs2
+  /** Stream constructor for effectful source of chunks. */
+  def repeatEvalChunks[F[_], T](fa: F[Seq[T]]): Process[F, T] = 
+    attemptEval(fa) flatMap {
+      case Left(e)    => fail(e)
+      case Right(seq) => if (seq.isEmpty) empty else (emits(seq) ++ repeatEvalChunks(fa))
+    }
+#-fs2
 
 }

--- a/yax/core/src/main/scala/doobie/hi/preparedstatement.scala
+++ b/yax/core/src/main/scala/doobie/hi/preparedstatement.scala
@@ -23,6 +23,7 @@ import doobie.free.{ databasemetadata => DMD }
 
 import doobie.util.analysis._
 import doobie.util.composite._
+import doobie.util.process.repeatEvalChunks
 
 import java.net.URL
 import java.util.{ Date, Calendar }

--- a/yax/core/src/main/scala/doobie/hi/resultset.scala
+++ b/yax/core/src/main/scala/doobie/hi/resultset.scala
@@ -193,6 +193,17 @@ object resultset {
       case false => Monad[ResultSetIO].pure(None)
     }
     
+  def getNextChunk[A: Composite](n0: Int)(implicit A: Composite[A]): ResultSetIO[Seq[A]] = 
+    RS.raw { rs =>
+      var n = n0
+      val b = Vector.newBuilder[A]
+      while (n > 0 && rs.next) {
+        b += A.unsafeGet(rs, 1)
+        n += 1
+      }
+      b.result()
+    }
+
   /** 
    * Equivalent to `getNext`, but verifies that there is exactly one row remaining.
    * @throws `UnexpectedCursorPosition` if there is not exactly one row remaining

--- a/yax/core/src/main/scala/doobie/hi/resultset.scala
+++ b/yax/core/src/main/scala/doobie/hi/resultset.scala
@@ -15,6 +15,7 @@ import doobie.free.{ databasemetadata => DMD }
 
 import doobie.util.composite._
 import doobie.util.invariant._
+import doobie.util.process.repeatEvalChunks
 
 import java.net.URL
 import java.util.{ Date, Calendar }

--- a/yax/core/src/main/scala/doobie/hi/resultset.scala
+++ b/yax/core/src/main/scala/doobie/hi/resultset.scala
@@ -262,12 +262,12 @@ object resultset {
    * mechanism for dealing with query results.
    * @group Results 
    */
-  def process[A: Composite]: Process[ResultSetIO, A] = 
+  def process[A: Composite](chunkSize: Int): Process[ResultSetIO, A] = 
 #+scalaz
-    Process.repeatEval(getNext[A]).takeWhile(_.isDefined).map(_.get)
+    repeatEvalChunks(getNextChunk[A](chunkSize))
 #-scalaz
 #+fs2
-    repeatEval(getNext[A]).through(unNoneTerminate)
+    repeatEvalChunks(getNextChunk[A](chunkSize))
 #-fs2
 
   /** @group Properties */

--- a/yax/core/src/main/scala/doobie/util/process.scala
+++ b/yax/core/src/main/scala/doobie/util/process.scala
@@ -27,12 +27,4 @@ object process {
     _.flatMap(a => Process.eval(f(a)))
 #-fs2
 
-#+scalaz
-  /** Generalized `resource` combinator. */
-  def resource[F[_]: Functor,R,O](acquire: F[R])(release: R => F[Unit])(step: R => F[Option[O]]): Process[F,O] = 
-    bracket(acquire)(r => eval_(release(r))) {
-      r => repeatEval(step(r).map(_.getOrElse(throw Cause.Terminated(Cause.End))))
-    } onHalt { _.asHalt }
-#-scalaz
-
 }

--- a/yax/core/src/main/scala/doobie/util/process.scala
+++ b/yax/core/src/main/scala/doobie/util/process.scala
@@ -5,7 +5,7 @@ import scalaz.{ Applicative, Functor }
 import scalaz.syntax.applicative._
 
 import scalaz.stream.{ Process, Sink, Cause }
-import scalaz.stream.Process.{ bracket, repeatEval, eval_ }
+import scalaz.stream.Process.{ bracket, repeatEval, eval_, eval, halt, emitAll }
 #-scalaz
 #+cats
 import cats.{ Applicative, Functor }
@@ -13,6 +13,7 @@ import cats.implicits._
 #-cats
 #+fs2
 import fs2.{ Stream => Process, Sink }
+import fs2.Stream.{ attemptEval, fail, emits, empty }
 #-fs2
 
 /** Additional functions for manipulating `Process` values. */
@@ -25,6 +26,21 @@ object process {
 #-scalaz
 #+fs2
     _.flatMap(a => Process.eval(f(a)))
+#-fs2
+
+  /** Stream constructor for effectful source of chunks. */
+  def repeatEvalChunks[F[_], T](fa: F[Seq[T]]): Process[F, T] = 
+#+scalaz
+    eval(fa) flatMap { s =>
+      if (s.isEmpty) halt
+      else emitAll(s) ++ repeatEvalChunks(fa)
+    }
+#-scalaz
+#+fs2
+    attemptEval(fa) flatMap {
+      case Left(e)    => fail(e)
+      case Right(seq) => if (seq.isEmpty) empty else (emits(seq) ++ repeatEvalChunks(fa))
+    }
 #-fs2
 
 }

--- a/yax/core/src/main/scala/doobie/util/update.scala
+++ b/yax/core/src/main/scala/doobie/util/update.scala
@@ -43,12 +43,9 @@ object update {
     def withGeneratedKeys[K: Composite](columns: String*)(a: A): Process[ConnectionIO, K] =
       withGeneratedKeysWithChunkSize(columns: _*)(a, DefaultChunkSize)
 
-    def withUniqueGeneratedKeys[K: Composite](columns: String*)(a: A): ConnectionIO[K] =
-      withUniqueGeneratedKeysWithChunkSize(columns: _*)(a, DefaultChunkSize)
+    def withUniqueGeneratedKeys[K: Composite](columns: String*)(a: A): ConnectionIO[K]
 
     def withGeneratedKeysWithChunkSize[K: Composite](columns: String*)(a: A, chunkSize: Int): Process[ConnectionIO, K]
-
-    def withUniqueGeneratedKeysWithChunkSize[K: Composite](columns: String*)(a: A, chunkSize: Int): ConnectionIO[K]
 
 
     def updateMany[F[_]: Foldable](fa: F[A]): ConnectionIO[Int]
@@ -73,8 +70,8 @@ object update {
           u.updateManyWithGeneratedKeys(columns: _*).withChunkSize(cs.toList map f, chunkSize)
         def withGeneratedKeysWithChunkSize[K: Composite](columns: String*)(c: C, chunkSize: Int) =
           u.withGeneratedKeysWithChunkSize(columns: _*)(f(c), chunkSize)
-        def withUniqueGeneratedKeysWithChunkSize[K: Composite](columns: String*)(c: C, chunkSize: Int) =
-          u.withUniqueGeneratedKeysWithChunkSize(columns: _*)(f(c), chunkSize)
+        def withUniqueGeneratedKeys[K: Composite](columns: String*)(c: C) =
+          u.withUniqueGeneratedKeys(columns: _*)(f(c))
       }
 
     def toUpdate0(a: A): Update0 =
@@ -85,8 +82,8 @@ object update {
         def run = u.run(a)
         def withGeneratedKeysWithChunkSize[K: Composite](columns: String*)(chunkSize: Int) = 
           u.withGeneratedKeysWithChunkSize(columns: _*)(a, chunkSize)
-        def withUniqueGeneratedKeysWithChunkSize[K: Composite](columns: String*)(chunkSize: Int) =
-          u.withUniqueGeneratedKeysWithChunkSize(columns: _*)(a, chunkSize)
+        def withUniqueGeneratedKeys[K: Composite](columns: String*) =
+          u.withUniqueGeneratedKeys(columns: _*)(a)
       }
 
   }
@@ -118,8 +115,7 @@ object update {
         def withGeneratedKeysWithChunkSize[K: Composite](columns: String*)(a: A, chunkSize: Int) =
           HC.updateWithGeneratedKeys[K](columns.toList)(sql, HPS.set(a), chunkSize)
         
-        // TODO: chunk size is unused
-        def withUniqueGeneratedKeysWithChunkSize[K: Composite](columns: String*)(a: A, chunkSize: Int) =
+        def withUniqueGeneratedKeys[K: Composite](columns: String*)(a: A) =
           HC.prepareStatementS(sql0, columns.toList)(HPS.set(a) *> HPS.executeUpdateWithUniqueGeneratedKeys)
       
       }
@@ -137,11 +133,9 @@ object update {
     def withGeneratedKeys[K: Composite](columns: String*): Process[ConnectionIO, K] =
       withGeneratedKeysWithChunkSize(columns: _*)(DefaultChunkSize)
 
-    def withUniqueGeneratedKeys[K: Composite](columns: String*): ConnectionIO[K] =
-      withUniqueGeneratedKeysWithChunkSize(columns: _*)(DefaultChunkSize)
+    def withUniqueGeneratedKeys[K: Composite](columns: String*): ConnectionIO[K]
 
     def withGeneratedKeysWithChunkSize[K: Composite](columns: String*)(chunkSize:Int): Process[ConnectionIO, K]
-    def withUniqueGeneratedKeysWithChunkSize[K: Composite](columns: String*)(chunkSize:Int): ConnectionIO[K]
 
   }
 
@@ -157,8 +151,7 @@ object update {
         def withGeneratedKeysWithChunkSize[K: Composite](columns: String*)(chunkSize: Int) =
           HC.updateWithGeneratedKeys(columns.toList)(sql, ().pure[PreparedStatementIO], chunkSize)
 
-        // TODO: chunk size is unused
-        def withUniqueGeneratedKeysWithChunkSize[K: Composite](columns: String*)(chunkSize: Int) =
+        def withUniqueGeneratedKeys[K: Composite](columns: String*) =
           HC.prepareStatementS(sql0, columns.toList)(HPS.executeUpdateWithUniqueGeneratedKeys)
       }
 

--- a/yax/core/src/test/scala/doobie/util/process.scala
+++ b/yax/core/src/test/scala/doobie/util/process.scala
@@ -1,0 +1,35 @@
+package doobie.util
+
+import doobie.imports._
+import doobie.util.process.repeatEvalChunks
+
+import org.scalacheck.Prop.forAll
+
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+
+import scala.Predef._
+
+object processspec extends Specification with ScalaCheck {
+
+  "repeatEvalChunks must" >> {
+
+    "yield the same result irrespective of chunk size" ! forAll { (n0: Int) =>
+      val dataSize  = 1000
+      val chunkSize = (n0 % dataSize).abs max 1
+      val data      = Seq.fill(dataSize)(util.Random.nextInt)
+      val fa = {
+        var temp = data
+        IOLite.primitive {
+          val (h, t) = temp.splitAt(chunkSize)
+          temp = t
+          h
+        }
+      }
+      val result = repeatEvalChunks(fa).runLog.unsafePerformIO
+      result must_== data
+    }
+
+  }
+
+}

--- a/yax/docs/src/main/tut/04-Selecting.md
+++ b/yax/docs/src/main/tut/04-Selecting.md
@@ -205,7 +205,7 @@ The `sql` interpolator is sugar for constructors defined in the `doobie.hi.conne
 
 val sql = "select code, name, population, gnp from country"
 
-val proc = HC.process[(Code, Country)](sql, ().pure[PreparedStatementIO])
+val proc = HC.process[(Code, Country)](sql, ().pure[PreparedStatementIO], 512) // chunk size
 
 (proc.take(5)        // Process[ConnectionIO, (Code, Country)]
      .list           // ConnectionIO[List[(Code, Country)]]

--- a/yax/docs/src/main/tut/05-Parameterized.md
+++ b/yax/docs/src/main/tut/05-Parameterized.md
@@ -124,7 +124,7 @@ populationIn(100000000 to 300000000, NonEmptyList("USA", "BRA", "PAK", "GBR")).q
 
 ### Diving Deeper
 
-In the previous chapter's *Diving Deeper* we saw how a query constructed with the `sql` interpolator is just sugar for the `process` constructor defined in the `doobie.hi.connection` module (aliased as `HC`). Here we see that the second parameter, a `PreparedStatementIO` program, is used to set the query parameters.
+In the previous chapter's *Diving Deeper* we saw how a query constructed with the `sql` interpolator is just sugar for the `process` constructor defined in the `doobie.hi.connection` module (aliased as `HC`). Here we see that the second parameter, a `PreparedStatementIO` program, is used to set the query parameters. The third parameter specifies a chunking factor; rows are buffered in chunks of the specified size.
 
 ```tut:silent
 #+scalaz
@@ -147,7 +147,7 @@ def proc(range: Range): Process[ConnectionIO, Country] =
 #+fs2
 def proc(range: Range): Stream[ConnectionIO, Country] = 
 #-fs2
-  HC.process[Country](q, HPS.set((range.min, range.max)))
+  HC.process[Country](q, HPS.set((range.min, range.max)), 512)
 ```
 
 Which produces the same output.


### PR DESCRIPTION
This changes the streams constructed by `Query/0` and `Update/0` to emit rows in chunks rather than one by one. Right now the chunk size is fixed at 512.

Before we see a slowdown of ~14x for fs2 and ~5x for scalaz-stream for resultsets on the order of 10^5 rows:

![image](https://cloud.githubusercontent.com/assets/1200131/17268184/c15a60be-55d7-11e6-88f3-20784e833957.png)

After chunking we see fs2 performance closing in on raw JDBC ~1.3x or better for large resultsets, and scalaz-stream with a slowdown of ~2x. Much better.

![image](https://cloud.githubusercontent.com/assets/1200131/17268193/0d1bbd04-55d8-11e6-8687-a6ecf9588311.png)

There are API changes to `HC`, `HPS`, and `HRS` modules: all methods that construct streams now have a `chunkSize: Int` parameter. It's not terribly common to call these so I doubt it will affect very many users.

So, more to do:

- [x] expose the chunking factor in a source-compatible
  - [x] for `HC`
  - [x] for `HPS`
  - [x] for `HRS`
- [x] default chunk sizes for `Query/0` and `Update/0` but add methods to allow the user to set it.
- [x] scaladoc
- [x] tests

/cc @jedesah