### PR TITLE
separate postgis to new module

### DIFF
--- a/yax/postgis/src/main/scala/doobie/postgis/pgtypes.scala
+++ b/yax/postgis/src/main/scala/doobie/postgis/pgtypes.scala
@@ -1,0 +1,49 @@
+package doobie.postgres
+
+import doobie.enum.jdbctype
+import doobie.imports._
+import doobie.util.invariant._
+
+import java.util.UUID
+import java.net.InetAddress
+
+import org.postgis._
+import org.postgresql.util._
+import org.postgresql.geometric._
+
+import scala.Predef._
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe.TypeTag
+
+/** `Meta` and `Atom` instances for Postgis types. */
+object pgtypes {
+
+  // PostGIS outer types
+  implicit val PGgeometryType = Meta.other[PGgeometry]("geometry")
+  implicit val PGbox3dType    = Meta.other[PGbox3d]("box3d")
+  implicit val PGbox2dType    = Meta.other[PGbox2d]("box2d")
+
+  // Constructor for geometry types via the `Geometry` member of PGgeometry
+  private def geometryType[A >: Null <: Geometry: TypeTag](implicit A: ClassTag[A]): Meta[A] =
+    PGgeometryType.nxmap[A](g =>
+      try A.runtimeClass.cast(g.getGeometry).asInstanceOf[A]
+      catch {
+        case _: ClassCastException => throw InvalidObjectMapping(A.runtimeClass, g.getGeometry.getClass)
+      }, new PGgeometry(_))
+
+  // PostGIS Geometry Types
+  implicit val GeometryType           = geometryType[Geometry]
+  implicit val ComposedGeomType       = geometryType[ComposedGeom]
+  implicit val GeometryCollectionType = geometryType[GeometryCollection]
+  implicit val MultiLineStringType    = geometryType[MultiLineString]
+  implicit val MultiPolygonType       = geometryType[MultiPolygon]
+  implicit val PointComposedGeomType  = geometryType[PointComposedGeom]
+  implicit val LineStringType         = geometryType[LineString]
+  implicit val MultiPointType         = geometryType[MultiPoint]
+  implicit val PolygonType            = geometryType[Polygon]
+  implicit val PointType              = geometryType[Point]
+}
+
+
+
+

