### PR TITLE
bump h2, postgresql and hikariCP versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -205,7 +205,7 @@ lazy val core = project.in(file("modules/core"))
       "org.scalaz"        %% "scalaz-core"      % "7.2.4",
       "org.scalaz"        %% "scalaz-effect"    % "7.2.4",
       "org.scalaz.stream" %% "scalaz-stream"    % "0.8.2a",
-      "com.h2database"    %  "h2"               % "1.3.170" % "test"
+      "com.h2database"    %  "h2"               % "1.4.192" % "test"
     ),
     scalazCrossSettings
   )
@@ -253,7 +253,7 @@ def postgresSettings(mod: String): Seq[Setting[_]] =
     name  := "doobie-" + mod,
     description := "Postgres support for doobie.",
     libraryDependencies ++= Seq(
-      "org.postgresql" % "postgresql"   % "9.4-1201-jdbc41",
+      "org.postgresql" % "postgresql"   % "9.4.1211",
       "org.postgis"    % "postgis-jdbc" % "1.3.3" exclude("org.postgis", "postgis-stubs")
     ),
     initialCommands := """
@@ -322,7 +322,7 @@ def hikariSettings(mod: String): Seq[Setting[_]] =
   publishSettings ++ Seq(
     name := "doobie-" + mod,
     description := "Hikari support for doobie.",
-    libraryDependencies += "com.zaxxer" % "HikariCP-java6" % "2.2.5"
+    libraryDependencies += "com.zaxxer" % "HikariCP" % "2.5.1"
   )
 
 lazy val hikari = project.in(file("modules/hikari"))

--- a/yax/core/src/main/scala/doobie/enum/jdbctype.scala
+++ b/yax/core/src/main/scala/doobie/enum/jdbctype.scala
@@ -46,6 +46,7 @@ object jdbctype {
   /** @group Values */ case object Other         extends JdbcType(OTHER)
   /** @group Values */ case object Real          extends JdbcType(REAL)
   /** @group Values */ case object Ref           extends JdbcType(REF)
+  /** @group Values */ case object RefCursor     extends JdbcType(REF_CURSOR)
   /** @group Values */ case object RowId         extends JdbcType(ROWID)
   /** @group Values */ case object SmallInt      extends JdbcType(SMALLINT)
   /** @group Values */ case object SqlXml        extends JdbcType(SQLXML)
@@ -90,8 +91,9 @@ object jdbctype {
         case NVarChar.toInt      => NVarChar      
         case Other.toInt         => Other         
         case Real.toInt          => Real          
-        case Ref.toInt           => Ref           
-        case RowId.toInt         => RowId         
+        case Ref.toInt           => Ref
+        case RefCursor.toInt     => RefCursor
+        case RowId.toInt         => RowId
         case SmallInt.toInt      => SmallInt      
         case SqlXml.toInt        => SqlXml        
         case Struct.toInt        => Struct        

--- a/yax/postgres/src/main/scala/doobie/postgres/free/pgconnection.scala
+++ b/yax/postgres/src/main/scala/doobie/postgres/free/pgconnection.scala
@@ -19,6 +19,8 @@ import doobie.util.capture._
 
 import java.lang.Class
 import java.lang.String
+
+import org.postgresql.util.PGobject
 import org.postgresql.PGConnection
 import org.postgresql.PGNotification
 import org.postgresql.copy.CopyManager
@@ -83,7 +85,7 @@ object pgconnection {
 
     // Primitive Operations
     case class  AddDataType(a: String, b: String) extends PGConnectionOp[Unit]
-    case class  AddDataType1(a: String, b: Class[_]) extends PGConnectionOp[Unit]
+    case class  AddDataType1(a: String, b: Class[_ <: PGobject]) extends PGConnectionOp[Unit]
     case object GetBackendPID extends PGConnectionOp[Int]
     case object GetCopyAPI extends PGConnectionOp[CopyManager]
     case object GetFastpathAPI extends PGConnectionOp[Fastpath]
@@ -169,7 +171,7 @@ object pgconnection {
   /** 
    * @group Constructors (Primitives)
    */
-  def addDataType(a: String, b: Class[_]): PGConnectionIO[Unit] =
+  def addDataType(a: String, b: Class[_ <: PGobject]): PGConnectionIO[Unit] =
     F.liftF(AddDataType1(a, b))
 
   /** 


### PR DESCRIPTION
Since doobie 0.3 depends on jdk8+ , can't we use hikariCP for java8 for 0.3.1 ?