### PR TITLE
Readme fix, minor version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The development version is **0.3.1-SNAPSHOT**. It is updated continuously and wi
 
 ### Cats Support
 
-The `0.3.1-SNAPSHOT` release is [also] compiled for [Cats 0.6.1](http://typelevel.org/cats/) with [FS2 0.9.0-RC1](https://github.com/functional-streams-for-scala/fs2) for **2.11 only** (FS2 isn't available for 2.10 and Cats isn't available for 2.12).
+The `0.3.1-SNAPSHOT` release is [also] compiled for [Cats 0.7.2](http://typelevel.org/cats/) with [FS2 0.9.0](https://github.com/functional-streams-for-scala/fs2) for **2.11 only** (FS2 isn't available for 2.10 and Cats isn't available for 2.12).
 
 Doc links for Cats artifacts (no unidoc yet, sorry):
 [core](https://oss.sonatype.org/service/local/repositories/snapshots/archive/org/tpolecat/doobie-core_2.11/0.3.1-SNAPSHOT/doobie-core_2.11-0.3.1-SNAPSHOT-javadoc.jar/!/index.html)

--- a/build.sbt
+++ b/build.sbt
@@ -217,8 +217,8 @@ lazy val core_cats = project.in(file("modules-cats/core"))
     yax(file("yax/core"), "cats", "fs2"),
     coreSettings("core-cats"),
     libraryDependencies ++= Seq(
-      "co.fs2"         %% "fs2-core"  % "0.9.0-RC2",
-      "co.fs2"         %% "fs2-cats"  % "0.1.0-RC2",
+      "co.fs2"         %% "fs2-core"  % "0.9.0",
+      "co.fs2"         %% "fs2-cats"  % "0.1.0",
       "org.typelevel"  %% "cats-core" % catsVersion,
       "org.typelevel"  %% "cats-free" % catsVersion,
       "org.typelevel"  %% "cats-laws" % catsVersion % "test",


### PR DESCRIPTION
I've noticed README shows old version... and I've also bumped versions... that should be fine I guess