### PR TITLE
Add disclaimer about 1-based JDBC indexing to MappingViolation instances

### DIFF
--- a/yax/core/src/main/scala/doobie/util/invariant.scala
+++ b/yax/core/src/main/scala/doobie/util/invariant.scala
@@ -33,12 +33,15 @@ object invariant {
     def index: Int
     def jdbcType: JdbcType
   }
+
+  private def oneBasedDisclaimer = "Note that JDBC column indexing is 1-based."
+
   final case class NonNullableParameter(index: Int, jdbcType: JdbcType) 
-    extends MappingViolation(s"Scala `null` value passed as parameter $index (JDBC type $jdbcType); use an Option type here.")
+    extends MappingViolation(s"Scala `null` value passed as parameter $index (JDBC type $jdbcType); use an Option type here. $oneBasedDisclaimer")
   final case class NonNullableColumnUpdate(index: Int, jdbcType: JdbcType) 
-    extends MappingViolation(s"Scala `null` value passed as update to column $index (JDBC type $jdbcType); use an Option type here.")
+    extends MappingViolation(s"Scala `null` value passed as update to column $index (JDBC type $jdbcType); use an Option type here. $oneBasedDisclaimer")
   final case class NonNullableColumnRead(index: Int, jdbcType: JdbcType)
-    extends MappingViolation(s"SQL `NULL` read at column $index (JDBC type $jdbcType) but mapping is to a non-Option type; use Option here.")
+    extends MappingViolation(s"SQL `NULL` read at column $index (JDBC type $jdbcType) but mapping is to a non-Option type; use Option here. $oneBasedDisclaimer")
 
   /** Array violations. Not terribly illuminating at this point. */
   sealed abstract class ArrayStructureViolation(msg: String) extends InvariantViolation(msg)

--- a/yax/core/src/test/scala/doobie/util/invariant.scala
+++ b/yax/core/src/test/scala/doobie/util/invariant.scala
@@ -1,0 +1,12 @@
+package doobie.util
+
+import org.specs2.mutable.Specification
+
+object invariantspec extends Specification {
+  "NonNullableColumnRead" >> {
+    "include a one-based indexing disclaimer" in {
+      val ex = invariant.NonNullableColumnRead(1, doobie.enum.jdbctype.Array)
+      ex.getMessage must beMatching(".*is 1-based[.]$")
+    }
+  }
+}


### PR DESCRIPTION
I'm happy to do this differently if you like. I considered adding the disclaimer to the `MappingViolation` constructor.

It seemed likely that there'd be a need to add the disclaimer to a message in `yax/core/src/main/scala/doobie/util/analysis.scala`. However I couldn't find any messages which included the index, so I didn't make a change there. It might be worth double-checking my (non-)work in that file.