### PR TITLE
update release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Notable changes thus far:
 - Updated to cats 1.0.0-MF and fs2 0.10-M5, removed some interim stubs, changed all doc and examples to use `IO`.
 - `FreeGen2` code generator now generates all effect types with `cats.effect.Async` instances, in preparation for transactors that can make use of distinct thread pools for certain operations (JDBC primitives for instance). Free algebras and interpreters for Postgres are also generated now.
 - The doc has been ported to [sbt-microsites](https://github.com/47deg/sbt-microsites) and is undergoing review (help wanted!).
+- The release process is somewhat better.
 
 ### <a name="0.4.2"></a>New and Noteworthy for Version 0.4.2
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,55 +1,43 @@
 
-> *These notes are for Rob ... right now nobody else can publish.*
+## Publishing - 0.5.x Branch
 
-### Publishing a Snapshot
+Despite a bunch of experimentation and reading a bunch of blog posts I still can't figure out how to do releases automatically. It's complicated as all fuck. So I'm giving up for now. It's not that hard to do it by hand. This is actually a lot simpler than it used to be.
 
-To publish a snapshot build all that is needed is:
+*Right now only tpolecat can do a release. Sorry.*
 
-```
-> +publish
-```
+#### Publishing a Snapshot
 
-### Publishing a Release
-
-This is more involved :-\
-
-- Create a staging branch from the series tip:
+- This can be done at any time. You'll be prompted for the **gpg pass phrase**.
 
 ```
-git checkout -b 0.2.4-staging
+> +publishSigned
 ```
 
-- Edit `README.md`, `CHANGELOG.md`, and `01-Introduction.md` to ensure that the versions, etc. are correct, notable changes are listed, and contributors are credited. Commit these changes.
+#### Publishing a Release
 
-- Stage the tut doc in `tpolecat.github.io`:
-
-```
-> ++2.11.11 // to avoid warnings about unused imports
-...
-> tut
-...
-> ctut
-```
-
-- Remove the `-SNAPSHOT` suffix from the tut doc root and then update `_config.yml`. Remove the warning block from the `00-index.md`.
-
-- Update the version in `projects.html`.
-
-- Commit and push the doc. Ensure that links from `projects.html` work, and that it looks generally ok. Note that source links won't work from the scaladoc until the tag is created.
-
-- Commit and push the staging branch and ensure that doc links work and go to the correct versions. The `CHANGELOG` link will be wrong.
-
-- Attempt to release.
-```
-> release cross
-```
-
-- If all goes well, which is unlikely, it will ask for PGP keys. These are in a secure note in your keychain called "Sonatype/SBT PGP Keys". Eventually the build will crap out after pushing the branch. Finish up with:
+- Create a staging branch with a name like `v0.5.1-staging`.
+- Make sure `CHANGELOG.md` looks ok and has a section for the release version, and make sure all contributors are recognized and thanked. Any last-minute changes can be pushed to the staging branch.
+- Release. You will be prompted for the **version** and later for **gpg pass phrase**.
 
 ```
-> sonatypeReleaseAll
+> release
+```
+
+- We can't publish the doc as an sbt-release step due to sbt-microsites [#210](https://github.com/47deg/sbt-microsites/issues/210) and related sbt limitations. So for now we need to say
+
+```
+> project docs
+> set version := "<the version we just released>"
+> publishMicrosite
+> ^D
 ```
 
 - Push the release branch, open a PR and merge.
 
-- Have a cocktail.
+#### Announcing the Release
+
+- Update the Gitter room header.
+- Tweet the release. Keep it simple:
+  - version
+  - thank contributors
+  - link to repo

--- a/build.sbt
+++ b/build.sbt
@@ -152,6 +152,7 @@ lazy val publishSettings = Seq(
     </developers>
   ),
   releaseProcess := Nil,
+  releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   mappings in (Compile, packageSrc) ++= (managedSources in Compile).value pair relativeTo(sourceManaged.value / "main" / "scala")
 )
 
@@ -171,7 +172,6 @@ lazy val doobie = project.in(file("."))
   .aggregate(free, core, h2, hikari, postgres, specs2, example, bench, scalatest, docs, refined)
   .settings(
     releaseCrossBuild := true,
-    releasePublishArtifactsAction := PgpKeys.publishSigned.value,
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,
       inquireVersions,

--- a/build.sbt
+++ b/build.sbt
@@ -183,7 +183,8 @@ lazy val doobie = project.in(file("."))
       tagRelease,
       publishArtifacts,
       releaseStepCommand("sonatypeReleaseAll"),
-      releaseStepCommand("docs/publishMicrosite"),
+      // no, "docs/publishMicrosite" doesn't work
+      releaseStepCommand(";project docs; publishMicrosite; project /"),
       setNextVersion,
       commitNextVersion,
       pushChanges

--- a/build.sbt
+++ b/build.sbt
@@ -184,7 +184,8 @@ lazy val doobie = project.in(file("."))
       tagRelease,
       publishArtifacts,
       releaseStepCommand("sonatypeReleaseAll"),
-      releaseStepCommand(microsites.MicrositesPlugin.autoImport.publishMicrositeCommand),
+      // Doesn't work, rats. See https://github.com/47deg/sbt-microsites/issues/210
+      // releaseStepCommand("docs/publishMicrosite"),
       setNextVersion,
       commitNextVersion,
       pushChanges

--- a/build.sbt
+++ b/build.sbt
@@ -126,17 +126,8 @@ lazy val commonSettings =
     addCompilerPlugin("org.spire-math" %% "kind-projector" % kindProjectorVersion)
   )
 
