### PR TITLE
PGInterval

### DIFF
--- a/modules/postgres/src/main/scala/doobie/postgres/Instances.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/Instances.scala
@@ -43,8 +43,10 @@ trait Instances {
   //   org.postgresql.jdbc4.AbstractJdbc4ResultSet.internalGetObject(AbstractJdbc4ResultSet.java:300)
   //   org.postgresql.jdbc2.AbstractJdbc2ResultSet.getObject(AbstractJdbc2ResultSet.java:2704)
 
-  // Interval Type (TODO)
-  // implicit val PGIntervalType = Meta.other[PGInterval]
+  // Interval Type
+  // There is no natural mapping to java.time types (https://github.com/tpolecat/doobie/pull/315)
+  // so we provide the bare mapping and leave it at that.
+  implicit val PGIntervalType = Meta.other[PGInterval]("interval")
 
   // UUID
   implicit val UuidType = Meta.other[UUID]("uuid")

--- a/modules/postgres/src/test/scala/doobie/postgres/pgtypes.scala
+++ b/modules/postgres/src/test/scala/doobie/postgres/pgtypes.scala
@@ -82,7 +82,7 @@ object pgtypesspec extends Specification {
   testInOut("date", java.time.LocalDate.of(4,5,6))
   testInOut("time", new java.sql.Time(3,4,5))
   skip("time with time zone")
-  skip("interval")
+  testInOut("interval", new PGInterval(1, 2, 3, 4, 5, 6.7))
 
   // 8.6 Boolean Type
   testInOut("boolean", true)


### PR DESCRIPTION
This exposes the default `PGInterval` mapping provided by the driver. No mapping to a JDK type is attempted, see the discussion in #315.