### PR TITLE
Fix Meta registration

### DIFF
--- a/yax/core/src/main/scala/doobie/util/meta.scala
+++ b/yax/core/src/main/scala/doobie/util/meta.scala
@@ -165,7 +165,9 @@ object meta {
       Order.orderBy(_.fold(
 #-scalaz
 #+cats
-      Order.by(_.fold(
+      // Type argument necessary to avoid spurious "illegal cyclic reference involving object Meta"
+      // only in Scala 2.11, and only with cats for whatever reason. Confidence high!
+      Order.by[Meta[_], (String, NonEmptyList[JdbcType], NonEmptyList[JdbcType], List[JdbcType]) \/ (String, NonEmptyList[JdbcType], NonEmptyList[JdbcType], NonEmptyList[String])](_.fold(
 #-cats
         b => -\/((b.scalaType, b.jdbcTarget, b.jdbcSource, b.jdbcSourceSecondary)),
         a => \/-((a.scalaType, a.jdbcTarget, a.jdbcSource, a.schemaTypes))))
@@ -186,9 +188,7 @@ object meta {
 
     // sorry
     private def reg(m: Meta[_]): Unit =
-      synchronized {
-          instances = instances + m
-      }
+      synchronized { instances = instances + m }
 
     implicit lazy val JdbcTypeMeta: Meta[doobie.enum.jdbctype.JdbcType] =
       IntMeta.xmap(doobie.enum.jdbctype.JdbcType.unsafeFromInt, _.toInt)

--- a/yax/core/src/main/scala/doobie/util/meta.scala
+++ b/yax/core/src/main/scala/doobie/util/meta.scala
@@ -7,6 +7,7 @@ import doobie.util.invariant._
 import java.sql.ResultSet
 
 import scala.annotation.implicitNotFound
+import scala.collection.immutable.TreeSet
 import scala.reflect.runtime.universe.TypeTag
 import scala.reflect.ClassTag
 import scala.Predef._
@@ -27,9 +28,8 @@ import shapeless.ops.hlist.IsHCons
 
 /** Module defining the lowest level of column mapping. */
 object meta {
-  type ISet[A] = Set[A]
-  val ISet = Set
-  /** 
+
+  /**
    * Metadata defining the column-level mapping to and from Scala type `A`. A given Scala type might
    * be read from or written to columns with a variety of JDBC and/or vendor-specific types,
    * depending on supported coercions and luck.
@@ -37,7 +37,7 @@ object meta {
   @implicitNotFound("Could not find an instance of Meta[${A}]; you can construct one based on a primitive instance via `xmap`.")
   sealed trait Meta[A] {
 
-    /** 
+    /**
      * Name of the Scala type, for diagnostic purposes. Smart constructors require a `TypeTag` to
      * guarantee this value is correct.
      */
@@ -45,10 +45,10 @@ object meta {
 
     /** Destination JDBC types to which values of type `A` can be written. */
     def jdbcTarget: NonEmptyList[JdbcType]
-    
+
     /** Source JDBC types from which values of type `A` can be read. */
     def jdbcSource: NonEmptyList[JdbcType]
-    
+
     /** Switch on the flavor of this `Meta`. */
     def fold[B](f: BasicMeta[A] => B, g: AdvancedMeta[A] => B): B
 
@@ -59,22 +59,22 @@ object meta {
     val get: Int => RS.ResultSetIO[A] = n => RS.raw(rs => unsafeGet(rs, n))
 
     /** Constructor for a `setXXX` operation for a given `A` at a given index. */
-    val set: (Int, A) => PS.PreparedStatementIO[Unit] 
+    val set: (Int, A) => PS.PreparedStatementIO[Unit]
 
     /** Constructor for an `updateXXX` operation for a given `A` at a given index. */
-    val update: (Int, A) => RS.ResultSetIO[Unit] 
+    val update: (Int, A) => RS.ResultSetIO[Unit]
 
     /** Constructor for a `setNull` operation for the primary JDBC type, at a given index. */
     val setNull: Int => PS.PreparedStatementIO[Unit]
 
     /**
-     * Invariant map (note that you must handle `null`; see `nxmap`). `Meta` is 
+     * Invariant map (note that you must handle `null`; see `nxmap`). `Meta` is
      * not quite an invariant functor because of the tag constraint, but I think it's worth the
      * sacrifice because we get much better diagnostic information as a result.
      */
     def xmap[B: TypeTag](f: A => B, g: B => A): Meta[B]
 
-    /** 
+    /**
      * Invariant map with `null` handling, for `A, B >: Null`; the functions `f` and `g` will
      * never be passed a `null` value.
      */
@@ -85,8 +85,8 @@ object meta {
   }
 
   /**
-   * `Meta` for "basic" JDBC types as defined by the specification. These include the basic numeric 
-   * and text types with distinct `get/setXXX` methods and fixed mappings that ostensibly work for 
+   * `Meta` for "basic" JDBC types as defined by the specification. These include the basic numeric
+   * and text types with distinct `get/setXXX` methods and fixed mappings that ostensibly work for
    * all compliant drivers. These types defined both "recommended" source types (`jdbcSource` here)
    * and "supported" types (`jdbcSourceSecondary`) which drivers must not reject outright, although
    * in many cases coercion failures are likely (reading an `Int` from a `VarChar` for instance) so
@@ -105,7 +105,7 @@ object meta {
     def canReadFrom(jdbc: JdbcType): Boolean =
       jdbcSource.element(jdbc)
 
-    /** 
+    /**
      * True if `A` might be readable from a column or 'out' parameter with the specified `JdbcType`,
      * taking into account non-recommended source types specified in `jdbcSourceSecondary`.
      */
@@ -120,14 +120,14 @@ object meta {
 
   /**
    * `Meta` for "advanced" JDBC types as defined by the specification. These include `Array`,
-   * `JavaObject`, `Struct`, and other types that require driver, schema, or vendor-specific 
+   * `JavaObject`, `Struct`, and other types that require driver, schema, or vendor-specific
    * knowledge and are unlikely to be portable between vendors (or indeed between applications).
-   * These mappings require (in addition to matching JDBC types) matching driver, schema, or 
+   * These mappings require (in addition to matching JDBC types) matching driver, schema, or
    * vendor-specific data types, sadly given as `String`s in JDBC.
-   */  
+   */
   sealed trait AdvancedMeta[A] extends Meta[A] {
 
-    /** 
+    /**
      * List of schema types to which values of type `A` can be written and from which they can be
      * read. Databases will often have several names for the same type, and the JDBC driver may
      * report an alias that doesn't appear in the schema or indeed in the database documentation.
@@ -135,16 +135,16 @@ object meta {
      */
     val schemaTypes: NonEmptyList[String]
 
-    /** 
+    /**
      * True if `A` can be written to a column or 'in' parameter with the specified `JdbcType` and
-     * schema types. 
+     * schema types.
      */
     def canWriteTo(jdbc: JdbcType, schema: String): Boolean =
       schemaTypes.element(schema) && jdbcTarget.element(jdbc)
 
-    /** 
+    /**
      * True if `A` can be read from a column or 'out' parameter with the specified `JdbcType` and
-     * schema types. 
+     * schema types.
      */
     def canReadFrom(jdbc: JdbcType, schema: String): Boolean =
       schemaTypes.element(schema) && jdbcSource.element(jdbc)
@@ -159,48 +159,59 @@ object meta {
   /** Constructors, accessors, and typeclass instances. */
   object Meta extends {
 
-    // See note on trait Meta above
-    private var instances: ISet[Meta[_]] = ISet.empty // scalastyle:ignore
+    /** @group Typeclass Instances */
+    implicit val MetaOrder: Order[Meta[_]] =
+#+scalaz
+      Order.orderBy(_.fold(
+#-scalaz
+#+cats
+      Order.by(_.fold(
+#-cats
+        b => -\/((b.scalaType, b.jdbcTarget, b.jdbcSource, b.jdbcSourceSecondary)),
+        a => \/-((a.scalaType, a.jdbcTarget, a.jdbcSource, a.schemaTypes))))
 
-//     /** @group Typeclass Instances */
-//     implicit val MetaOrder: Order[Meta[_]] =
-// #+scalaz
-//       Order.orderBy(_.fold(
-// #-scalaz        
-// #+cats
-//       Order.by(_.fold(
-// #-cats      
-//         b => -\/((b.scalaType, b.jdbcTarget, b.jdbcSource, b.jdbcSourceSecondary)),
-//         a => \/-((a.scalaType, a.jdbcTarget, a.jdbcSource, a.schemaTypes))))
-  
+    /** @group Typeclass Instances */
+    implicit val MetaOrdering: scala.Ordering[Meta[_]] =
+#+scalaz
+      MetaOrder.toScalaOrdering
+#-scalaz
+#+cats
+      MetaOrder.toOrdering
+#-cats
+
+    // See note on trait Meta above
+    private var instances: TreeSet[Meta[_]] = TreeSet.empty // scalastyle:ignore
+
   } with LowPriorityImplicits with MetaInstances {
 
     // sorry
-    private def reg(m: Meta[_]): Unit = 
-      synchronized { instances = instances + m }
+    private def reg(m: Meta[_]): Unit =
+      synchronized {
+          instances = instances + m
+      }
 
     implicit lazy val JdbcTypeMeta: Meta[doobie.enum.jdbctype.JdbcType] =
       IntMeta.xmap(doobie.enum.jdbctype.JdbcType.unsafeFromInt, _.toInt)
 
     def apply[A](implicit A: Meta[A]): Meta[A] = A
 
-    /** 
-     * Computes the set of know `Meta`s that support reading the indicated schema type. 
+    /**
+     * Computes the set of know `Meta`s that support reading the indicated schema type.
      * @group Accessors
      */
-    def readersOf(jdbc: JdbcType, schema: String): ISet[Meta[_]] =
+    def readersOf(jdbc: JdbcType, schema: String): TreeSet[Meta[_]] =
       instances.filter(_.fold(_.canReadFrom(jdbc), _.canReadFrom(jdbc, schema)))
 
-    /** 
-     * Computes the set of know `Meta`s that support writing the indicated schema type. 
+    /**
+     * Computes the set of know `Meta`s that support writing the indicated schema type.
      * @group Accessors
      */
-    def writersOf(jdbc: JdbcType, schema: String): ISet[Meta[_]] =
+    def writersOf(jdbc: JdbcType, schema: String): TreeSet[Meta[_]] =
       instances.filter(_.fold(_.canWriteTo(jdbc), _.canWriteTo(jdbc, schema)))
 
     /**
      * Construct a `BasicMeta` for the given type.
-     * @group Constructors     
+     * @group Constructors
      */
     def basic[A](
       jdbcTarget0: NonEmptyList[JdbcType],
@@ -208,7 +219,7 @@ object meta {
       jdbcSourceSecondary0: List[JdbcType],
       get0: (ResultSet, Int) => A,
       set0: (Int, A) => PS.PreparedStatementIO[Unit],
-      update0: (Int, A) => RS.ResultSetIO[Unit] 
+      update0: (Int, A) => RS.ResultSetIO[Unit]
     )(implicit ev: TypeTag[A]): BasicMeta[A] =
       new BasicMeta[A] {
         val scalaType = ev.tpe.toString
@@ -217,27 +228,27 @@ object meta {
         val jdbcSourceSecondary = jdbcSourceSecondary0
         def fold[B](f: BasicMeta[A] => B, g: AdvancedMeta[A] => B) = f(this)
         val (unsafeGet, set, update) = (get0, set0, update0)
-        def xmap[B: TypeTag](f: A => B, g: B => A): Meta[B] = 
+        def xmap[B: TypeTag](f: A => B, g: B => A): Meta[B] =
           basic[B](jdbcTarget, jdbcSource, jdbcSourceSecondary, (r, n) => f(unsafeGet(r, n)),
             (n, b) => set(n, g(b)), (n, b) => update(n, g(b)))
       } <| reg
 
     /**
      * Construct a `BasicMeta` for the given type, with symmetric primary mappings.
-     * @group Constructors     
+     * @group Constructors
      */
     def basic1[A](
       jdbcType: JdbcType,
       jdbcSourceSecondary0: List[JdbcType],
       get0: (ResultSet, Int) => A,
       set0: (Int, A) => PS.PreparedStatementIO[Unit],
-      update0: (Int, A) => RS.ResultSetIO[Unit] 
+      update0: (Int, A) => RS.ResultSetIO[Unit]
     )(implicit ev: TypeTag[A]): BasicMeta[A] =
       basic(NonEmptyListOf(jdbcType), NonEmptyListOf(jdbcType), jdbcSourceSecondary0, get0, set0, update0)
 
     /**
      * Construct an `AdvancedMeta` for the given type.
-     * @group Constructors     
+     * @group Constructors
      */
     def advanced[A](
       jdbcTypes: NonEmptyList[JdbcType],
@@ -253,18 +264,18 @@ object meta {
         val schemaTypes = schemaTypes0
         def fold[B](f: BasicMeta[A] => B, g: AdvancedMeta[A] => B) = g(this)
         val (unsafeGet, set, update) = (get0, set0, update0)
-        def xmap[B: TypeTag](f: A => B, g: B => A): Meta[B] = 
-          advanced[B](jdbcTypes, schemaTypes, (r, n) => f(unsafeGet(r, n)), (n, b) => set(n, g(b)), 
+        def xmap[B: TypeTag](f: A => B, g: B => A): Meta[B] =
+          advanced[B](jdbcTypes, schemaTypes, (r, n) => f(unsafeGet(r, n)), (n, b) => set(n, g(b)),
             (n, b) => update(n, g(b)))
       } <| reg
 
     /**
      * Construct an `AdvancedMeta` for the given type, mapped as JDBC `Array`.
-     * @group Constructors     
+     * @group Constructors
      */
     def array[A >: Null <: AnyRef: TypeTag](elementType: String, schemaH: String, schemaT: String*): AdvancedMeta[Array[A]] =
       advanced[Array[A]](NonEmptyListOf(JdbcArray), NonEmptyListOf(schemaH, schemaT : _*),
-        { (r, n) => 
+        { (r, n) =>
           val a = r.getArray(n)
           (if (a == null) null else a.getArray).asInstanceOf[Array[A]]
         },
@@ -274,7 +285,7 @@ object meta {
             arr  <- PS.lift(conn, C.createArrayOf(elementType, a.asInstanceOf[Array[AnyRef]]))
             _    <- PS.setArray(n, arr)
           } yield (),
-        (n, a) => 
+        (n, a) =>
           for {
             stmt <- RS.getStatement // somewhat irritating; no getConnection on ResultSet
             conn <- RS.lift(stmt, S.getConnection)
@@ -285,25 +296,25 @@ object meta {
 
     /**
      * Construct an `AdvancedMeta` for the given type, mapped as JDBC `Other,JavaObject`.
-     * @group Constructors     
+     * @group Constructors
      */
     def other[A >: Null <: AnyRef: TypeTag](schemaH: String, schemaT: String*)(implicit A: ClassTag[A]): AdvancedMeta[A] =
       advanced[A](NonEmptyListOf(Other, JavaObject), NonEmptyListOf(schemaH, schemaT : _*),
-        _.getObject(_) match { 
+        _.getObject(_) match {
           case null => null
-          case a    => 
+          case a    =>
             // force the cast here rather than letting a potentially ill-typed value escape
             try A.runtimeClass.cast(a).asInstanceOf[A]
             catch {
               case _: ClassCastException => throw InvalidObjectMapping(A.runtimeClass, a.getClass)
             }
         },
-        PS.setObject(_: Int, _: A), 
+        PS.setObject(_: Int, _: A),
         RS.updateObject(_: Int, _: A))
 
     // /**
     //  * Construct an `AdvancedMeta` for the given type, mapped as JDBC `Struct`.
-    //  * @group Constructors     
+    //  * @group Constructors
     //  */
     // def struct[A: TypeTag](schemaH: String, schemaT: String*): AdvancedMeta[A] =
     //   advanced[A](NonEmptyListOf(Struct), NonEmptyListOf(schemaH, schemaT : _*))
@@ -364,52 +375,52 @@ object meta {
 
     /** @group Instances */
     implicit val ByteMeta = Meta.basic1[Byte](
-      TinyInt, 
-      List(SmallInt, Integer, BigInt, Real, Float, Double, Decimal, Numeric, Bit, Char, VarChar, 
+      TinyInt,
+      List(SmallInt, Integer, BigInt, Real, Float, Double, Decimal, Numeric, Bit, Char, VarChar,
         LongVarChar),
       _.getByte(_), PS.setByte, RS.updateByte)
 
     /** @group Instances */
     implicit val ShortMeta = Meta.basic1[Short](
-      SmallInt, 
-      List(TinyInt, Integer, BigInt, Real, Float, Double, Decimal, Numeric, Bit, Char, VarChar, 
+      SmallInt,
+      List(TinyInt, Integer, BigInt, Real, Float, Double, Decimal, Numeric, Bit, Char, VarChar,
         LongVarChar),
       _.getShort(_), PS.setShort, RS.updateShort)
 
     /** @group Instances */
     implicit val IntMeta = Meta.basic1[Int](
-      Integer, 
-      List(TinyInt, SmallInt, BigInt, Real, Float, Double, Decimal, Numeric, Bit, Char, VarChar, 
+      Integer,
+      List(TinyInt, SmallInt, BigInt, Real, Float, Double, Decimal, Numeric, Bit, Char, VarChar,
         LongVarChar),
       _.getInt(_), PS.setInt, RS.updateInt)
 
     /** @group Instances */
     implicit val LongMeta = Meta.basic1[Long](
-      BigInt, 
-      List(TinyInt, Integer, SmallInt, Real, Float, Double, Decimal, Numeric, Bit, Char, VarChar, 
+      BigInt,
+      List(TinyInt, Integer, SmallInt, Real, Float, Double, Decimal, Numeric, Bit, Char, VarChar,
         LongVarChar),
       _.getLong(_), PS.setLong, RS.updateLong)
 
     /** @group Instances */
     implicit val FloatMeta = Meta.basic1[Float](
-      Real, 
-      List(TinyInt, Integer, SmallInt, BigInt, Float, Double, Decimal, Numeric, Bit, Char, VarChar, 
+      Real,
+      List(TinyInt, Integer, SmallInt, BigInt, Float, Double, Decimal, Numeric, Bit, Char, VarChar,
         LongVarChar),
       _.getFloat(_), PS.setFloat, RS.updateFloat)
 
     /** @group Instances */
     implicit val DoubleMeta = Meta.basic[Double](
-      NonEmptyListOf(Double), 
+      NonEmptyListOf(Double),
       NonEmptyListOf(Float, Double),
-      List(TinyInt, Integer, SmallInt, BigInt, Float, Real, Decimal, Numeric, Bit, Char, VarChar, 
+      List(TinyInt, Integer, SmallInt, BigInt, Float, Real, Decimal, Numeric, Bit, Char, VarChar,
         LongVarChar),
       _.getDouble(_), PS.setDouble, RS.updateDouble)
 
     /** @group Instances */
     implicit val BigDecimalMeta = Meta.basic[java.math.BigDecimal](
-      NonEmptyListOf(Numeric), 
-      NonEmptyListOf(Decimal, Numeric), 
-      List(TinyInt, Integer, SmallInt, BigInt, Float, Double, Real, Bit, Char, VarChar, 
+      NonEmptyListOf(Numeric),
+      NonEmptyListOf(Decimal, Numeric),
+      List(TinyInt, Integer, SmallInt, BigInt, Float, Double, Real, Bit, Char, VarChar,
         LongVarChar),
       _.getBigDecimal(_), PS.setBigDecimal, RS.updateBigDecimal)
 
@@ -417,7 +428,7 @@ object meta {
     implicit val BooleanMeta = Meta.basic[Boolean](
       NonEmptyListOf(Bit, JdbcBoolean),
       NonEmptyListOf(Bit, JdbcBoolean),
-      List(TinyInt, Integer, SmallInt, BigInt, Float, Double, Real, Decimal, Numeric, Char, VarChar, 
+      List(TinyInt, Integer, SmallInt, BigInt, Float, Double, Real, Decimal, Numeric, Char, VarChar,
         LongVarChar),
       _.getBoolean(_), PS.setBoolean, RS.updateBoolean)
 
@@ -425,10 +436,10 @@ object meta {
     implicit val StringMeta = Meta.basic[String](
       NonEmptyListOf(VarChar, Char, LongVarChar),
       NonEmptyListOf(Char, VarChar),
-      List(TinyInt, Integer, SmallInt, BigInt, Float, Double, Real, Decimal, Numeric, Bit, 
+      List(TinyInt, Integer, SmallInt, BigInt, Float, Double, Real, Decimal, Numeric, Bit,
         LongVarChar, Binary, VarBinary, LongVarBinary, Date, Time, Timestamp),
       _.getString(_), PS.setString, RS.updateString)
-  
+
     /** @group Instances */
     implicit val ByteArrayMeta = Meta.basic[Array[Byte]](
       NonEmptyListOf(Binary, VarBinary, LongVarBinary),
@@ -457,13 +468,13 @@ object meta {
     /** @group Instances */
     implicit val ScalaBigDecimalMeta: Meta[BigDecimal] =
       BigDecimalMeta.xmap(
-        a => if (a == null) null else BigDecimal(a), 
+        a => if (a == null) null else BigDecimal(a),
         a => if (a == null) null else a.bigDecimal)
 
     /** @group Instances */
     implicit val JavaUtilDateMeta: Meta[java.util.Date] =
       DateMeta.xmap(
-        a => a, 
+        a => a,
         d => if (d == null) null else new java.sql.Date(d.getTime))
 
     /** @group Instances */
@@ -480,4 +491,3 @@ object meta {
   }
 
 }
-

--- a/yax/core/src/test/scala/doobie/util/meta.scala
+++ b/yax/core/src/test/scala/doobie/util/meta.scala
@@ -1,7 +1,9 @@
 package doobie.util
 
 import shapeless._, shapeless.test._
+import scala.Predef.classOf
 import doobie.imports._
+import doobie.enum.jdbctype._
 import org.specs2.mutable.Specification
 
 object metaspec extends Specification {
@@ -12,6 +14,9 @@ object metaspec extends Specification {
 
   case class Z(i: Int, s: String)
   object S
+
+  case class Reg1(x: Int)
+  case class Reg2(x: Int)
 
   "Meta" should {
 
@@ -37,6 +42,18 @@ object metaspec extends Specification {
       illTyped("Meta[S.type]")
 
       true
+    }
+
+    "register new instances" in {
+      Meta[Reg1]
+      Meta.readersOf(Integer, "").filter(_.scalaType == "doobie.util.metaspec.Reg1").size must_== 1
+    }
+
+    "not register multiple equivalent instances" in {
+      Meta[Reg2]
+      Meta[Reg2]
+      Meta[Reg2]
+      Meta.readersOf(Integer, "").filter(_.scalaType == "doobie.util.metaspec.Reg2").size must_== 1
     }
 
   }


### PR DESCRIPTION
`Meta` instances are registered on construction as a side-effect. This is used by query checking to provide hints about known mappings if the asserted ones don't work.

In 0.3.0 there is a `scalaz.Order[Meta[_]]` and the instances live in an `ISet` but this doesn't work in Cats, so I temporarily switched it to `Set` to get things compiling but I never switched it back to a set that uses reasonable equality, which resulted in #394 … inductively derived instances were getting re-registered.

This fixes that by defining both `scalaz.Order` and `cats.Order`, and from there deriving `scala.Ordering` and using a `TreeSet` as storage.

fixes #394