### PR TITLE
link to world.sql file fixed in docs

### DIFF
--- a/yax/docs/src/main/tut/01-Introduction.md
+++ b/yax/docs/src/main/tut/01-Introduction.md
@@ -29,7 +29,7 @@ This book is compiled as part of the build using the [tut](https://github.com/tp
 The example code assumes a local [PostgreSQL](http://www.postgresql.org/) server with a `postgres` user with no password, [PostGIS](http://postgis.net/) extensions (optional), and the sample `world` database loaded up. If you're on a Mac you might check out the excellent [Postgres.app](http://postgresapp.com/) if you don't want to install PostgreSQL as a service. You can set up the user and sample database (and an `enum` we use in a few examples) as follows:
 
 ```
-$ curl -O https://raw.githubusercontent.com/tpolecat/doobie/master/world.sql
+$ curl -O https://raw.githubusercontent.com/tpolecat/doobie/series/0.4.x/world.sql
 $ psql -c 'create user postgres createdb'
 $ psql -c 'create database world;' -U postgres
 $ psql -c '\i world.sql' -d world -U postgres


### PR DESCRIPTION
The already existing link does not work (probably because master branch has been deleted). The one I used works.

I spent 5 minutes looking for that, hope this PR will save this time for others :)