### PR TITLE
Update 14-Managing-Connections.md

### DIFF
--- a/modules/docs/src/main/tut/docs/14-Managing-Connections.md
+++ b/modules/docs/src/main/tut/docs/14-Managing-Connections.md
@@ -68,7 +68,7 @@ val q = sql"select 42".query[Int].unique
 
 val p: IO[Int] = for {
   xa <- HikariTransactor[IO]("org.postgresql.Driver", "jdbc:postgresql:world", "postgres", "")
-  _  <- xa.configure(hx => IO( /* do something with hx */ ()))
+  _  <- xa.configure(hx => /* do something with hx */ ())
   a  <- q.transact(xa) guarantee xa.shutdown
 } yield a
 ```


### PR DESCRIPTION
The configure method does not take a `A => IO[B]` but a `A => B`, hence the code inside IO will be discarded. This fixes the doc but having the method take a `A => IO[B]` would be nicer !