### PR TITLE
simplify `repeatEvalChunks`

### DIFF
--- a/modules/core/src/main/scala/doobie/util/stream.scala
+++ b/modules/core/src/main/scala/doobie/util/stream.scala
@@ -5,17 +5,11 @@
 package doobie.util
 
 import fs2.Stream
-import fs2.Stream.{ attemptEval, emits, empty, raiseError }
 
 /** Additional functions for manipulating `Stream` values. */
 object stream {
 
   /** Stream constructor for effectful source of chunks. */
-  @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
   def repeatEvalChunks[F[_], T](fa: F[Seq[T]]): Stream[F, T] =
-    attemptEval(fa) flatMap {
-      case Left(e)    => raiseError(e)
-      case Right(seq) => if (seq.isEmpty) empty else (emits(seq) ++ repeatEvalChunks(fa))
-    }
-
+    Stream.repeatEval(fa).takeWhile(_.nonEmpty).flatMap(Stream.emits(_))
 }


### PR DESCRIPTION
I've also removed `VoidStreamOps` syntax in `Strategy`. It's redundant and makes code less straightforward IMHO. I'll undelete it, if you think it's useful.