### PR TITLE
Update 01-Introduction.md

### DIFF
--- a/modules/docs/src/main/tut/docs/01-Introduction.md
+++ b/modules/docs/src/main/tut/docs/01-Introduction.md
@@ -91,7 +91,7 @@ Each page begins with some imports, like this.
 
 ```tut:silent
 import cats._, cats.data._, cats.implicits._
-import doobie.imports._
+import doobie._
 ```
 
 After that there is text interspersed with code examples. Sometimes definitions will stand alone.


### PR DESCRIPTION
Importing `doobie.imports._` is deprecated since `0.5.0` change to `doobie._`
  