### PR TITLE
Stream Alias for Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file summarizes **notable** changes for each release, but does not describe
 
 ### <a name="0.4.2"></a>Notable Work in Progress for Version 0.4.2
 
-non-tpolecat contributors thus far: n4to4, Alexa DeWit, wedens, Colt Frederickson, Benjamin Trenker, nigredo-tori, Suhas Gaddam
+non-tpolecat contributors thus far: n4to4, Alexa DeWit, wedens, Colt Frederickson, Benjamin Trenker, nigredo-tori, Suhas Gaddam, ChristopherDavenport
 
 - Replaced all the `doobie.free` internals with a new design that makes it practical to write your own interpreter (or, more commonly, subclass the default one) which is very useful for testing and who knows what else. For most users this will not be an observable change. Book update TBD.
 - Switched to a new transactor design that makes it simple to customize behavior, and combined with new interpreter design makes it practical to use **doobie** types in free coproducts (see `coproduct.scala` in the `example` project). This is a **minor breaking change**:
@@ -26,6 +26,7 @@ non-tpolecat contributors thus far: n4to4, Alexa DeWit, wedens, Colt Frederickso
 - Added mapping for Postgres `hstore` type.
 - Make postgres enums nullable (change `Atom` instance to `Meta`).
 - Generalized `QueryChecker` to allow any effect type.
+- Added `stream` and `streamWithChunkSize` as fs2 friendly aliases on `Query`.
 
 ### <a name="0.4.1"></a>New and Noteworthy for Version 0.4.1
 

--- a/yax/core/src/main/scala/doobie/util/query.scala
+++ b/yax/core/src/main/scala/doobie/util/query.scala
@@ -137,6 +137,13 @@ object query {
       HC.process[O](sql, HPS.set(ai(a)), chunkSize).map(ob)
 
     /**
+     * FS2 Friendly Alias for processWithChunkSize.
+     * @group Results
+     */
+    def streamWithChunkSize(a: A, chunkSize: Int): Process[ConnectionIO, B] =
+      processWithChunkSize(a, chunkSize)
+
+    /**
      * Apply the argument `a` to construct a `Process` with `DefaultChunkSize`, with
      * effect type  `[[doobie.free.connection.ConnectionIO ConnectionIO]]` yielding elements of
      * type `B`.
@@ -144,6 +151,13 @@ object query {
      */
     def process(a: A): Process[ConnectionIO, B] =
       processWithChunkSize(a, DefaultChunkSize)
+
+    /**
+     * FS2 Friendly Alias for process.
+     * @group Results
+     */
+    def stream(a: A): Process[ConnectionIO, B] =
+      process(a)
 
     /**
      * Apply the argument `a` to construct a program in
@@ -357,11 +371,25 @@ object query {
       processWithChunkSize(DefaultChunkSize)
 
     /**
+     * FS2 Friendly Alias for process.
+     * @group Results
+     */
+    def stream : Process[ConnectionIO, B] =
+      process
+
+    /**
      * `Process` with given chunk factor, with effect type
      * `[[doobie.free.connection.ConnectionIO ConnectionIO]]` yielding  elements of type `B`.
      * @group Results
      */
     def processWithChunkSize(n: Int): Process[ConnectionIO, B]
+
+    /**
+     * FS2 Friendly Alias for processWithChunkSize.
+     * @group Results
+     */
+    def streamWithChunkSize(n: Int): Process[ConnectionIO, B] =
+      processWithChunkSize(n)
 
     /**
      * Program in `[[doobie.free.connection.ConnectionIO ConnectionIO]]` yielding an `F[B]`


### PR DESCRIPTION
As discussed in gitter, alias methods for `.stream` and `streamWithChunkSize`