-// Ok so for now if you're publishing you need to have signing keys locally. Note that the key
-// we're using (it's the only one in the ring but whatevs) is below in publishSettings.
-pgpPublicRing in Global := file(System.getProperty("user.home")) / ".sbt" / "gpg" / "doobie" / "pubring.gpg"
-pgpSecretRing in Global := file(System.getProperty("user.home")) / ".sbt" / "gpg" / "doobie" / "secring.gpg"
-
-// And if you wish you can pass the passphrase in the environment.
-pgpPassphrase in Global := sys.env.get("DOOBIE_PGP_PASS").map(_.toArray)
-
 lazy val publishSettings = Seq(
   useGpg := false,
-  usePgpKeyHex("89B1B6AF25AA090C"),
   publishMavenStyle := true,
   publishTo := {
     val nexus = "https://oss.sonatype.org/"

--- a/build.sbt
+++ b/build.sbt
@@ -151,22 +151,15 @@ lazy val publishSettings = Seq(
       </developer>
     </developers>
   ),
-  releaseCrossBuild := true,
-  releasePublishArtifactsAction := PgpKeys.publishSigned.value,
-  releaseProcess := Seq[ReleaseStep](
-    checkSnapshotDependencies,
-    inquireVersions,
-    runClean,
-    ReleaseStep(action = Command.process("package", _)),
-    setReleaseVersion,
-    commitReleaseVersion,
-    tagRelease,
-    ReleaseStep(action = Command.process("publishSigned", _)),
-    setNextVersion,
-    commitNextVersion,
-    ReleaseStep(action = Command.process("sonatypeReleaseAll", _)),
-    pushChanges),
+  releaseProcess := Nil,
   mappings in (Compile, packageSrc) ++= (managedSources in Compile).value pair relativeTo(sourceManaged.value / "main" / "scala")
+)
+
+lazy val noPublishSettings = Seq(
+  publish := (),
+  publishLocal := (),
+  publishArtifact := false,
+  releaseProcess := Nil
 )
 
 lazy val doobieSettings = buildSettings ++ commonSettings
@@ -176,12 +169,26 @@ lazy val doobie = project.in(file("."))
   .settings(noPublishSettings)
   .dependsOn(free, core, h2, hikari, postgres, specs2, example, bench, scalatest, docs, refined)
   .aggregate(free, core, h2, hikari, postgres, specs2, example, bench, scalatest, docs, refined)
-
-lazy val noPublishSettings = Seq(
-  publish := (),
-  publishLocal := (),
-  publishArtifact := false
-)
+  .settings(
+    releaseCrossBuild := true,
+    releasePublishArtifactsAction := PgpKeys.publishSigned.value,
+    releaseProcess := Seq[ReleaseStep](
+      checkSnapshotDependencies,
+      inquireVersions,
+      runClean,
+      runTest,
+      releaseStepCommand("docs/tut"),
+      setReleaseVersion,
+      commitReleaseVersion,
+      tagRelease,
+      publishArtifacts,
+      releaseStepCommand("sonatypeReleaseAll"),
+      releaseStepCommand("docs/publishMicrosite"),
+      setNextVersion,
+      commitNextVersion,
+      pushChanges
+    )
+  )
 
 lazy val free = project
   .in(file("modules/free"))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.0-M3"
+version in ThisBuild := "0.5.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.0-SNAPSHOT"
+version in ThisBuild := "0.5.0-M3"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.0-M5"
+version in ThisBuild := "0.5.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.0-SNAPSHOT"
+version in ThisBuild := "0.5.0-M5"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.0-SNAPSHOT"
+version in ThisBuild := "0.5.0-M4"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.0-M4"
+version in ThisBuild := "0.5.0-SNAPSHOT"


### PR DESCRIPTION
Ok this simplifies the release. Not as much as I'd like but it's a lot better. The big revelation is that `releaseCrossBuild` and `releaseProcess` need to be defined *only* in the top-level project, and `releaseProcess` should be `Nil` everywhere else just to prevent confusion.  And `publishMicrosite` can't be a `ReleaseStep` because computer says no (see https://github.com/47deg/sbt-microsites/issues/210).

![](https://media1.giphy.com/media/TuXtlb6AdqwsU/giphy.gif)

I tried setting up automatic releases but it's too fucking complicated. I need to do it from scratch on a dummy project first, then document the hell out of it.
