### PR TITLE
Fix Travis builds for the new ubuntu trusty default environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ env:
 
 addons:
   postgresql: "9.3"
+  apt:
+    packages:
+    - postgresql-9.3-postgis-2.3
 
 before_script:
   - project/travis-before-build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,3 +50,4 @@ before_cache:
   - find $HOME/.sbt -name "*.lock" -type f -delete
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete
   - find $HOME/.coursier/cache -name "*.lock" -type f -delete
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
   postgresql: "9.3"
   apt:
     packages:
-    - postgresql-9.3-postgis-2.3
+    - postgresql-9.3-postgis-2.3 # This might not be necessary in the future. If the Travis people update the trusty env to include this package whenever it sees pg getting installed then this can go away.
 
 before_script:
   - project/travis-before-build.sh


### PR DESCRIPTION
Looks like the `precise` environment had the `postgresql-9.3-postgis-2.3` apt package installed by default, and `trusty` does not.  This was causing a failure whenever the before-script tried to create the postgis extension.  I added the package to `addons.apt.packages` in `.travis.yml`.  This [seems to have fixed the problem](https://travis-ci.org/Jacoby6000/doobie/jobs/257047857). Another solution would be to set the `dist` to `precise` in the build file, but if the default env is going to be `trusty` I figure it's best just to roll with it.