### PR TITLE
Do not use refined's macros in tests

### DIFF
--- a/yax/refined/src/test/scala/doobie/refined/refinedtypes.scala
+++ b/yax/refined/src/test/scala/doobie/refined/refinedtypes.scala
@@ -3,7 +3,6 @@ package doobie.refined
 import org.specs2.mutable.Specification
 import eu.timepit.refined.api.{Refined, Validate}
 import eu.timepit.refined.numeric.Positive
-import eu.timepit.refined.auto._
 import eu.timepit.refined._
 import doobie.imports._
 import doobie.util.invariant._
@@ -89,7 +88,7 @@ object refinedtypes extends Specification {
     }
 
     "save a Some of a refined type" in {
-      val somePositiveInt: Option[PositiveInt] = Some(5)
+      val somePositiveInt: Option[PositiveInt] = refineV[Positive](5).toOption
       insertOptionalPositiveInt(somePositiveInt)
 
       true

--- a/yax/refined/src/test/scala/doobie/refined/refinedtypes.scala
+++ b/yax/refined/src/test/scala/doobie/refined/refinedtypes.scala
@@ -88,7 +88,7 @@ object refinedtypes extends Specification {
     }
 
     "save a Some of a refined type" in {
-      val somePositiveInt: Option[PositiveInt] = refineV[Positive](5).toOption
+      val somePositiveInt: Option[PositiveInt] = refineV[Positive](5).right.toOption
       insertOptionalPositiveInt(somePositiveInt)
 
       true


### PR DESCRIPTION
Using refined's macro in doobies tests leads to nondeterministic
compiler crashes (https://github.com/fthomas/refined/issues/260).
Fortunately these macros are not essential for testing doobie-refined,
so I removed its usage from the tests.