--- a/yax/postgis/src/test/scala/doobie/postgis/pgtypes.scala
+++ b/yax/postgis/src/test/scala/doobie/postgis/pgtypes.scala
@@ -1,0 +1,86 @@
+package doobie.postgres
+
+import doobie.imports._
+import doobie.postgres.pgtypes._
+
+import org.postgis._
+import org.postgresql.util._
+import org.postgresql.geometric._
+import org.specs2.mutable.Specification
+
+#+scalaz
+import scalaz.{ Maybe, \/- }
+#-scalaz
+#+cats
+import scala.util.{ Left => -\/, Right => \/- }
+#-cats
+
+// Establish that we can write and read various types.
+object pgtypesspec extends Specification {
+
+  val xa = DriverManagerTransactor[IOLite](
+    "org.postgresql.Driver",
+    "jdbc:postgresql:world",
+    "postgres", ""
+  )
+
+  def inOut[A: Atom](col: String, a: A) =
+    for {
+      _  <- Update0(s"CREATE TEMPORARY TABLE TEST (value $col)", None).run
+      a0 <- Update[A](s"INSERT INTO TEST VALUES (?)", None).withUniqueGeneratedKeys[A]("value")(a)
+    } yield (a0)
+
+  def testInOut[A](col: String, a: A)(implicit m: Meta[A]) =
+    s"Mapping for $col as ${m.scalaType}" >> {
+      s"write+read $col as ${m.scalaType}" in {
+        inOut(col, a).transact(xa).attempt.unsafePerformIO must_== \/-(a)
+      }
+      s"write+read $col as Option[${m.scalaType}] (Some)" in {
+        inOut[Option[A]](col, Some(a)).transact(xa).attempt.unsafePerformIO must_== \/-(Some(a))
+      }
+      s"write+read $col as Option[${m.scalaType}] (None)" in {
+        inOut[Option[A]](col, None).transact(xa).attempt.unsafePerformIO must_== \/-(None)
+      }
+#+scalaz
+      s"write+read $col as Maybe[${m.scalaType}] (Just)" in {
+        inOut[Maybe[A]](col, Maybe.just(a)).transact(xa).attempt.unsafePerformIO must_== \/-(Maybe.Just(a))
+      }
+      s"write+read $col as Maybe[${m.scalaType}] (Empty)" in {
+        inOut[Maybe[A]](col, Maybe.empty[A]).transact(xa).attempt.unsafePerformIO must_== \/-(Maybe.Empty())
+      }
+#-scalaz
+    }
+
+  // PostGIS geometry types
+
+  // Random streams of geometry values
+  lazy val rnd: Iterator[Double]     = Stream.continually(util.Random.nextDouble).iterator
+  lazy val pts: Iterator[Point]      = Stream.continually(new Point(rnd.next, rnd.next)).iterator
+  lazy val lss: Iterator[LineString] = Stream.continually(new LineString(Array(pts.next, pts.next, pts.next))).iterator
+  lazy val lrs: Iterator[LinearRing] = Stream.continually(new LinearRing({ lazy val p = pts.next; Array(p, pts.next, pts.next, pts.next, p) })).iterator
+  lazy val pls: Iterator[Polygon]    = Stream.continually(new Polygon(lras.next)).iterator
+
+  // Streams of arrays of random geometry values
+  lazy val ptas: Iterator[Array[Point]]      = Stream.continually(Array(pts.next, pts.next, pts.next)).iterator
+  lazy val plas: Iterator[Array[Polygon]]    = Stream.continually(Array(pls.next, pls.next, pls.next)).iterator
+  lazy val lsas: Iterator[Array[LineString]] = Stream.continually(Array(lss.next, lss.next, lss.next)).iterator
+  lazy val lras: Iterator[Array[LinearRing]] = Stream.continually(Array(lrs.next, lrs.next, lrs.next)).iterator
+
+  // All these types map to `geometry`
+  def testInOutGeom[A <: Geometry: Meta](a: A) =
+    testInOut[A]("geometry", a)
+
+  testInOutGeom[Geometry](pts.next)
+  testInOutGeom[ComposedGeom](new MultiLineString(lsas.next))
+  testInOutGeom[GeometryCollection](new GeometryCollection(Array(pts.next, lss.next)))
+  testInOutGeom[MultiLineString](new MultiLineString(lsas.next))
+  testInOutGeom[MultiPolygon](new MultiPolygon(plas.next))
+  testInOutGeom[PointComposedGeom](lss.next)
+  testInOutGeom[LineString](lss.next)
+  testInOutGeom[MultiPoint](new MultiPoint(ptas.next))
+  testInOutGeom[Polygon](pls.next)
+  testInOutGeom[Point](pts.next)
+
+}
+
+

--- a/yax/postgres/src/main/scala/doobie/postgres/pgtypes.scala
+++ b/yax/postgres/src/main/scala/doobie/postgres/pgtypes.scala
@@ -7,7 +7,6 @@ import doobie.util.invariant._
 import java.util.UUID
 import java.net.InetAddress
 
-import org.postgis._
 import org.postgresql.util._
 import org.postgresql.geometric._
 
