### PR TITLE
Align API with cats and fs2 (fixes #654) 

### DIFF
--- a/modules/bench/src/main/scala/doobie/bench/select.scala
+++ b/modules/bench/src/main/scala/doobie/bench/select.scala
@@ -49,7 +49,7 @@ class bench {
   def doobieBenchP(n: Int): Int =
     sql"select a.name, b.name, c.name from country a, country b, country c limit $n"
       .query[(String,String,String)]
-      .process
+      .stream
       .list
       .transact(xa)
       .map(_.length)

--- a/modules/core/src/main/scala/doobie/hi/connection.scala
+++ b/modules/core/src/main/scala/doobie/hi/connection.scala
@@ -67,7 +67,16 @@ object connection {
    * action, and return results via a `Stream`.
    * @group Prepared Statements
    */
+  @deprecated(message = "Use `stream`", since = "0.5.0")
   def process[A: Composite](sql: String, prep: PreparedStatementIO[Unit], chunkSize: Int): Stream[ConnectionIO, A] =
+    stream(sql, prep, chunkSize)
+
+  /**
+   * Construct a prepared statement from the given `sql`, configure it with the given `PreparedStatementIO`
+   * action, and return results via a `Stream`.
+   * @group Prepared Statements
+   */
+  def stream[A: Composite](sql: String, prep: PreparedStatementIO[Unit], chunkSize: Int): Stream[ConnectionIO, A] =
     liftStream(chunkSize, FC.prepareStatement(sql), prep, FPS.executeQuery)
 
   /**

--- a/modules/core/src/main/scala/doobie/hi/preparedstatement.scala
+++ b/modules/core/src/main/scala/doobie/hi/preparedstatement.scala
@@ -46,7 +46,12 @@ object preparedstatement {
     repeatEvalChunks(FPS.embed(rs, resultset.getNextChunk[A](chunkSize)))
 
   /** @group Execution */
+  @deprecated(message = "Use `stream`", since = "0.5.0")
   def process[A: Composite](chunkSize: Int): Stream[PreparedStatementIO, A] =
+    stream(chunkSize)
+
+  /** @group Execution */
+  def stream[A: Composite](chunkSize: Int): Stream[PreparedStatementIO, A] =
     bracket(FPS.executeQuery)(unrolled[A](_, chunkSize), FPS.embed(_, FRS.close))
 
   /**

--- a/modules/core/src/main/scala/doobie/hi/resultset.scala
+++ b/modules/core/src/main/scala/doobie/hi/resultset.scala
@@ -223,7 +223,16 @@ object resultset {
    * mechanism for dealing with query results.
    * @group Results
    */
+  @deprecated(message = "Use `stream`", since = "0.5.0")
   def process[A: Composite](chunkSize: Int): Stream[ResultSetIO, A] =
+    stream(chunkSize)
+
+  /**
+   * Stream that reads from the `ResultSet` and returns a stream of `A`s. This is the preferred
+   * mechanism for dealing with query results.
+   * @group Results
+   */
+  def stream[A: Composite](chunkSize: Int): Stream[ResultSetIO, A] =
     repeatEvalChunks(getNextChunk[A](chunkSize))
 
   /** @group Properties */

--- a/modules/core/src/main/scala/doobie/util/composite.scala
+++ b/modules/core/src/main/scala/doobie/util/composite.scala
@@ -66,9 +66,14 @@ object composite {
       }
 
     /** Product of two Composites. */
+    @deprecated(message = "Use `product`", since = "0.5.0")
     def zip[B](cb: Composite[B]): Composite[(A, B)] =
+      product(cb)
+
+    /** Product of two Composites. */
+    def product[B](cb: Composite[B]): Composite[(A, B)] =
       new Composite[(A, B)] {
-        val kernel = c.kernel.zip(cb.kernel)
+        val kernel = c.kernel.product(cb.kernel)
         val meta   = c.meta ++ cb.meta
         val toList = (p: (A, B)) => c.toList(p._1) ++ cb.toList(p._2)
       }
@@ -88,7 +93,7 @@ object composite {
     implicit val compositeSemigroupal: Semigroupal[Composite] =
       new Semigroupal[Composite] {
         def product[A, B](a: Composite[A], b: Composite[B]): Composite[(A, B)] =
-          a.zip(b)
+          a.product(b)
       }
 
     implicit val unitComposite: Composite[Unit] =

--- a/modules/core/src/main/scala/doobie/util/fragment.scala
+++ b/modules/core/src/main/scala/doobie/util/fragment.scala
@@ -38,7 +38,7 @@ object fragment {
     def ++(fb: Fragment): Fragment =
       new Fragment {
         type A  = (fa.A, fb.A)
-        val ca  = fa.ca zip fb.ca
+        val ca  = fa.ca product fb.ca
         val a   = (fa.a, fb.a)
         val sql = fa.sql + fb.sql
         val pos = fa.pos orElse fb.pos

--- a/modules/core/src/main/scala/doobie/util/kernel.scala
+++ b/modules/core/src/main/scala/doobie/util/kernel.scala
@@ -41,7 +41,11 @@ object kernel {
         val width   = outer.width
       }
 
+    @deprecated(message = "Use `product`", since = "0.5.0")
     def zip[B](b: Kernel[B]): Kernel[(A, B)] =
+      product(b)
+
+    def product[B](b: Kernel[B]): Kernel[(A, B)] =
       Kernel.product(this, b)
 
   }

--- a/modules/core/src/main/scala/doobie/util/query.scala
+++ b/modules/core/src/main/scala/doobie/util/query.scala
@@ -115,15 +115,18 @@ object query {
      * type `B`.
      * @group Results
      */
+    @deprecated(message = "Use `streamWithChunkSize`", since = "0.5.0")
     def processWithChunkSize(a: A, chunkSize: Int): Stream[ConnectionIO, B] =
-      HC.process[O](sql, HPS.set(ai(a)), chunkSize).map(ob)
+      streamWithChunkSize(a, chunkSize)
 
     /**
-     * FS2 Friendly Alias for processWithChunkSize.
+     * Apply the argument `a` to construct a `Stream` with the given chunking factor, with
+     * effect type  `[[doobie.free.connection.ConnectionIO ConnectionIO]]` yielding elements of
+     * type `B`.
      * @group Results
      */
     def streamWithChunkSize(a: A, chunkSize: Int): Stream[ConnectionIO, B] =
-      processWithChunkSize(a, chunkSize)
+      HC.stream[O](sql, HPS.set(ai(a)), chunkSize).map(ob)
 
     /**
      * Apply the argument `a` to construct a `Stream` with `DefaultChunkSize`, with
@@ -131,15 +134,18 @@ object query {
      * type `B`.
      * @group Results
      */
+    @deprecated(message = "Use `stream`", since = "0.5.0")
     def process(a: A): Stream[ConnectionIO, B] =
-      processWithChunkSize(a, DefaultChunkSize)
+      stream(a)
 
     /**
-     * FS2 Friendly Alias for process.
+     * Apply the argument `a` to construct a `Stream` with `DefaultChunkSize`, with
+     * effect type  `[[doobie.free.connection.ConnectionIO ConnectionIO]]` yielding elements of
+     * type `B`.
      * @group Results
      */
     def stream(a: A): Stream[ConnectionIO, B] =
-      process(a)
+      streamWithChunkSize(a, DefaultChunkSize)
 
     /**
      * Apply the argument `a` to construct a program in
@@ -238,7 +244,7 @@ object query {
         def toFragment = outer.toFragment(a)
         def analysis = outer.analysis
         def outputAnalysis = outer.outputAnalysis
-        def processWithChunkSize(n: Int) = outer.processWithChunkSize(a, n)
+        def streamWithChunkSize(n: Int) = outer.streamWithChunkSize(a, n)
         def accumulate[F[_]: Alternative] = outer.accumulate[F](a)
         def to[F[_]](implicit cbf: CanBuildFrom[Nothing, B, F[B]]) = outer.to[F](a)
         def unique = outer.unique(a)
@@ -335,29 +341,33 @@ object query {
      * `[[doobie.free.connection.ConnectionIO ConnectionIO]]` yielding  elements of type `B`.
      * @group Results
      */
+    @deprecated(message = "Use `stream`", since = "0.5.0")
     def process: Stream[ConnectionIO, B] =
-      processWithChunkSize(DefaultChunkSize)
+      stream
 
     /**
-     * FS2 Friendly Alias for process.
+     * `Stream` with default chunk factor, with effect type
+     * `[[doobie.free.connection.ConnectionIO ConnectionIO]]` yielding  elements of type `B`.
      * @group Results
      */
     def stream : Stream[ConnectionIO, B] =
-      process
+      streamWithChunkSize(DefaultChunkSize)
 
     /**
      * `Stream` with given chunk factor, with effect type
      * `[[doobie.free.connection.ConnectionIO ConnectionIO]]` yielding  elements of type `B`.
      * @group Results
      */
-    def processWithChunkSize(n: Int): Stream[ConnectionIO, B]
+    @deprecated("Use `streamWithChunkSize`", since = "0.5.0")
+    def processWithChunkSize(n: Int): Stream[ConnectionIO, B] =
+      streamWithChunkSize(n)
 
     /**
-     * FS2 Friendly Alias for processWithChunkSize.
+     * `Stream` with given chunk factor, with effect type
+     * `[[doobie.free.connection.ConnectionIO ConnectionIO]]` yielding  elements of type `B`.
      * @group Results
      */
-    def streamWithChunkSize(n: Int): Stream[ConnectionIO, B] =
-      processWithChunkSize(n)
+    def streamWithChunkSize(n: Int): Stream[ConnectionIO, B]
 
     /**
      * Program in `[[doobie.free.connection.ConnectionIO ConnectionIO]]` yielding an `F[B]`
@@ -399,10 +409,10 @@ object query {
     def map[C](f: B => C): Query0[C]
 
     /**
-     * Convenience method; equivalent to `process.sink(f)`
+     * Convenience method; equivalent to `stream.sink(f)`
      * @group Results
      */
-    def sink(f: B => ConnectionIO[Unit]): ConnectionIO[Unit] = process.sink(f)
+    def sink(f: B => ConnectionIO[Unit]): ConnectionIO[Unit] = stream.sink(f)
 
     /**
      * Convenience method; equivalent to `to[List]`

--- a/modules/core/src/main/scala/doobie/util/yolo.scala
+++ b/modules/core/src/main/scala/doobie/util/yolo.scala
@@ -77,7 +77,7 @@ object yolo {
     implicit class Update0YoloOps(u: Update0) {
 
       def quick: M[Unit] =
-        u.run.flatMap(a => out(s"$a row(s) updated")).transact(xa)
+        u.compile.flatMap(a => out(s"$a row(s) updated")).transact(xa)
 
       def check: M[Unit] =
         (delay(showSql(u.sql)) *> u.analysis.attempt.flatMap {

--- a/modules/core/src/test/scala/doobie/util/log.scala
+++ b/modules/core/src/test/scala/doobie/util/log.scala
@@ -33,8 +33,8 @@ object logspec extends Specification {
   def eventForUniqueUpdate[A: Composite](sql: String, arg: A = HNil : HNil): LogEvent = {
     var result  = null : LogEvent
     val handler = LogHandler(result = _)
-    val cio     = sql"create table if not exists foo (bar integer)".update.run *>
-                  Update[A](sql, None, handler).run(arg)
+    val cio     = sql"create table if not exists foo (bar integer)".update.compile *>
+                  Update[A](sql, None, handler).compile(arg)
     cio.transact(xa).attempt.unsafeRunSync
     result
   }
@@ -116,7 +116,7 @@ object logspec extends Specification {
     "implicit handler" in {
       var result  = null : LogEvent
       implicit val handler: LogHandler = LogHandler(result = _)
-      val cio = sql"drop table if exists barf".update.run
+      val cio = sql"drop table if exists barf".update.compile
       cio.transact(xa).attempt.unsafeRunSync
       result must beLike {
         case Success(_, _, _, _) => ok
@@ -126,7 +126,7 @@ object logspec extends Specification {
     "implicit handler" in {
       var result  = null : LogEvent
       val handler = LogHandler(result = _)
-      val cio = sql"drop table if exists barf".updateWithLogHandler(handler).run
+      val cio = sql"drop table if exists barf".updateWithLogHandler(handler).compile
       cio.transact(xa).attempt.unsafeRunSync
       result must beLike {
         case Success(_, _, _, _) => ok

--- a/modules/core/src/test/scala/doobie/util/strategy.scala
+++ b/modules/core/src/test/scala/doobie/util/strategy.scala
@@ -109,43 +109,43 @@ object strategyspec extends Specification {
 
     "Connection.autoCommit should be set to false" in {
       val i = new Interp
-      sql"select 1".query[Int].process.list.transact(xa(i)).unsafeRunSync
+      sql"select 1".query[Int].stream.list.transact(xa(i)).unsafeRunSync
       i.Connection.autoCommit must_== Some(false)
     }
 
     "Connection.commit should be called on success" in {
       val i = new Interp
-      sql"select 1".query[Int].process.list.transact(xa(i)).unsafeRunSync
+      sql"select 1".query[Int].stream.list.transact(xa(i)).unsafeRunSync
       i.Connection.commit must_== Some(())
     }
 
     "Connection.commit should NOT be called on failure" in {
       val i = new Interp
-      sql"abc".query[Int].process.list.transact(xa(i)).attempt.unsafeRunSync.toOption must_== None
+      sql"abc".query[Int].stream.list.transact(xa(i)).attempt.unsafeRunSync.toOption must_== None
       i.Connection.commit must_== None
     }
 
     "Connection.rollback should NOT be called on success" in {
       val i = new Interp
-      sql"select 1".query[Int].process.list.transact(xa(i)).unsafeRunSync
+      sql"select 1".query[Int].stream.list.transact(xa(i)).unsafeRunSync
       i.Connection.rollback must_== None
     }
 
     "Connection.rollback should be called on failure" in {
       val i = new Interp
-      sql"abc".query[Int].process.list.transact(xa(i)).attempt.unsafeRunSync.toOption must_== None
+      sql"abc".query[Int].stream.list.transact(xa(i)).attempt.unsafeRunSync.toOption must_== None
       i.Connection.rollback must_== Some(())
     }
 
     "Connection.close should be called on success" in {
       val i = new Interp
-      sql"select 1".query[Int].process.list.transact(xa(i)).unsafeRunSync
+      sql"select 1".query[Int].stream.list.transact(xa(i)).unsafeRunSync
       i.Connection.close must_== Some(())
     }
 
     "Connection.close should be called on failure" in {
       val i = new Interp
-      sql"abc".query[Int].process.list.transact(xa(i)).attempt.unsafeRunSync.toOption must_== None
+      sql"abc".query[Int].stream.list.transact(xa(i)).attempt.unsafeRunSync.toOption must_== None
       i.Connection.close must_== Some(())
     }
 
@@ -171,13 +171,13 @@ object strategyspec extends Specification {
 
     "PreparedStatement.close should be called on success" in {
       val i = new Interp
-      sql"select 1".query[Int].process.list.transact(xa(i)).unsafeRunSync
+      sql"select 1".query[Int].stream.list.transact(xa(i)).unsafeRunSync
       i.PreparedStatement.close must_== Some(())
     }
 
     "PreparedStatement.close should be called on failure" in {
       val i = new Interp
-      sql"select 'x'".query[Int].process.list.transact(xa(i)).attempt.unsafeRunSync.toOption must_== None
+      sql"select 'x'".query[Int].stream.list.transact(xa(i)).attempt.unsafeRunSync.toOption must_== None
       i.PreparedStatement.close must_== Some(())
     }
 
@@ -203,13 +203,13 @@ object strategyspec extends Specification {
 
     "ResultSet.close should be called on success" in {
       val i = new Interp
-      sql"select 1".query[Int].process.list.transact(xa(i)).unsafeRunSync
+      sql"select 1".query[Int].stream.list.transact(xa(i)).unsafeRunSync
       i.ResultSet.close must_== Some(())
     }
 
     "ResultSet.close should be called on failure" in {
       val i = new Interp
-      sql"select 'x'".query[Int].process.list.transact(xa(i)).attempt.unsafeRunSync.toOption must_== None
+      sql"select 'x'".query[Int].stream.list.transact(xa(i)).attempt.unsafeRunSync.toOption must_== None
       i.ResultSet.close must_== Some(())
     }
 

--- a/modules/docs/src/main/tut/docs/05-Parameterized.md
+++ b/modules/docs/src/main/tut/docs/05-Parameterized.md
@@ -43,7 +43,7 @@ case class Country(code: String, name: String, pop: Int, gnp: Option[Double])
 
 ```tut
 (sql"select code, name, population, gnp from country"
-  .query[Country].process.take(5).quick.unsafeRunSync)
+  .query[Country].stream.take(5).quick.unsafeRunSync)
 ```
 
 Still works. Ok.
@@ -116,7 +116,7 @@ populationIn(100000000 to 300000000, NonEmptyList.of("USA", "BRA", "PAK", "GBR")
 
 ### Diving Deeper
 
-In the previous chapter's *Diving Deeper* we saw how a query constructed with the `sql` interpolator is just sugar for the `process` constructor defined in the `doobie.hi.connection` module (aliased as `HC`). Here we see that the second parameter, a `PreparedStatementIO` program, is used to set the query parameters. The third parameter specifies a chunking factor; rows are buffered in chunks of the specified size.
+In the previous chapter's *Diving Deeper* we saw how a query constructed with the `sql` interpolator is just sugar for the `stream` constructor defined in the `doobie.hi.connection` module (aliased as `HC`). Here we see that the second parameter, a `PreparedStatementIO` program, is used to set the query parameters. The third parameter specifies a chunking factor; rows are buffered in chunks of the specified size.
 
 ```tut:silent
 import fs2.Stream
@@ -129,7 +129,7 @@ val q = """
   """
 
 def proc(range: Range): Stream[ConnectionIO, Country] =
-  HC.process[Country](q, HPS.set((range.min, range.max)), 512)
+  HC.stream[Country](q, HPS.set((range.min, range.max)), 512)
 ```
 
 Which produces the same output.

--- a/modules/docs/src/main/tut/docs/12-Custom-Mappings.md
+++ b/modules/docs/src/main/tut/docs/12-Custom-Mappings.md
@@ -174,7 +174,7 @@ implicit val PersonMeta = codecMeta[Person]
 Now let's create a table that has a `json` column to store a `Person`.
 
 ```tut:silent
-val drop = sql"DROP TABLE IF EXISTS pet".update.run
+val drop = sql"DROP TABLE IF EXISTS pet".update.compile
 
 val create =
   sql"""
@@ -183,7 +183,7 @@ val create =
       name  VARCHAR NOT NULL UNIQUE,
       owner JSON    NOT NULL
     )
-  """.update.run
+  """.update.compile
 
 (drop *> create).quick.unsafeRunSync
 ```

--- a/modules/docs/src/main/tut/docs/17-FAQ.md
+++ b/modules/docs/src/main/tut/docs/17-FAQ.md
@@ -93,8 +93,8 @@ cities(Code("USA"), true).check.unsafeRunSync
 And it works!
 
 ```tut
-cities(Code("USA"), true).process.take(5).quick.unsafeRunSync
-cities(Code("USA"), false).process.take(5).quick.unsafeRunSync
+cities(Code("USA"), true).stream.take(5).quick.unsafeRunSync
+cities(Code("USA"), false).stream.take(5).quick.unsafeRunSync
 ```
 
 ### How do I handle outer joins?
@@ -120,7 +120,7 @@ val join: Query0[(Country, Option[City])] =
 Some examples, filtered for size.
 
 ```tut
-join.process.filter(_._1.name.startsWith("United")).quick.unsafeRunSync
+join.stream.filter(_._1.name.startsWith("United")).quick.unsafeRunSync
 ```
 
 ### How do I resolve `error: Could not find or construct Param[...]`?
@@ -246,7 +246,7 @@ implicit val XmlMeta: Meta[Elem] =
 
 ## How do I set the chunk size for streaming results?
 
-By default streams constructed with the `sql` interpolator are fetched `Query.DefaultChunkSize` rows at a time (currently 512). If you wish to change this chunk size you can use `processWithChunkSize` for queries, and `withGeneratedKeysWithChunkSize` for updates that return results.
+By default streams constructed with the `sql` interpolator are fetched `Query.DefaultChunkSize` rows at a time (currently 512). If you wish to change this chunk size you can use `streamWithChunkSize` for queries, and `withGeneratedKeysWithChunkSize` for updates that return results.
 
 ## My Postgres domains are all type checking as DISTINCT! How can I get my Yolo tests to pass?
 

--- a/modules/example/src/main/scala/example/FirstExample.scala
+++ b/modules/example/src/main/scala/example/FirstExample.scala
@@ -73,19 +73,19 @@ object FirstExample {
   object DAO {
 
     def coffeesLessThan(price: Double): Stream[ConnectionIO, (String, String)] =
-      Queries.coffeesLessThan(price).process
+      Queries.coffeesLessThan(price).stream
 
     def insertSuppliers(ss: List[Supplier]): ConnectionIO[Int] =
-      Queries.insertSupplier.updateMany(ss) // bulk insert (!)
+      Queries.insertSupplier.compileMany(ss) // bulk insert (!)
 
     def insertCoffees(cs: List[Coffee]): ConnectionIO[Int] =
-      Queries.insertCoffee.updateMany(cs)
+      Queries.insertCoffee.compileMany(cs)
 
     def allCoffees: Stream[ConnectionIO, Coffee] =
-      Queries.allCoffees.process
+      Queries.allCoffees.stream
 
     def create: ConnectionIO[Unit] =
-      Queries.create.run.void
+      Queries.create.compile.void
 
   }
 

--- a/modules/example/src/main/scala/example/HiUsage.scala
+++ b/modules/example/src/main/scala/example/HiUsage.scala
@@ -28,6 +28,6 @@ object HiUsage {
   // Construct an action to find countries where more than `pct` of the population speaks `lang`.
   // The result is a scalaz.stream.Process that can be further manipulated by the caller.
   def speakerQuery(lang: String, pct: Double): Stream[ConnectionIO,CountryCode] =
-  sql"SELECT COUNTRYCODE FROM COUNTRYLANGUAGE WHERE LANGUAGE = $lang AND PERCENTAGE > $pct".query[CountryCode].process
+  sql"SELECT COUNTRYCODE FROM COUNTRYLANGUAGE WHERE LANGUAGE = $lang AND PERCENTAGE > $pct".query[CountryCode].stream
 
 }

--- a/modules/example/src/main/scala/example/StreamingCopy.scala
+++ b/modules/example/src/main/scala/example/StreamingCopy.scala
@@ -108,7 +108,7 @@ object StreamingCopy {
       sql"""
         INSERT INTO city (id, name, countrycode, district, population)
         VALUES (${c.id}, ${c.name}, ${c.countrycode}, ${c.district}, ${c.population})
-      """.update.run.void
+      """.update.compile.void
     )
 
   /** Table creation for our destination DB. We assume the source is populated. */
@@ -121,7 +121,7 @@ object StreamingCopy {
           district varchar NOT NULL,
           population integer NOT NULL
       )
-    """.update.run.void
+    """.update.compile.void
 
 
   // A postges transactor for our source. We assume the WORLD database is set up already.

--- a/modules/postgres/src/test/scala/doobie/postgres/manyrows.scala
+++ b/modules/postgres/src/test/scala/doobie/postgres/manyrows.scala
@@ -24,7 +24,7 @@ object manyrows extends Specification {
     // TODO add timeout to test the server-side cursor
     "take consistent memory" in {
       val q = sql"""select a.name, b.name from city a, city b""".query[(String, String)]
-      q.process.take(5).transact(xa).compile.drain.unsafeRunSync
+      q.stream.take(5).transact(xa).compile.drain.unsafeRunSync
       true
     }
   }

--- a/modules/refined/src/test/scala/doobie/refined/refinedtypes.scala
+++ b/modules/refined/src/test/scala/doobie/refined/refinedtypes.scala
@@ -87,8 +87,8 @@ object refinedtypes extends Specification {
 
     def insertOptionalPositiveInt(v: Option[PositiveInt]) = {
       val queryRes = for {
-        _  <- Update0(s"CREATE LOCAL TEMPORARY TABLE TEST (value INT)", None).run
-        _  <- sql"INSERT INTO TEST VALUES ($v)".update.run
+        _  <- Update0(s"CREATE LOCAL TEMPORARY TABLE TEST (value INT)", None).compile
+        _  <- sql"INSERT INTO TEST VALUES ($v)".update.compile
       } yield ()
       queryRes.transact(xa).unsafeRunSync
     }

--- a/modules/specs2/src/test/scala/doobie/specs2/beforeall.scala
+++ b/modules/specs2/src/test/scala/doobie/specs2/beforeall.scala
@@ -30,7 +30,7 @@ object beforeall extends Specification with IOChecker with BeforeAll {
 
   // A hook for database initialization
   def beforeAll() = {
-    initQ.run
+    initQ.compile
       .transact(transactor)
       .unsafeRunSync
     ()

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.0-RC4
+sbt.version=1.1.0


### PR DESCRIPTION
This PR introduces following API changes to keep it
consistent with cats and fs2:

 Before               |    After
-----------------------  | ----------------------
 `Update(0)#run`         | `Update(0)#compile`
 `Update(0)#updateMany*` | `Update(0)#compileMany*`
 `Query(0)#process*`     | `Query(0)#stream*`
 `HC.process`            | `HC.stream`
 `HRS.process`           | `HRS.stream`
 `Composite#zip`         | `Composite#product`
 `Kernel#zip`            | `Kernel#product`

The old ones are deprecated.