### PR TITLE
Hide extra type parameter in `Transactor`

### DIFF
--- a/yax/core/src/main/scala/doobie/imports.scala
+++ b/yax/core/src/main/scala/doobie/imports.scala
@@ -122,7 +122,7 @@ object imports extends ToDoobieCatchSqlOps
   /** @group Type Aliases */      type Param[A] = doobie.util.param.Param[A]
   /** @group Companion Aliases */ val  Param    = doobie.util.param.Param
 
-  /** @group Type Aliases */      type Transactor[M[_], A] = doobie.util.transactor.Transactor[M, A]
+  /** @group Type Aliases */      type Transactor[M[_]] = doobie.util.transactor.Transactor[M]
   /** @group Type Aliases */      val  Transactor          = doobie.util.transactor.Transactor
 
   /** @group Companion Aliases */ val DriverManagerTransactor = doobie.util.transactor.Transactor.DriverManagerTransactor

--- a/yax/core/src/main/scala/doobie/syntax/connectionio.scala
+++ b/yax/core/src/main/scala/doobie/syntax/connectionio.scala
@@ -13,7 +13,7 @@ import cats.Monad
 object connectionio {
 
   implicit class MoreConnectionIOOps[A](ma: ConnectionIO[A]) {
-    def transact[M[_]: Monad](xa: Transactor[M, _]): M[A] =
+    def transact[M[_]: Monad](xa: Transactor[M]): M[A] =
       xa.trans.apply(ma)
   }
 

--- a/yax/core/src/main/scala/doobie/syntax/process.scala
+++ b/yax/core/src/main/scala/doobie/syntax/process.scala
@@ -42,7 +42,7 @@ object process {
     def sink(f: A => F[Unit]): F[Unit] =
       fa.to(doobie.util.process.sink(f)).run
 
-    def transact[M[_]: Monad](xa: Transactor[M, _])(implicit ev: Process[F, A] =:= Process[ConnectionIO, A]): Process[M, A] =
+    def transact[M[_]: Monad](xa: Transactor[M])(implicit ev: Process[F, A] =:= Process[ConnectionIO, A]): Process[M, A] =
       xa.transP.apply(fa)
 
   }

--- a/yax/core/src/main/scala/doobie/util/yolo.scala
+++ b/yax/core/src/main/scala/doobie/util/yolo.scala
@@ -39,10 +39,10 @@ import Predef._
 object yolo {
 
 #+scalaz
-  class Yolo[M[_]: Monad: Catchable: Capture](xa: Transactor[M, _]) {
+  class Yolo[M[_]: Monad: Catchable: Capture](xa: Transactor[M]) {
 #-scalaz
 #+fs2
-  class Yolo[M[_]: Catchable: Suspendable](xa: Transactor[M, _]) {
+  class Yolo[M[_]: Catchable: Suspendable](xa: Transactor[M]) {
 #-fs2
 
     private def out(s: String): ConnectionIO[Unit] =

--- a/yax/core/src/test/scala/doobie/issue/262.scala
+++ b/yax/core/src/test/scala/doobie/issue/262.scala
@@ -29,14 +29,14 @@ object `262` extends Specification {
 
   }
 
-  val baseXa = DriverManagerTransactor[IOLite](
+  val baseXa = Transactor.fromDriverManager[IOLite](
     "org.h2.Driver",
     "jdbc:h2:mem:queryspec;DB_CLOSE_DELAY=-1",
     "sa", ""
   )
 
   // A transactor that uses our interpreter above
-  val xa: Transactor[IOLite, _] =
+  val xa: Transactor[IOLite] =
     Transactor.interpret.set(baseXa, Interp.ConnectionInterpreter)
 
   "getColumnJdbcMeta" should {

--- a/yax/example/src/main/scala/example/StreamingCopy.scala
+++ b/yax/example/src/main/scala/example/StreamingCopy.scala
@@ -26,8 +26,8 @@ object StreamingCopy {
     source: Stream[ConnectionIO, A],
     sink:   A => ConnectionIO[B]
   )(
-    sourceXA: Transactor[F, _],
-    sinkXA:   Transactor[F, _]
+    sourceXA: Transactor[F],
+    sinkXA:   Transactor[F]
   ): Stream[F, B] = {
 
     // Interpret a ConnectionIO into a Kleisli arrow for F via the sink interpreter.
@@ -74,8 +74,8 @@ object StreamingCopy {
     source: Stream[ConnectionIO, A],
     sink: A => ConnectionIO[B]
   )(
-    sourceXA: Transactor[F, _],
-    sinkXA: Transactor[F, _]
+    sourceXA: Transactor[F],
+    sinkXA: Transactor[F]
   ): F[Unit] =
     sinkXA.exec.apply {
       source
@@ -92,9 +92,9 @@ object StreamingCopy {
     HC.delay(Console.println(s"$tag: $s")) <* _
 
   /** Derive a new transactor that logs stuff. */
-  def addLogging[F[_], A](name: String)(xa: Transactor[F, A]): Transactor[F, A] = {
+  def addLogging[F[_], A](name: String)(xa: Transactor[F]): Transactor[F] = {
     import Transactor._ // bring the lenses into scope
-    val update: State[Transactor[F, A], Unit] =
+    val update: State[Transactor[F], Unit] =
       for {
         _ <- before %= printBefore(name, "before - setting up the connection")
         _ <- after  %= printBefore(name, "after - committing")

--- a/yax/h2/src/main/scala/doobie/h2/H2Transactor.scala
+++ b/yax/h2/src/main/scala/doobie/h2/H2Transactor.scala
@@ -17,7 +17,7 @@ import fs2.util.{ Catchable, Suspendable => Capture }
 /** Module for a `Transactor` backed by an H2 `JdbcConnectionPool`. */
 object h2transactor {
 
-  type H2Transactor[M[_]] = Transactor[M, JdbcConnectionPool]
+  type H2Transactor[M[_]] = Transactor.Aux[M, JdbcConnectionPool]
 
   implicit class H2TransactorOps[M[_]: Capture](h2: H2Transactor[M]) {
 

--- a/yax/hikari/src/main/scala/doobie/hikari/HikariTransactor.scala
+++ b/yax/hikari/src/main/scala/doobie/hikari/HikariTransactor.scala
@@ -18,7 +18,7 @@ import fs2.util.{ Catchable, Suspendable => Capture }
 
 object hikaritransactor {
 
-  type HikariTransactor[M[_]] = Transactor[M, HikariDataSource]
+  type HikariTransactor[M[_]] = Transactor.Aux[M, HikariDataSource]
 
   implicit class HikariTransactorOps[M[_]: Capture](xa: HikariTransactor[M]) {
     /** A program that shuts down this `HikariTransactor`. */

--- a/yax/scalatest/src/main/scala/doobie/scalatest/Checker.scala
+++ b/yax/scalatest/src/main/scala/doobie/scalatest/Checker.scala
@@ -62,7 +62,7 @@ trait Checker[M[_]] {
 #-cats
   def unsafePerformIO[A](ma: M[A]): A
 
-  def transactor: Transactor[M, _]
+  def transactor: Transactor[M]
 
 
   def check[A, B](q: Query[A, B])(implicit A: WeakTypeTag[A], B: WeakTypeTag[B]) =

--- a/yax/specs2/src/main/scala/doobie/specs2/specs2.scala
+++ b/yax/specs2/src/main/scala/doobie/specs2/specs2.scala
@@ -67,7 +67,7 @@ object analysisspec {
 #-cats
     def unsafePerformIO[A](ma: M[A]): A
 
-    def transactor: Transactor[M, _]
+    def transactor: Transactor[M]
 
     def check[A, B](q: Query[A, B])(implicit A: TypeTag[A], B: TypeTag[B]): Fragments =
       checkAnalysis(s"Query[${typeName(A)}, ${typeName(B)}]", q.pos, q.sql, q.analysis)


### PR DESCRIPTION
Type parameter `A` is removed from `Transactor` type signature. `Transactor` constructor now return `Aux` type so that you can retain `A` or throw it away if you don't need it.