### PR TITLE
Add automatic derivation of Composite[Option[A]] for A: Composite

### DIFF
--- a/yax/core/src/main/scala/doobie/util/composite.scala
+++ b/yax/core/src/main/scala/doobie/util/composite.scala
@@ -34,10 +34,10 @@ import java.sql.ParameterMetaData
  */
 object composite {
 
-  @implicitNotFound("""Could not find or construct Composite[${A}]. 
-Ensure that this type has a Composite instance in scope; or is a Product type whose members have 
-Composite instances in scope; or is an atomic type with an Atom instance in scope. You can usually 
-diagnose this problem by trying to summon the Composite instance for each element in the REPL. See 
+  @implicitNotFound("""Could not find or construct Composite[${A}].
+Ensure that this type has a Composite instance in scope; or is a Product type whose members have
+Composite instances in scope; or is an atomic type with an Atom instance in scope. You can usually
+diagnose this problem by trying to summon the Composite instance for each element in the REPL. See
 the FAQ in the Book of Doobie for more hints.""")
   trait Composite[A] { c =>
     val set: (Int, A) => PS.PreparedStatementIO[Unit]
@@ -61,20 +61,20 @@ the FAQ in the Book of Doobie for more hints.""")
       }
   }
 
-  object Composite extends LowerPriorityComposite {
+  object Composite extends LowerPriorityComposite with CompositesDerivations {
 
     def apply[A](implicit A: Composite[A]): Composite[A] = A
 
     implicit val compositeInvariantFunctor: InvariantFunctor[Composite] =
       new InvariantFunctor[Composite] {
-#+scalaz        
+#+scalaz
         def xmap[A, B](ma: Composite[A], f: A => B, g: B => A): Composite[B] =
           ma.xmap(f, g)
-#-scalaz        
-#+cats        
+#-scalaz
+#+cats
         def imap[A, B](ma: Composite[A])(f: A => B)(g: B => A): Composite[B] =
           ma.imap(f)(g)
-#-cats              
+#-cats
       }
 
     implicit def fromAtom[A](implicit A: Atom[A]): Composite[A] =
@@ -96,6 +96,94 @@ the FAQ in the Book of Doobie for more hints.""")
         val meta = H.meta ++ T.meta
       }
 
+  }
+
+  trait CompositesDerivations {
+    import shapeless._
+    import shapeless.ops.hlist._
+    import tag.@@
+
+    private[CompositesDerivations] sealed trait Required
+    private[CompositesDerivations] object Required {
+      private val tagger = new tag.Tagger[Required]
+      def apply[T](t: T) = tagger(t)
+    }
+
+    private[CompositesDerivations] sealed trait Optional
+    private[CompositesDerivations] object Optional {
+      private val tagger = new tag.Tagger[Optional]
+      def apply[T](t: T) = tagger(t)
+    }
+
+    trait LowPriorityOptionify extends Poly1 {
+      implicit def caseDefault[A] =
+        at[A] { a => Required(Option(a)) }
+    }
+
+    object optionify extends LowPriorityOptionify {
+      implicit def caseOption[A] =
+        at[Option[A]] { a => Optional(a) }
+    }
+
+    object mergeOptions extends Poly2 {
+      implicit def caseOptional[H <: HList, A](implicit pre: Prepend[H, A :: HNil]) =
+        at[Option[H], Option[A] @@ Required] { (oh, oa) =>
+          for {
+            h <- oh
+            a <- oa
+          } yield h :+ a
+        }
+
+      implicit def caseRequired[H <: HList, A](implicit pre: Prepend[H, Option[A] :: HNil]) =
+        at[Option[H], Option[A] @@ Optional] { (oh, oa) =>
+          for {
+            h <- oh
+          } yield h :+ oa.asInstanceOf[Option[A]]
+        }
+    }
+
+    implicit def taggedCompositeRequired[T](implicit c: Composite[Option[T]]): Composite[Option[T] @@ Required] =
+      Composite[Option[T]].xmap(Required.apply, _.asInstanceOf[Option[T]])
+
+    implicit def taggedCompositeOptional[T](implicit c: Composite[Option[T]]): Composite[Option[T] @@ Optional] =
+      Composite[Option[T]].xmap(Optional.apply, _.asInstanceOf[Option[T]])
+
+    implicit def hlistGeneric[H <: HList] =
+      new Generic[H] {
+        type Repr = H
+        def from(r: H): H = r
+        def to(t: H): H = t
+      }
+
+    trait OptionalCompositeDerivation[A] {
+      def apply[Repr <: HList, MOut <: HList, L <: Nat](empty: Option[A])(implicit
+        gen: Lazy[Generic.Aux[A, Repr]],
+        map: Lazy[Mapper.Aux[optionify.type, Repr, MOut]],
+        comp: Lazy[Composite[MOut]],
+        lf: Lazy[LeftFolder.Aux[MOut, Option[shapeless.HNil.type], mergeOptions.type, Option[Repr]]],
+        length: Lazy[Length.Aux[Repr, L]],
+        fill: Lazy[Fill[L, None.type]]
+      ): Composite[Option[A]] = {
+        implicit val folder = lf.value
+        implicit val mapper = map.value
+        val nones = fill.value(None).asInstanceOf[MOut]
+        comp.value.xmap(
+          { mo =>
+            val res =
+              mo.foldLeft(Option(HNil))(mergeOptions)
+            // If all fields are Optional, and are all Nones,
+            // use the empty value
+            if (res == Option(nones)) empty
+            else res.map(gen.value.from)
+          },
+          _.map { a =>
+            gen.value.to(a).map(optionify)
+          }.getOrElse(nones)
+        )
+      }
+    }
+
+    def optional[A] = new OptionalCompositeDerivation[A]{}
   }
 
   // N.B. we're separating this out in order to make the atom ~> composite derivation higher
@@ -121,7 +209,7 @@ the FAQ in the Book of Doobie for more hints.""")
         val meta = Nil
       }
 
