### PR TITLE
Use `IO.ioEffect` to find `Effect[IO]` in test modules

### DIFF
--- a/modules/scalatest/src/main/scala/doobie/scalatest/AnalysisMatchers.scala
+++ b/modules/scalatest/src/main/scala/doobie/scalatest/AnalysisMatchers.scala
@@ -51,5 +51,5 @@ trait AnalysisMatchers[F[_]] extends CheckerBase[F] {
 }
 
 trait IOAnalysisMatchers extends AnalysisMatchers[IO] {
-  implicit val M: Effect[IO] = implicitly
+  implicit val M: Effect[IO] = IO.ioEffect
 }

--- a/modules/specs2/src/main/scala/doobie/specs2/analysisspec.scala
+++ b/modules/specs2/src/main/scala/doobie/specs2/analysisspec.scala
@@ -87,6 +87,6 @@ object analysisspec {
 
   /** Implementation of Checker[IO] */
   trait IOChecker extends Checker[IO] { this: Specification =>
-    val M: Effect[IO] = implicitly
+    val M: Effect[IO] = IO.ioEffect
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.0-RC4
+sbt.version=1.1.0


### PR DESCRIPTION
This uses `IO.ioEffect` to find the `implicit val M: Effect[IO]` in `IOChecker` and `IOAnalysisMatchers`. Without this, I had some runtime issues with uninitialized fields when attempting to find the implicit `Effect`.

(also update sbt to 1.1.0 final)