### PR TITLE
Update to fs2 0.9.0-RC1

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The development version is **0.3.1-SNAPSHOT**. It is updated continuously and wi
 
 ### Cats Support
 
-The `0.3.1-SNAPSHOT` release is [also] compiled for [Cats 0.6.1](http://typelevel.org/cats/) with [FS2 0.9.0-M6](https://github.com/functional-streams-for-scala/fs2) for **2.11 only** (FS2 isn't available for 2.10 and Cats isn't available for 2.12).
+The `0.3.1-SNAPSHOT` release is [also] compiled for [Cats 0.6.1](http://typelevel.org/cats/) with [FS2 0.9.0-RC1](https://github.com/functional-streams-for-scala/fs2) for **2.11 only** (FS2 isn't available for 2.10 and Cats isn't available for 2.12).
 
 Doc links for Cats artifacts (no unidoc yet, sorry):
 [core](https://oss.sonatype.org/service/local/repositories/snapshots/archive/org/tpolecat/doobie-core_2.11/0.3.1-SNAPSHOT/doobie-core_2.11-0.3.1-SNAPSHOT-javadoc.jar/!/index.html)

--- a/build.sbt
+++ b/build.sbt
@@ -217,7 +217,7 @@ lazy val core_cats = project.in(file("modules-cats/core"))
     coreSettings("core-cats"),
     libraryDependencies ++= Seq(
       "org.typelevel"  %% "cats"     % "0.6.1",
-      "co.fs2"         %% "fs2-core" % "0.9.0-M5",
+      "co.fs2"         %% "fs2-core" % "0.9.0-RC1",
       "com.h2database" %  "h2"       % "1.3.170" % "test"
     )
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.12

--- a/yax/core/src/main/scala/doobie/util/compat.scala
+++ b/yax/core/src/main/scala/doobie/util/compat.scala
@@ -63,7 +63,14 @@ object compat {
 
 #+fs2
     object fs2 {
-      import _root_.fs2.util.{ ~> => Fs2Nat }
+      import _root_.fs2.util.{ Monad => Fs2Monad, ~> => Fs2Nat }
+
+      implicit def monadCompat[F[_]](implicit monad: Monad[F]): Fs2Monad[F] =
+        new Fs2Monad[F] {
+          def pure[A](a: A) = monad.pure(a)
+          override def map[A, B](fa: F[A])(f: A => B) = monad.map(fa)(f)
+          def flatMap[A, B](fa: F[A])(f: A => F[B]) = monad.flatMap(fa)(f)
+        }
 
       implicit def naturalTransformationCompat[F[_], G[_]](nat: CatsNat[F, G]): Fs2Nat[F, G] =
         new Fs2Nat[F, G] {

--- a/yax/core/src/main/scala/doobie/util/transactor.scala
+++ b/yax/core/src/main/scala/doobie/util/transactor.scala
@@ -27,6 +27,7 @@ import cats.implicits._
 #+fs2
 import fs2.{ Stream => Process }
 import fs2.Stream.{ eval, eval_ }
+import compat.cats.fs2._
 #-fs2
 
 import java.sql.Connection
@@ -93,7 +94,7 @@ object transactor {
         (before.p ++ pa ++ after.p) onFailure { e => oops.p ++ eval_(delay(throw e)) } onComplete always.p
 #-scalaz
 #+fs2
-        (before.p ++ pa ++ after.p) onError { e => oops.p ++ eval_(delay(throw e)) } onComplete always.p
+        (before.p ++ pa ++ after.p) onError { e => oops.p ++ eval_(delay(throw e)) } onFinalize always
 #-fs2        
 
       def apply[A](pa: Process[ConnectionIO, A]): Process[M, A] = 


### PR DESCRIPTION
The only breaking change was removal of `Stream#onComplete`. To replace it with `onFinalize` [as recommended](https://github.com/functional-streams-for-scala/fs2/blob/v0.9.0-RC1/docs/guide.md#-appendix-a2-how-interruption-of-streams-works), I had to add one more implicit conversion from `cats.Monad` to `fs2.util.Monad` to compat module.