### PR TITLE
Problem: update statements not being logged

### DIFF
--- a/yax/core/src/main/scala/doobie/util/update.scala
+++ b/yax/core/src/main/scala/doobie/util/update.scala
@@ -115,7 +115,7 @@ object update {
      * @group Execution
      */
     def run(a: A): ConnectionIO[Int] =
-      HC.prepareStatement(sql)(HPS.set(ai(a)) *> HPS.executeUpdate)
+      HC.prepareStatement(sql)(HPS.set(ai(a)) *> executeUpdate(a))
 
     /**
      * Program to execute a batch update and yield a count of affected rows.


### PR DESCRIPTION
This PR corrects a trivial mistake where the custom `executeUpdate` function was never being called, which resulted in no logging output even if a handler was defined.

I dislike not having a test for the logging functionality for executeUpdate - but I wasn't sure how to add one so would appreciate some pointers.