-    implicit def generic[F, G](implicit gen: Generic.Aux[F, G], G: Lazy[Composite[G]]): Composite[F] = 
+    implicit def generic[F, G](implicit gen: Generic.Aux[F, G], G: Lazy[Composite[G]]): Composite[F] =
       new Composite[F] {
         val set: (Int, F) => PS.PreparedStatementIO[Unit] = (n, f) => G.value.set(n, gen.to(f))
         val update: (Int, F) => RS.ResultSetIO[Unit] = (n, f) => G.value.update(n, gen.to(f))

--- a/yax/core/src/test/scala/doobie/util/composite.scala
+++ b/yax/core/src/test/scala/doobie/util/composite.scala
@@ -12,11 +12,11 @@ object compositespec extends Specification {
 
   case class LenStr2(n: Int, s: String)
   object LenStr2 {
-    implicit val LenStrMeta = 
+    implicit val LenStrMeta =
       Meta[String].nxmap[LenStr2](s => LenStr2(s.length, s), _.s)
   }
 
-  "Composite" should { 
+  "Composite" should {
 
     "exist for some fancy types" in {
       Composite[Int]
@@ -37,10 +37,10 @@ object compositespec extends Specification {
 
       type DL = (Double, Long)
       type A = Record.`'foo -> Int, 'bar -> String, 'baz -> DL, 'quz -> Woozle`.T
-      
+
       Composite[A]
       Composite[(A, A)]
-      
+
       true
     }
 
@@ -52,23 +52,34 @@ object compositespec extends Specification {
       Composite[LenStr2].length must_== 1
     }
 
+    "derive Composite[Option[A]] for all A: Composite" in {
+      import Composite._
+      implicit val optT1 = optional[(String, Int)](None)
+      implicit val optH1 = optional[Int :: String :: HNil](None)
+      implicit val optWoozle = optional[Woozle](None)
+      Composite[Option[(String, Int)]]
+      Composite[Option[Int :: String :: HNil]]
+      Composite[Option[Woozle]]
+      true
+    }
+
     // "work for products of ludicrous size (128)" in {
     //   Composite[
     //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
-    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
-    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
-    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
-    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
-    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
-    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
     //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
     //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
-    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
-    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
-    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
-    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
-    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
-    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: 
+    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
+    //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int ::
     //     Int :: Int :: Int :: Int :: Int :: Int :: Int :: Int :: HNil]
     //   true
     // }
@@ -81,14 +92,14 @@ object compositespec extends Specification {
     //     Option[String] :: Option[String] :: Option[String] :: Option[String] ::
     //     Option[String] :: Option[String] :: Option[String] :: Option[String] ::
     //     Option[String] :: Option[String] :: Option[String] :: Option[String] ::
-    //     Option[String] :: Option[String] :: Option[String] :: Option[String] :: 
-    //     Option[String] :: Option[String] :: Option[LocalDateTime] :: Option[LocalDateTime] :: 
-    //     Option[LocalDateTime] :: Option[LocalDateTime] :: Option[String] :: Option[String] :: 
+    //     Option[String] :: Option[String] :: Option[String] :: Option[String] ::
+    //     Option[String] :: Option[String] :: Option[LocalDateTime] :: Option[LocalDateTime] ::
+    //     Option[LocalDateTime] :: Option[LocalDateTime] :: Option[String] :: Option[String] ::
     //     Option[String] :: Option[String] :: Option[String] :: Option[String] ::
     //     Option[String] :: Option[String] :: Option[String] :: Option[String] ::
     //     Option[String] :: Option[String] :: Option[String] :: Option[String] ::
     //     Option[String] :: Option[String] :: Option[String] :: Option[String] ::
-    //     Option[String] :: Option[String] :: Option[String] :: Option[BigDecimal] :: 
+    //     Option[String] :: Option[String] :: Option[String] :: Option[BigDecimal] ::
     //     Option[String] :: Option[BigDecimal] :: Option[BigDecimal] ::
     //     Option[String] :: Option[String] :: Option[String] :: Option[String] ::
     //     Option[String] :: Option[String] :: Option[String] :: Option[String] ::


### PR DESCRIPTION
Following our discussion on https://github.com/tpolecat/doobie/issues/200, here's a first draft of semi-automatic derivation (sorry for the delay, I had less time than I expected last week...).

See the example in test. The user has to explicitly pass the "empty" value. It's a bit annoying because it's only necessary if every fields in A is an Option. The alternative would be to just use None in that case I guess ? In which case we could automatically derive everything.
