### PR TITLE
[cats-1.0.0] Update Travis cache setup, bump to circe 0.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,8 @@ cache:
   - $HOME/.sbt/launchers
   - $HOME/.ivy2
   - $HOME/.coursier
+  - $HOME/.rvm/
+  - vendor/bundle
 
 before_cache:
   - du -h -d 1 $HOME/.ivy2/

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ notifications:
 
 cache:
   directories:
-  - $HOME/.sbt/0.13
+  - $HOME/.sbt/1.0
   - $HOME/.sbt/boot/scala*
   - $HOME/.sbt/cache
   - $HOME/.sbt/launchers

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ resolvers in Global += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/con
 
 // Library versions all in one place, for convenience and sanity.
 lazy val catsVersion          = "1.0.1"
-lazy val circeVersion         = "0.9.0-M3"
+lazy val circeVersion         = "0.9.0"
 lazy val fs2CoreVersion       = "0.10.0-M10"
 lazy val h2Version            = "1.4.196"
 lazy val hikariVersion        = "2.7.4"

--- a/modules/docs/src/main/tut/docs/12-Custom-Mappings.md
+++ b/modules/docs/src/main/tut/docs/12-Custom-Mappings.md
@@ -13,7 +13,7 @@ In this chapter we learn how to use custom `Meta` instances to map arbitrary dat
 The examples in this chapter require the `doobie-postgres` add-on, as well as the [circe](http://circe.io/) JSON library, which you can add to your build thus:
 
 ```scala
-val circeVersion = "0.7.0"
+val circeVersion = "0.9.0"
 
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-core",


### PR DESCRIPTION
_This PR is for cats-1.0.0 branch #650_

We've been still caching `~/.sbt/0.13` after migrating to sbt 1.0. I'm not sure it's the most significant cause of increaset build time, but it must be helpful.

Bumped to circe 0.9 as well, including example docs.