### PR TITLE
ScalaTest output formatting, assertions.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -209,12 +209,12 @@ lazy val example = project.in(file("modules/example"))
     yax(file("yax/example"), "scalaz"),
     scalazCrossSettings
   )
-  .dependsOn(core, postgres, specs2, hikari, h2)
+  .dependsOn(core, postgres, specs2, scalatest, hikari, h2)
 
 lazy val example_cats = project.in(file("modules-cats/example"))
   .settings(doobieSettings ++ noPublishSettings)
   .settings(yax(file("yax/example"), "cats", "fs2"))
-  .dependsOn(core_cats, postgres_cats, specs2_cats, hikari_cats, h2_cats)
+  .dependsOn(core_cats, postgres_cats, specs2_cats, scalatest_cats, hikari_cats, h2_cats)
 
 ///
 /// POSTGRES

--- a/build.sbt
+++ b/build.sbt
@@ -427,9 +427,22 @@ lazy val docs = project.in(file("modules/docs"))
     docsSettings("scalaz"),
     scalazCrossSettings
   )
-  .dependsOn(core, postgres, specs2, hikari, h2)
-
+  .dependsOn(
+    core,
+    postgres,
+    specs2,
+    hikari,
+    h2,
+    scalatest
+  )
 
 lazy val docs_cats = project.in(file("modules-cats/docs"))
   .settings(docsSettings("cats", "fs2"))
-  .dependsOn(core_cats, postgres_cats, specs2_cats, hikari_cats, h2_cats)
+  .dependsOn(
+    core_cats, 
+    postgres_cats, 
+    specs2_cats, 
+    hikari_cats, 
+    h2_cats, 
+    scalatest_cats
+  )

--- a/yax/example/src/test/scala/doobie/AnalysisTestScalaTest.scala
+++ b/yax/example/src/test/scala/doobie/AnalysisTestScalaTest.scala
@@ -1,0 +1,20 @@
+package doobie.example
+
+import doobie.imports._
+import doobie.scalatest.QueryChecker
+import org.scalatest._
+
+class AnalysisTestScalaCheck extends FunSuite with Matchers with QueryChecker {
+  val transactor = DriverManagerTransactor[IOLite]("org.postgresql.Driver", "jdbc:postgresql:world", "postgres", "")
+
+  // Commented tests fail!
+//test("speakerQuery")  { check(AnalysisTest.speakerQuery(null, 0)) }
+  test("speakerQuery2") { check(AnalysisTest.speakerQuery2) }
+  test("arrayTest")     { check(AnalysisTest.arrayTest) }
+//test("arrayTest2")    { check(AnalysisTest.arrayTest2) }
+  test("pointTest")     { check(AnalysisTest.pointTest) }
+//test("pointTest2")    { check(AnalysisTest.pointTest2) }
+//test("update")        { check(AnalysisTest.update("foo", 42)) }
+  test("update2")       { check(AnalysisTest.update2) }
+
+}

--- a/yax/example/src/test/scala/doobie/AnalysisTestScalaTest.scala
+++ b/yax/example/src/test/scala/doobie/AnalysisTestScalaTest.scala
@@ -1,7 +1,7 @@
 package doobie.example
 
 import doobie.imports._
-import doobie.scalatest.QueryChecker
+import doobie.scalatest.imports._
 import org.scalatest._
 
 class AnalysisTestScalaCheck extends FunSuite with Matchers with QueryChecker {

--- a/yax/example/src/test/scala/doobie/AnalysisTestSpecs2.scala
+++ b/yax/example/src/test/scala/doobie/AnalysisTestSpecs2.scala
@@ -1,14 +1,10 @@
 package doobie.example
 
 import doobie.imports._
-
 import doobie.specs2.analysisspec._
-
 import org.specs2.mutable.Specification
 
-import scalaz.concurrent.Task
-
-object AnalysisTestSpec extends Specification with AnalysisSpec {
+object AnalysisTestSpecs2 extends Specification with AnalysisSpec {
   val transactor = DriverManagerTransactor[IOLite]("org.postgresql.Driver", "jdbc:postgresql:world", "postgres", "")
   // Commented tests fail!
   // check(AnalysisTest.speakerQuery(null, 0))
@@ -20,4 +16,3 @@ object AnalysisTestSpec extends Specification with AnalysisSpec {
   // check(AnalysisTest.update("foo", 42))
   check(AnalysisTest.update2)
 }
-

--- a/yax/specs2/src/main/scala/doobie/specs2/specs2.scala
+++ b/yax/specs2/src/main/scala/doobie/specs2/specs2.scala
@@ -65,7 +65,7 @@ object analysisspec {
       checkAnalysis(s"Update0", q.pos, q.sql, q.analysis)
 
     private def checkAnalysis(typeName: String, pos: Option[Pos], sql: String, analysis: ConnectionIO[Analysis]): Fragments =
-      s"$typeName defined at ${loc(pos)}\n${sql.lines.map(s => "  " + s.trim).filterNot(_.isEmpty).mkString("\n")}" >> {
+      s"\n$typeName defined at ${loc(pos)}\n${sql.lines.map(s => "  " + s.trim).filterNot(_.isEmpty).mkString("\n")}" >> {
         transactor.trans(analysis).attempt.unsafePerformIO match {
           case -\/(e) => Fragments("SQL Compiles and Typechecks" in failure(formatError(e.getMessage)))
           case \/-(a) => Fragments("SQL Compiles and Typechecks" in ok)


### PR DESCRIPTION
Various fixes for ScalaTest. Issue #406 requested that output be shown on success but there's not a way I can see to output a success message … I can print to the console but it's disconnected from the test summary so you don't know what test it's associated with.

There were some formatting issues I fixed, and it was running the analysis twice which wasn't ideal. The mixin was also over-constrained with a `FunSuite` self-type, which has been widened to `Assertions` so it can work with any ScalaTest style.

Todo:
- [x] add doc (resolves #370)