### PR TITLE
add fail ctor

### DIFF
--- a/project/FreeGen2.scala
+++ b/project/FreeGen2.scala
@@ -260,6 +260,7 @@ class FreeGen2(managed: List[Class[_]], log: Logger) {
     |  def lift[F[_], J, A](j: J, fa: FF[F, A])(implicit ev: Embeddable[F, J]): FF[${sname}Op, A] = embed(j, fa)
     |  def delay[A](a: => A): ${sname}IO[A] = FF.liftF(Delay(() => a))
     |  def attempt[A](fa: ${sname}IO[A]): ${sname}IO[Throwable \\/ A] = FF.liftF[${sname}Op, Throwable \\/ A](Attempt(fa))
+    |  def fail[A](err: Throwable): ${sname}IO[A] = delay(throw err)
     |
     |  // Smart constructors for $sname-specific operations.
     |  ${ctors[A].map(_.lifted(sname)).mkString("\n  ")}
@@ -269,7 +270,7 @@ class FreeGen2(managed: List[Class[_]], log: Logger) {
     |  implicit val Catchable${sname}IO: Catchable[${sname}IO] with Capture[${sname}IO] =
     |    new Catchable[${sname}IO] with Capture[${sname}IO] {
     |      def attempt[A](f: ${sname}IO[A]): ${sname}IO[Throwable \\/ A] = ${sname.toLowerCase}.attempt(f)
-    |      def fail[A](err: Throwable): ${sname}IO[A] = delay(throw err)
+    |      def fail[A](err: Throwable): ${sname}IO[A] = ${sname.toLowerCase}.fail(err)
     |      def apply[A](a: => A): ${sname}IO[A] = ${sname.toLowerCase}.delay(a)
     |    }
     |#-scalaz
@@ -282,7 +283,7 @@ class FreeGen2(managed: List[Class[_]], log: Logger) {
     |      def suspend[A](fa: => ${sname}IO[A]): ${sname}IO[A] = FF.suspend(fa)
     |      override def delay[A](a: => A): ${sname}IO[A] = ${sname.toLowerCase}.delay(a)
     |      def attempt[A](f: ${sname}IO[A]): ${sname}IO[Throwable \\/ A] = ${sname.toLowerCase}.attempt(f)
-    |      def fail[A](err: Throwable): ${sname}IO[A] = delay(throw err)
+    |      def fail[A](err: Throwable): ${sname}IO[A] = ${sname.toLowerCase}.fail(err)
     |    }
     |#-fs2
     |

--- a/yax/core/src/main/scala/doobie/free/blob.scala
+++ b/yax/core/src/main/scala/doobie/free/blob.scala
@@ -147,6 +147,7 @@ object blob {
   def lift[F[_], J, A](j: J, fa: FF[F, A])(implicit ev: Embeddable[F, J]): FF[BlobOp, A] = embed(j, fa)
   def delay[A](a: => A): BlobIO[A] = FF.liftF(Delay(() => a))
   def attempt[A](fa: BlobIO[A]): BlobIO[Throwable \/ A] = FF.liftF[BlobOp, Throwable \/ A](Attempt(fa))
+  def fail[A](err: Throwable): BlobIO[A] = delay(throw err)
 
   // Smart constructors for Blob-specific operations.
   val free: BlobIO[Unit] = FF.liftF(Free)
@@ -166,7 +167,7 @@ object blob {
   implicit val CatchableBlobIO: Catchable[BlobIO] with Capture[BlobIO] =
     new Catchable[BlobIO] with Capture[BlobIO] {
       def attempt[A](f: BlobIO[A]): BlobIO[Throwable \/ A] = blob.attempt(f)
-      def fail[A](err: Throwable): BlobIO[A] = delay(throw err)
+      def fail[A](err: Throwable): BlobIO[A] = blob.fail(err)
       def apply[A](a: => A): BlobIO[A] = blob.delay(a)
     }
 #-scalaz
@@ -179,7 +180,7 @@ object blob {
       def suspend[A](fa: => BlobIO[A]): BlobIO[A] = FF.suspend(fa)
       override def delay[A](a: => A): BlobIO[A] = blob.delay(a)
       def attempt[A](f: BlobIO[A]): BlobIO[Throwable \/ A] = blob.attempt(f)
-      def fail[A](err: Throwable): BlobIO[A] = delay(throw err)
+      def fail[A](err: Throwable): BlobIO[A] = blob.fail(err)
     }
 #-fs2
 

--- a/yax/core/src/main/scala/doobie/free/callablestatement.scala
+++ b/yax/core/src/main/scala/doobie/free/callablestatement.scala
@@ -1044,6 +1044,7 @@ object callablestatement {
   def lift[F[_], J, A](j: J, fa: FF[F, A])(implicit ev: Embeddable[F, J]): FF[CallableStatementOp, A] = embed(j, fa)
   def delay[A](a: => A): CallableStatementIO[A] = FF.liftF(Delay(() => a))
   def attempt[A](fa: CallableStatementIO[A]): CallableStatementIO[Throwable \/ A] = FF.liftF[CallableStatementOp, Throwable \/ A](Attempt(fa))
+  def fail[A](err: Throwable): CallableStatementIO[A] = delay(throw err)
 
   // Smart constructors for CallableStatement-specific operations.
   val addBatch: CallableStatementIO[Unit] = FF.liftF(AddBatch)
@@ -1283,7 +1284,7 @@ object callablestatement {
   implicit val CatchableCallableStatementIO: Catchable[CallableStatementIO] with Capture[CallableStatementIO] =
     new Catchable[CallableStatementIO] with Capture[CallableStatementIO] {
       def attempt[A](f: CallableStatementIO[A]): CallableStatementIO[Throwable \/ A] = callablestatement.attempt(f)
-      def fail[A](err: Throwable): CallableStatementIO[A] = delay(throw err)
+      def fail[A](err: Throwable): CallableStatementIO[A] = callablestatement.fail(err)
       def apply[A](a: => A): CallableStatementIO[A] = callablestatement.delay(a)
     }
 #-scalaz
@@ -1296,7 +1297,7 @@ object callablestatement {
       def suspend[A](fa: => CallableStatementIO[A]): CallableStatementIO[A] = FF.suspend(fa)
       override def delay[A](a: => A): CallableStatementIO[A] = callablestatement.delay(a)
       def attempt[A](f: CallableStatementIO[A]): CallableStatementIO[Throwable \/ A] = callablestatement.attempt(f)
-      def fail[A](err: Throwable): CallableStatementIO[A] = delay(throw err)
+      def fail[A](err: Throwable): CallableStatementIO[A] = callablestatement.fail(err)
     }
 #-fs2
 

--- a/yax/core/src/main/scala/doobie/free/clob.scala
+++ b/yax/core/src/main/scala/doobie/free/clob.scala
@@ -158,6 +158,7 @@ object clob {
   def lift[F[_], J, A](j: J, fa: FF[F, A])(implicit ev: Embeddable[F, J]): FF[ClobOp, A] = embed(j, fa)
   def delay[A](a: => A): ClobIO[A] = FF.liftF(Delay(() => a))
   def attempt[A](fa: ClobIO[A]): ClobIO[Throwable \/ A] = FF.liftF[ClobOp, Throwable \/ A](Attempt(fa))
+  def fail[A](err: Throwable): ClobIO[A] = delay(throw err)
 
   // Smart constructors for Clob-specific operations.
   val free: ClobIO[Unit] = FF.liftF(Free)
@@ -179,7 +180,7 @@ object clob {
   implicit val CatchableClobIO: Catchable[ClobIO] with Capture[ClobIO] =
     new Catchable[ClobIO] with Capture[ClobIO] {
       def attempt[A](f: ClobIO[A]): ClobIO[Throwable \/ A] = clob.attempt(f)
-      def fail[A](err: Throwable): ClobIO[A] = delay(throw err)
+      def fail[A](err: Throwable): ClobIO[A] = clob.fail(err)
       def apply[A](a: => A): ClobIO[A] = clob.delay(a)
     }
 #-scalaz
@@ -192,7 +193,7 @@ object clob {
       def suspend[A](fa: => ClobIO[A]): ClobIO[A] = FF.suspend(fa)
       override def delay[A](a: => A): ClobIO[A] = clob.delay(a)
       def attempt[A](f: ClobIO[A]): ClobIO[Throwable \/ A] = clob.attempt(f)
-      def fail[A](err: Throwable): ClobIO[A] = delay(throw err)
+      def fail[A](err: Throwable): ClobIO[A] = clob.fail(err)
     }
 #-fs2
 

--- a/yax/core/src/main/scala/doobie/free/databasemetadata.scala
+++ b/yax/core/src/main/scala/doobie/free/databasemetadata.scala
@@ -817,6 +817,7 @@ object databasemetadata {
   def lift[F[_], J, A](j: J, fa: FF[F, A])(implicit ev: Embeddable[F, J]): FF[DatabaseMetaDataOp, A] = embed(j, fa)
   def delay[A](a: => A): DatabaseMetaDataIO[A] = FF.liftF(Delay(() => a))
   def attempt[A](fa: DatabaseMetaDataIO[A]): DatabaseMetaDataIO[Throwable \/ A] = FF.liftF[DatabaseMetaDataOp, Throwable \/ A](Attempt(fa))
+  def fail[A](err: Throwable): DatabaseMetaDataIO[A] = delay(throw err)
 
   // Smart constructors for DatabaseMetaData-specific operations.
   val allProceduresAreCallable: DatabaseMetaDataIO[Boolean] = FF.liftF(AllProceduresAreCallable)
@@ -1003,7 +1004,7 @@ object databasemetadata {
   implicit val CatchableDatabaseMetaDataIO: Catchable[DatabaseMetaDataIO] with Capture[DatabaseMetaDataIO] =
     new Catchable[DatabaseMetaDataIO] with Capture[DatabaseMetaDataIO] {
       def attempt[A](f: DatabaseMetaDataIO[A]): DatabaseMetaDataIO[Throwable \/ A] = databasemetadata.attempt(f)
-      def fail[A](err: Throwable): DatabaseMetaDataIO[A] = delay(throw err)
+      def fail[A](err: Throwable): DatabaseMetaDataIO[A] = databasemetadata.fail(err)
       def apply[A](a: => A): DatabaseMetaDataIO[A] = databasemetadata.delay(a)
     }
 #-scalaz
@@ -1016,7 +1017,7 @@ object databasemetadata {
       def suspend[A](fa: => DatabaseMetaDataIO[A]): DatabaseMetaDataIO[A] = FF.suspend(fa)
       override def delay[A](a: => A): DatabaseMetaDataIO[A] = databasemetadata.delay(a)
       def attempt[A](f: DatabaseMetaDataIO[A]): DatabaseMetaDataIO[Throwable \/ A] = databasemetadata.attempt(f)
-      def fail[A](err: Throwable): DatabaseMetaDataIO[A] = delay(throw err)
+      def fail[A](err: Throwable): DatabaseMetaDataIO[A] = databasemetadata.fail(err)
     }
 #-fs2
 

--- a/yax/core/src/main/scala/doobie/free/nclob.scala
+++ b/yax/core/src/main/scala/doobie/free/nclob.scala
@@ -158,6 +158,7 @@ object nclob {
   def lift[F[_], J, A](j: J, fa: FF[F, A])(implicit ev: Embeddable[F, J]): FF[NClobOp, A] = embed(j, fa)
   def delay[A](a: => A): NClobIO[A] = FF.liftF(Delay(() => a))
   def attempt[A](fa: NClobIO[A]): NClobIO[Throwable \/ A] = FF.liftF[NClobOp, Throwable \/ A](Attempt(fa))
+  def fail[A](err: Throwable): NClobIO[A] = delay(throw err)
 
   // Smart constructors for NClob-specific operations.
   val free: NClobIO[Unit] = FF.liftF(Free)
@@ -179,7 +180,7 @@ object nclob {
   implicit val CatchableNClobIO: Catchable[NClobIO] with Capture[NClobIO] =
     new Catchable[NClobIO] with Capture[NClobIO] {
       def attempt[A](f: NClobIO[A]): NClobIO[Throwable \/ A] = nclob.attempt(f)
-      def fail[A](err: Throwable): NClobIO[A] = delay(throw err)
+      def fail[A](err: Throwable): NClobIO[A] = nclob.fail(err)
       def apply[A](a: => A): NClobIO[A] = nclob.delay(a)
     }
 #-scalaz
@@ -192,7 +193,7 @@ object nclob {
       def suspend[A](fa: => NClobIO[A]): NClobIO[A] = FF.suspend(fa)
       override def delay[A](a: => A): NClobIO[A] = nclob.delay(a)
       def attempt[A](f: NClobIO[A]): NClobIO[Throwable \/ A] = nclob.attempt(f)
-      def fail[A](err: Throwable): NClobIO[A] = delay(throw err)
+      def fail[A](err: Throwable): NClobIO[A] = nclob.fail(err)
     }
 #-fs2
 

--- a/yax/core/src/main/scala/doobie/free/ref.scala
+++ b/yax/core/src/main/scala/doobie/free/ref.scala
@@ -120,6 +120,7 @@ object ref {
   def lift[F[_], J, A](j: J, fa: FF[F, A])(implicit ev: Embeddable[F, J]): FF[RefOp, A] = embed(j, fa)
   def delay[A](a: => A): RefIO[A] = FF.liftF(Delay(() => a))
   def attempt[A](fa: RefIO[A]): RefIO[Throwable \/ A] = FF.liftF[RefOp, Throwable \/ A](Attempt(fa))
+  def fail[A](err: Throwable): RefIO[A] = delay(throw err)
 
   // Smart constructors for Ref-specific operations.
   val getBaseTypeName: RefIO[String] = FF.liftF(GetBaseTypeName)
@@ -132,7 +133,7 @@ object ref {
   implicit val CatchableRefIO: Catchable[RefIO] with Capture[RefIO] =
     new Catchable[RefIO] with Capture[RefIO] {
       def attempt[A](f: RefIO[A]): RefIO[Throwable \/ A] = ref.attempt(f)
-      def fail[A](err: Throwable): RefIO[A] = delay(throw err)
+      def fail[A](err: Throwable): RefIO[A] = ref.fail(err)
       def apply[A](a: => A): RefIO[A] = ref.delay(a)
     }
 #-scalaz
@@ -145,7 +146,7 @@ object ref {
       def suspend[A](fa: => RefIO[A]): RefIO[A] = FF.suspend(fa)
       override def delay[A](a: => A): RefIO[A] = ref.delay(a)
       def attempt[A](f: RefIO[A]): RefIO[Throwable \/ A] = ref.attempt(f)
-      def fail[A](err: Throwable): RefIO[A] = delay(throw err)
+      def fail[A](err: Throwable): RefIO[A] = ref.fail(err)
     }
 #-fs2
 


### PR DESCRIPTION
This adds a `fail` constructor to each language. Resolves #479 

Relying on existing tests for error handling combinators.