### PR TITLE
Composite instance for Unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ non-tpolecat contributors thus far: n4to4, Alexa DeWit, wedens, coltfred, Benjam
 - Added support for type refinements (refined library)
 - Added a `fail` constructor to all the `F*` modules.
 - Made `Meta.nxmap` unnecessary and fixed issues with mappings that are undefined for zero values of underlying unboxed types.
+- Added `Composite` instance for `Unit`.
 
 ### <a name="0.4.1"></a>New and Noteworthy for Version 0.4.1
 

--- a/yax/core/src/main/scala/doobie/util/composite.scala
+++ b/yax/core/src/main/scala/doobie/util/composite.scala
@@ -93,6 +93,14 @@ the FAQ in the Book of Doobie for more hints.""")
 #-cats
       }
 
+    implicit val unitComposite: Composite[Unit] =
+#+scalaz
+      emptyProduct.xmap(_ => (), _ => HNil)
+#-scalaz
+#+cats
+      emptyProduct.imap(_ => ())(_ => HNil)
+#-cats
+
     implicit def fromAtom[A](implicit A: Atom[A]): Composite[A] =
       new Composite[A] {
         val set = A.set

--- a/yax/core/src/test/scala/doobie/util/composite.scala
+++ b/yax/core/src/test/scala/doobie/util/composite.scala
@@ -33,6 +33,11 @@ object compositespec extends Specification {
       true
     }
 
+    "exist for Unit" in {
+      Composite[Unit]
+      Composite[(Int, Unit)].length must_== 1
+    }
+
     "exist for shapeless record types" in {
 
       type DL = (Double, Long)


### PR DESCRIPTION
`Composite[Unit]` has the same meaning as `Composite[HNil]`.
It allows fields that are ignored by database mapping. Such fields are useful for parametric types.
For example:
```scala
case class Topic[A](name: String, posts: A)
type TopicWithoutPosts = Topic[Unit]
// note there is only one column in select statement
sql"select name from topic".query[TopicWithoutPosts]
```