### PR TITLE
Update fs2 to 0.10.0-M11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
   - oraclejdk8
 
 scala:
-  - 2.11.11
+  - 2.11.12
   - 2.12.4
 
 env:

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ resolvers in Global += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/con
 // Library versions all in one place, for convenience and sanity.
 lazy val catsVersion          = "1.0.1"
 lazy val circeVersion         = "0.9.0"
-lazy val fs2CoreVersion       = "0.10.0-M10"
+lazy val fs2CoreVersion       = "0.10.0-M11"
 lazy val h2Version            = "1.4.196"
 lazy val hikariVersion        = "2.7.4"
 lazy val kindProjectorVersion = "0.9.5"
@@ -20,7 +20,7 @@ lazy val scalatestVersion     = "3.0.4"
 lazy val shapelessVersion     = "2.3.3"
 lazy val sourcecodeVersion    = "0.1.4"
 lazy val specs2Version        = "4.0.2"
-lazy val scala211Version      = "2.11.11"
+lazy val scala211Version      = "2.11.12"
 lazy val scala212Version      = "2.12.4"
 
 // Our set of warts

--- a/modules/core/src/main/scala/doobie/syntax/stream.scala
+++ b/modules/core/src/main/scala/doobie/syntax/stream.scala
@@ -10,13 +10,12 @@ import doobie.free.connection.ConnectionIO
 import scala.Predef.=:=
 
 import cats.effect.{ Effect, Sync }
-import cats.implicits._
 import fs2.Stream
 
 class StreamOps[F[_]: Sync, A](fa: Stream[F, A]) {
-  def vector: F[Vector[A]] = fa.runLog.map(_.toVector)
-  def list: F[List[A]] = fa.runLog.map(_.toList)
-  def sink(f: A => F[Unit]): F[Unit] = fa.evalMap(f).run
+  def vector: F[Vector[A]] = fa.compile.toVector
+  def list: F[List[A]] = fa.compile.toList
+  def sink(f: A => F[Unit]): F[Unit] = fa.evalMap(f).compile.drain
   def transact[M[_]: Effect](xa: Transactor[M])(implicit ev: Stream[F, A] =:= Stream[ConnectionIO, A]): Stream[M, A] = xa.transP.apply(fa)
 }
 

--- a/modules/core/src/test/scala/doobie/util/process.scala
+++ b/modules/core/src/test/scala/doobie/util/process.scala
@@ -30,7 +30,7 @@ object processspec extends Specification with ScalaCheck {
           h
         }
       }
-      val result = repeatEvalChunks(fa).runLog.unsafeRunSync
+      val result = repeatEvalChunks(fa).compile.toVector.unsafeRunSync
       result must_== data
     }
 

--- a/modules/docs/src/main/tut/docs/04-Selecting.md
+++ b/modules/docs/src/main/tut/docs/04-Selecting.md
@@ -172,7 +172,7 @@ And just for fun, since the `Code` values are constructed from the primary key, 
 
 ### Final Streaming
 
-In the examples above we construct a `Stream[ConnectionIO, A]` and discharge it via `.list` (which is just shorthand for `.runLog.map(_.toList)`), yielding a `ConnectionIO[List[A]]` which eventually becomes a `IO[List[A]]`. So the construction and execution of the `Stream` is entirely internal to the **doobie** program.
+In the examples above we construct a `Stream[ConnectionIO, A]` and discharge it via `.list` (which is just shorthand for `.compile.toList`), yielding a `ConnectionIO[List[A]]` which eventually becomes a `IO[List[A]]`. So the construction and execution of the `Stream` is entirely internal to the **doobie** program.
 
 However in some cases a stream is what we want as our "top level" type. For example, [http4s](https://github.com/http4s/http4s) can use a `Stream[IO, A]` directly as a response type, which could allow us to stream a resultset directly to the network socket. We can achieve this in **doobie** by calling `transact` directly on the `Stream[ConnectionIO, A]`.
 
@@ -184,7 +184,7 @@ val p = {
     .transact(xa)    // Stream[IO, Country]
  }
 
-p.take(5).runLog.unsafeRunSync.foreach(println)
+p.take(5).compile.toVector.unsafeRunSync.foreach(println)
 ```
 
 

--- a/modules/example/src/main/scala/example/StreamingCopy.scala
+++ b/modules/example/src/main/scala/example/StreamingCopy.scala
@@ -136,7 +136,7 @@ object StreamingCopy {
   // Our main program
   val io: IO[Unit] =
     for {
-      _ <- fuseMap(read, write)(pg, h2).run // do the copy with fuseMap
+      _ <- fuseMap(read, write)(pg, h2).compile.drain // do the copy with fuseMap
       n <- sql"select count(*) from city".query[Int].unique.transact(h2)
       _ <- IO(Console.println(s"Copied $n cities!"))
     } yield ()

--- a/modules/postgres/src/test/scala/doobie/postgres/manyrows.scala
+++ b/modules/postgres/src/test/scala/doobie/postgres/manyrows.scala
@@ -24,7 +24,7 @@ object manyrows extends Specification {
     // TODO add timeout to test the server-side cursor
     "take consistent memory" in {
       val q = sql"""select a.name, b.name from city a, city b""".query[(String, String)]
-      q.process.take(5).transact(xa).run.unsafeRunSync
+      q.process.take(5).transact(xa).compile.drain.unsafeRunSync
       true
     }
   }


### PR DESCRIPTION
_This PR is for cats-1.0.0 branch #650_

Updated to FS2 0.10.0-M11 and Scala 2.11.12.

In FS2, `Stream#run*` are deprecated in favor of `Stream#compile{.drain, .toVector, .toList, ...}`. Should we do something similar about `Update#run`? At this point, `.run` looks a bit misleading to me.
https://github.com/functional-streams-for-scala/fs2/blob/v0.10.0-M11/docs/migration-guide-0.10.md#compiling--interpreting-streams
  