### PR TITLE
generic effect type for scalacheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ non-tpolecat contributors thus far: n4to4, Alexa DeWit, wedens, Colt Frederickso
 - Fix execution flow for AnalysisSpec checks.
 - Added mapping for Postgres `hstore` type.
 - Make postgres enums nullable (change `Atom` instance to `Meta`).
+- Generalized `QueryChecker` to allow any effect type.
 
 ### <a name="0.4.1"></a>New and Noteworthy for Version 0.4.1
 

--- a/build.sbt
+++ b/build.sbt
@@ -383,7 +383,10 @@ def scalaTestSettings(mod: String): Seq[Setting[_]] =
   publishSettings ++ Seq(
     name := s"doobie-$mod",
     description := "Scalatest support for doobie.",
-    libraryDependencies += "org.scalatest" %% "scalatest" % scalatestVersion
+    libraryDependencies ++= Seq(
+      "org.scalatest"  %% "scalatest" % scalatestVersion,
+      "com.h2database"  %  "h2"       % h2Version % "test"
+    )
   )
 
 lazy val scalatest = project.in(file("modules/scalatest"))

--- a/yax/docs/src/main/tut/13-Unit-Testing.md
+++ b/yax/docs/src/main/tut/13-Unit-Testing.md
@@ -110,7 +110,7 @@ The `doobie-scalatest-cats` add-on provides a mix-in trait that we can add to an
 import doobie.scalatest.imports._
 import org.scalatest._
 
-class AnalysisTestScalaCheck extends FunSuite with Matchers with QueryChecker {
+class AnalysisTestScalaCheck extends FunSuite with Matchers with IOLiteChecker {
 
   val transactor = DriverManagerTransactor[IOLite](
     "org.postgresql.Driver", "jdbc:postgresql:world", "postgres", ""

--- a/yax/example/src/test/scala/doobie/AnalysisTestScalaTest.scala
+++ b/yax/example/src/test/scala/doobie/AnalysisTestScalaTest.scala
@@ -8,7 +8,7 @@ import org.scalatest._
 import fs2.interop.cats._
 #-cats
 
-class AnalysisTestScalaCheck extends FunSuite with Matchers with QueryChecker {
+class AnalysisTestScalaCheck extends FunSuite with Matchers with IOLiteChecker {
   val transactor = DriverManagerTransactor[IOLite]("org.postgresql.Driver", "jdbc:postgresql:world", "postgres", "")
 
   // Commented tests fail!

--- a/yax/scalatest/src/main/scala/doobie/scalatest/Checker.scala
+++ b/yax/scalatest/src/main/scala/doobie/scalatest/Checker.scala
@@ -171,7 +171,7 @@ trait CheckerTask extends Checker[Task] {
   val monadM: Monad[Task] = implicitly
   val catchableM: Catchable[Task] = implicitly
   val captureM: Suspendable[Task] = implicitly
-  def unsafePerformIO[A](ma: Task[A]) = Await.result(ma.unsafeRunAsyncFuture, Duration.Inf)
+  def unsafePerformIO[A](ma: Task[A]) = ma.unsafeRun
 }
 #-cats
 

--- a/yax/scalatest/src/main/scala/doobie/scalatest/Checker.scala
+++ b/yax/scalatest/src/main/scala/doobie/scalatest/Checker.scala
@@ -1,7 +1,6 @@
 package doobie.scalatest
 
 import doobie.free.connection._
-import doobie.syntax.catchable.ToDoobieCatchableOps
 import doobie.util.analysis.{AlignmentError, Analysis}
 import doobie.util.pretty._
 import doobie.util.pos.Pos
@@ -49,17 +48,17 @@ import fs2.interop.cats._
   * }
   * }}}
   */
-trait Checker[M[_]] extends ToDoobieCatchableOps {
+trait Checker[M[_]] {
   self: Assertions =>
 
   // Effect type, required instances, unsafe run
-  val monadM: Monad[M]
-  val catchableM: Catchable[M]
+  implicit val monadM: Monad[M]
+  implicit val catchableM: Catchable[M]
 #+scalaz
-  val captureM: Capture[M]
+  implicit val captureM: Capture[M]
 #-scalaz
 #+cats
-  val captureM: Suspendable[M]
+  implicit val captureM: Suspendable[M]
 #-cats
   def unsafePerformIO[A](ma: M[A]): A
 
@@ -166,7 +165,7 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.Await
 
 /** Implementation of Checker[fs2.Task] */
-trait CheckerTask extends Checker[Task] {
+trait TaskChecker extends Checker[Task] {
   self: Assertions =>
   val monadM: Monad[Task] = implicitly
   val catchableM: Catchable[Task] = implicitly

--- a/yax/scalatest/src/main/scala/doobie/scalatest/imports.scala
+++ b/yax/scalatest/src/main/scala/doobie/scalatest/imports.scala
@@ -5,7 +5,7 @@ object imports {
   type Checker[M[_]] = doobie.scalatest.Checker[M]
   type IOLiteChecker = doobie.scalatest.IOLiteChecker
 
-  @deprecated("Use CheckerIOLite.", "0.4.2")
+  @deprecated("Use IOLiteChecker.", "0.4.2")
   type QueryChecker = IOLiteChecker
 
 }

--- a/yax/scalatest/src/main/scala/doobie/scalatest/imports.scala
+++ b/yax/scalatest/src/main/scala/doobie/scalatest/imports.scala
@@ -1,5 +1,11 @@
 package doobie.scalatest
 
 object imports {
-  type QueryChecker = doobie.scalatest.QueryChecker
+
+  type Checker[M[_]] = doobie.scalatest.Checker[M]
+  type IOLiteChecker = doobie.scalatest.IOLiteChecker
+
+  @deprecated("Use CheckerIOLite.", "0.4.2")
+  type QueryChecker = IOLiteChecker
+
 }

--- a/yax/scalatest/src/test/scala/doobie/scalatest/CheckerTests.scala
+++ b/yax/scalatest/src/test/scala/doobie/scalatest/CheckerTests.scala
@@ -1,0 +1,31 @@
+package doobie.scalatest
+
+import doobie.imports._
+import doobie.scalatest.imports._
+import org.scalatest._
+
+#+cats
+import fs2.Task
+#-cats
+#+scalaz
+import scalaz.concurrent.Task
+import scalaz.effect.IO
+#-scalaz
+
+trait CheckerChecks[M[_]] extends FunSuite with Matchers with Checker[M] {
+  lazy val transactor = DriverManagerTransactor[M](
+    "org.h2.Driver",
+    "jdbc:h2:mem:queryspec;DB_CLOSE_DELAY=-1",
+    "sa", ""
+  )
+  test("trivial") { check(sql"select 1".query[Int]) }
+}
+
+class IOLiteCheckerCheck extends CheckerChecks[IOLite] with IOLiteChecker
+#+cats
+class TaskCheckerCheck   extends CheckerChecks[Task]   with TaskChecker
+#-cats
+#+scalaz
+class TaskCheckerCheck   extends CheckerChecks[Task]   with TaskChecker
+class IOCheckerCheck     extends CheckerChecks[IO]     with IOChecker
+#-scalaz


### PR DESCRIPTION
This lets the scalacheck trait work with an arbitrary effect type.

resolves #448 