@@ -121,31 +120,6 @@ object pgtypes {
 
   // TODO: multidimensional arrays; in the worst case it's just copy/paste of everything above but
   // we can certainly do better than that.
-
-  // PostGIS outer types
-  implicit val PGgeometryType = Meta.other[PGgeometry]("geometry")
-  implicit val PGbox3dType    = Meta.other[PGbox3d]("box3d")
-  implicit val PGbox2dType    = Meta.other[PGbox2d]("box2d")
-
-  // Constructor for geometry types via the `Geometry` member of PGgeometry
-  private def geometryType[A >: Null <: Geometry: TypeTag](implicit A: ClassTag[A]): Meta[A] =
-    PGgeometryType.nxmap[A](g =>
-      try A.runtimeClass.cast(g.getGeometry).asInstanceOf[A]
-      catch {
-        case _: ClassCastException => throw InvalidObjectMapping(A.runtimeClass, g.getGeometry.getClass)
-      }, new PGgeometry(_))
-
-  // PostGIS Geometry Types
-  implicit val GeometryType           = geometryType[Geometry]
-  implicit val ComposedGeomType       = geometryType[ComposedGeom]
-  implicit val GeometryCollectionType = geometryType[GeometryCollection]
-  implicit val MultiLineStringType    = geometryType[MultiLineString]
-  implicit val MultiPolygonType       = geometryType[MultiPolygon]
-  implicit val PointComposedGeomType  = geometryType[PointComposedGeom]
-  implicit val LineStringType         = geometryType[LineString]
-  implicit val MultiPointType         = geometryType[MultiPoint]
-  implicit val PolygonType            = geometryType[Polygon]
-  implicit val PointType              = geometryType[Point]
 
   // It seems impossible to write a NULL value for an enum column/parameter using the current JDBC
   // driver, so we will define a mapping only for non-nullables. As a further twist, we read as 

--- a/yax/postgres/src/test/scala/doobie/postgres/pgtypes.scala
+++ b/yax/postgres/src/test/scala/doobie/postgres/pgtypes.scala
@@ -8,7 +8,6 @@ import java.net.InetAddress
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
 
-import org.postgis._
 import org.postgresql.util._
 import org.postgresql.geometric._
 import org.specs2.mutable.Specification
@@ -167,37 +166,6 @@ object pgtypesspec extends Specification {
   skip("tstzrange")
   skip("daterange")
   skip("custom")
-
-  // PostGIS geometry types
-
-  // Random streams of geometry values
-  lazy val rnd: Iterator[Double]     = Stream.continually(util.Random.nextDouble).iterator
-  lazy val pts: Iterator[Point]      = Stream.continually(new Point(rnd.next, rnd.next)).iterator
-  lazy val lss: Iterator[LineString] = Stream.continually(new LineString(Array(pts.next, pts.next, pts.next))).iterator
-  lazy val lrs: Iterator[LinearRing] = Stream.continually(new LinearRing({ lazy val p = pts.next; Array(p, pts.next, pts.next, pts.next, p) })).iterator
-  lazy val pls: Iterator[Polygon]    = Stream.continually(new Polygon(lras.next)).iterator
-
-  // Streams of arrays of random geometry values
-  lazy val ptas: Iterator[Array[Point]]      = Stream.continually(Array(pts.next, pts.next, pts.next)).iterator
-  lazy val plas: Iterator[Array[Polygon]]    = Stream.continually(Array(pls.next, pls.next, pls.next)).iterator
-  lazy val lsas: Iterator[Array[LineString]] = Stream.continually(Array(lss.next, lss.next, lss.next)).iterator
-  lazy val lras: Iterator[Array[LinearRing]] = Stream.continually(Array(lrs.next, lrs.next, lrs.next)).iterator
-
-  // All these types map to `geometry`
-  def testInOutGeom[A <: Geometry: Meta](a: A) =
-    testInOut[A]("geometry", a)
-
-  testInOutGeom[Geometry](pts.next)
-  testInOutGeom[ComposedGeom](new MultiLineString(lsas.next))
-  testInOutGeom[GeometryCollection](new GeometryCollection(Array(pts.next, lss.next)))
-  testInOutGeom[MultiLineString](new MultiLineString(lsas.next))
-  testInOutGeom[MultiPolygon](new MultiPolygon(plas.next))
-  testInOutGeom[PointComposedGeom](lss.next)
-  testInOutGeom[LineString](lss.next)
-  testInOutGeom[MultiPoint](new MultiPoint(ptas.next))
-  testInOutGeom[Polygon](pls.next)
-  testInOutGeom[Point](pts.next)
-
 }
 
 


### PR DESCRIPTION
Addresses #357 by separating postgis classes into different module. 

Another approach could be, as suggested by @tpolecat "just mark it as provided and ensure that it's only referenced in one object. If we do that you're fine unless you reference the object."