### PR TITLE
wip: add scalatest module

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ It is likely that you will want one or more add-on libraries. **doobie** provide
 * `doobie-contrib-hikari` for [HikariCP](https://github.com/brettwooldridge/HikariCP) connection pooling.
 * `doobie-contrib-postgresql` for [PostgreSQL](http://postgresql.org)-specific type mappings.
 * `doobie-contrib-specs2` for [specs2](http://etorreborre.github.io/specs2/) support for typechecking queries.
+* `doobie-contrib-scalatest` for [scalatest](http://www.scalatest.org/) support for typechecking queries.
 
 See the [**book of doobie**](http://tpolecat.github.io/doobie-0.3.0/00-index.html) for more information on these add-ons.
 

--- a/build.sbt
+++ b/build.sbt
@@ -96,8 +96,8 @@ lazy val doobie = project.in(file("."))
   .settings(noPublishSettings)
   // .settings(unidocSettings)
   // .settings(unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(example, bench, docs))
-  .dependsOn(core, core_cats, h2, h2_cats, hikari, hikari_cats, postgres, postgres_cats, specs2, specs2_cats, example, example_cats, bench, bench_cats) //, docs, docs_cats
-  .aggregate(core, core_cats, h2, h2_cats, hikari, hikari_cats, postgres, postgres_cats, specs2, specs2_cats, example, example_cats, bench, bench_cats) //, docs, docs_cats
+  .dependsOn(core, core_cats, h2, h2_cats, hikari, hikari_cats, postgres, postgres_cats, specs2, specs2_cats, scalatest, scalatest_cats, example, example_cats, bench, bench_cats) //, docs, docs_cats
+  .aggregate(core, core_cats, h2, h2_cats, hikari, hikari_cats, postgres, postgres_cats, specs2, specs2_cats, scalatest, scalatest_cats, example, example_cats, bench, bench_cats) //, docs, docs_cats
   .settings(freeGenSettings)
   .settings(
     freeGenDir := file("yax/core/src/main/scala/doobie/free"),
@@ -165,8 +165,8 @@ lazy val ctut = taskKey[Unit]("Copy tut output to blog repo nearby.")
 /// CORE
 ///
 
-def coreSettings(mod: String) = 
-  doobieSettings  ++ 
+def coreSettings(mod: String) =
+  doobieSettings  ++
   publishSettings ++ Seq(
     name := "doobie-" + mod,
     description := "Pure functional JDBC layer for Scala.",
@@ -318,7 +318,7 @@ lazy val h2_cats = project.in(file("modules-cats/h2"))
 ///
 
 def hikariSettings(mod: String): Seq[Setting[_]] =
-  doobieSettings  ++ 
+  doobieSettings  ++
   publishSettings ++ Seq(
     name := "doobie-" + mod,
     description := "Hikari support for doobie.",
@@ -347,7 +347,7 @@ lazy val hikari_cats = project.in(file("modules-cats/hikari"))
 ///
 
 def specs2Settings(mod: String): Seq[Setting[_]] =
-  doobieSettings  ++ 
+  doobieSettings  ++
   publishSettings ++ Seq(
     name := "doobie-contrib-specs2",
     description := "Specs2 support for doobie.",
@@ -370,6 +370,36 @@ lazy val specs2_cats = project.in(file("modules-cats/specs2"))
     specs2Settings("specs2")
   )
   .dependsOn(core_cats)
+
+///
+/// SCALATEST
+///
+
+def scalatestSettings(mod: String): Seq[Setting[_]] =
+  doobieSettings  ++
+    publishSettings ++ Seq(
+    name := "doobie-contrib-scalatest",
+    description := "Scalatest support for doobie.",
+    libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.0"
+  )
+
+lazy val scalatest = project.in(file("modules/scalatest"))
+  .enablePlugins(SbtOsgi)
+  .settings(
+    yax(file("yax/scalatest"), "scalaz"),
+    scalatestSettings("scalatest"),
+    scalazCrossSettings
+  )
+  .dependsOn(core)
+
+lazy val scalatest_cats = project.in(file("modules-cats/scalatest"))
+  .enablePlugins(SbtOsgi)
+  .settings(
+    yax(file("yax/scalatest"), "cats"),
+    scalatestSettings("scalatest")
+  )
+  .dependsOn(core_cats)
+
 
 ///
 /// BENCH
@@ -395,7 +425,7 @@ lazy val bench_cats = project.in(file("modules-cats/bench"))
 def docsSettings(token: String, tokens: String*): Seq[Setting[_]] =
   doobieSettings          ++
   noPublishSettings       ++
-  tutSettings             ++ 
+  tutSettings             ++
   docSkipScala212Settings ++ Seq(
     ctut := {
       val src = crossTarget.value / "tut"

--- a/yax/scalatest/src/main/scala/doobie/scalatest/scalatest.scala
+++ b/yax/scalatest/src/main/scala/doobie/scalatest/scalatest.scala
@@ -25,7 +25,7 @@ import scala.reflect.runtime.universe.TypeTag
 import scalaz.{ -\/, \/- }
 #-scalaz
 #+cats
-import cats.data.Xor.{ Left => -\/, Right => \/- }
+import scala.util.{ Left => -\/, Right => \/- }
 #-cats
 
 /**

--- a/yax/scalatest/src/main/scala/doobie/scalatest/scalatest.scala
+++ b/yax/scalatest/src/main/scala/doobie/scalatest/scalatest.scala
@@ -1,0 +1,133 @@
+package doobie.scalatest
+
+import doobie.free.connection.ConnectionIO
+
+import doobie.util.transactor._
+import doobie.util.query._
+import doobie.util.update._
+import doobie.util.analysis._
+import doobie.util.pretty._
+import doobie.util.iolite.IOLite
+
+import doobie.free.connection.ConnectionIO
+import doobie.util.analysis._
+import doobie.util.iolite.IOLite
+import doobie.util.pretty._
+import doobie.util.query._
+import doobie.util.transactor._
+import doobie.util.update._
+
+import org.scalatest.{ FreeSpec, Matchers, TestSuite }
+
+import scala.reflect.runtime.universe.TypeTag
+
+#+scalaz
+import scalaz.{ -\/, \/- }
+#-scalaz
+#+cats
+import cats.data.Xor.{ Left => -\/, Right => \/- }
+#-cats
+
+/**
+ * Module with a mix-in trait for specifications that enables checking of doobie `Query` and `Update` values.
+ * {{{
+ * // An example specification, taken from the examples project.
+ * object AnalysisTestSpec extends AnalysisSpec {
+ *
+ *   // The transactor to use for the tests.
+ *   val transactor = DriverManagerTransactor[IOLite](
+ *     "org.postgresql.Driver", 
+ *     "jdbc:postgresql:world", 
+ *     "postgres", ""
+ *   )
+ *
+ *   // Now just mention the queries. Arguments are not used.
+ *   check(MyDaoModule.findByNameAndAge(null, 0))
+ *   check(MyDaoModule.allWoozles)
+ *
+ * }
+ * }}}
+ */
+
+object analysisspec {
+
+  type IgnoreReason = String
+  type ColumnName   = String
+
+  trait AnalysisSpec extends FreeSpec { self: TestSuite =>
+    def transactor: Transactor[IOLite]
+
+    def ignoreColumns: Map[ColumnName, IgnoreReason] = Map.empty[ColumnName, IgnoreReason]
+
+    def check[A, B](q: Query[A, B])(implicit A: TypeTag[A], B: TypeTag[B]) =
+      checkAnalysis(s"Query[${typeName(A)}, ${typeName(B)}]", q.stackFrame, q.sql, q.analysis)
+
+    def check[A](q: Query0[A])(implicit A: TypeTag[A]) =
+      checkAnalysis(s"Query0[${typeName(A)}]", q.stackFrame, q.sql, q.analysis)
+
+    def checkOutput[A](q: Query0[A])(implicit A: TypeTag[A]) =
+      checkAnalysis(s"Query0[${typeName(A)}]", q.stackFrame, q.sql, q.outputAnalysis)
+
+    def check[A](q: Update[A])(implicit A: TypeTag[A]) =
+      checkAnalysis(s"Update[${typeName(A)}]", q.stackFrame, q.sql, q.analysis)
+
+    def check[A](q: Update0)(implicit A: TypeTag[A]) =
+      checkAnalysis(s"Update0", q.stackFrame, q.sql, q.analysis)
+
+    private def checkAnalysis(typeName: String,
+                              stackFrame: Option[StackTraceElement],
+                              sql: String,
+                              analysis: ConnectionIO[Analysis]) =
+      s"$typeName defined at ${loc(stackFrame)}\n${sql.lines.map(s => "  " + s.trim).filterNot(_.isEmpty).mkString("\n")}" - {
+
+        "SQL Compiles and Typechecks" - {
+          transactor.trans(analysis).attempt.unsafePerformIO match {
+            case -\/(e) =>
+              "" in {
+                fail(formatError(e.getMessage))
+              }
+            case \/-(a) =>
+              a.paramDescriptions.foreach(x => assertIfNotIgnored(x._1, x._2, stackFrame))
+              a.columnDescriptions.foreach(x => assertIfNotIgnored(x._1, x._2, stackFrame))
+          }
+        }
+      }
+
+    private def assertIfNotIgnored(s: String,
+                                   es: List[AlignmentError],
+                                   stackFrame: Option[StackTraceElement]) =
+      (for {
+        column <- extractColumn.findFirstIn(s)
+        reason <- ignoreColumns.get(column)
+      } yield s + s"[ignore reason: $reason]" ignore {}).getOrElse {
+        assertEmpty(s, es, stackFrame)
+      }
+
+    private def loc(f: Option[StackTraceElement]): String =
+      f.map(f => s"${f.getFileName}:${f.getLineNumber}").getOrElse("(source location unknown)")
+
+    private def assertEmpty(s: String, es: List[AlignmentError], f: Option[StackTraceElement]) =
+      s in {
+        if (es.isEmpty) succeed
+        else fail(es.map(formatError).mkString("\n"))
+      }
+
+    private val packagePrefix = "\\b[a-z]+\\.".r
+
+    private def typeName[A](tag: TypeTag[A]): String =
+      packagePrefix.replaceAllIn(tag.tpe.toString, "")
+
+    private def formatError(e: AlignmentError): String =
+      formatError(e.msg)
+
+    private def formatError(s: String): String =
+      (wrap(80)(s) match {
+        case s :: ss => (s"x " + s) :: ss.map("  " + _)
+        case Nil     => Nil
+      }).mkString("\n")
+
+    private val extractColumn = """(?<=\()(.*?)(?=\))""".r
+
+  }
+
+}


### PR DESCRIPTION
This is just the most naive port of Specs2 stuff to Scalatest 

and option to ignore checking of some columns, because in our codebase we use postgres enums and they check fails for them even when query is valid. There is hacky way I extract column name using regex, so if someone could check it out ... I can also remove this functionality if it's desired to match specs2 stuff 1:1.

Lets see if it builds ...

resolves #350