### PR TITLE
downgrade fs2 dependency to 0.10.0-M10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ resolvers in Global += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/con
 // Library versions all in one place, for convenience and sanity.
 lazy val catsVersion          = "1.0.1"
 lazy val circeVersion         = "0.9.0"
-lazy val fs2CoreVersion       = "0.10.0-M11"
+lazy val fs2CoreVersion       = "0.10.0-M10"
 lazy val h2Version            = "1.4.196"
 lazy val hikariVersion        = "2.7.4"
 lazy val kindProjectorVersion = "0.9.5"

--- a/modules/core/src/main/scala/doobie/syntax/stream.scala
+++ b/modules/core/src/main/scala/doobie/syntax/stream.scala
@@ -14,9 +14,9 @@ import cats.effect.Sync
 import fs2.Stream
 
 class StreamOps[F[_], A](fa: Stream[F, A]) {
-  def vector(implicit ev: Sync[F]): F[Vector[A]] = fa.compile.toVector
-  def list(implicit ev: Sync[F]): F[List[A]] = fa.compile.toList
-  def sink(f: A => F[Unit])(implicit ev: Sync[F]): F[Unit] = fa.evalMap(f).compile.drain
+  def vector(implicit ev: Sync[F]): F[Vector[A]] = fa.runLog
+  def list(implicit ev: Sync[F]): F[List[A]] = ev.map(fa.runLog)(_.toList)
+  def sink(f: A => F[Unit])(implicit ev: Sync[F]): F[Unit] = fa.evalMap(f).run
   def transact[M[_]: Monad](xa: Transactor[M])(implicit ev: Stream[F, A] =:= Stream[ConnectionIO, A]): Stream[M, A] = xa.transP.apply(fa)
 }
 

--- a/modules/core/src/test/scala/doobie/util/process.scala
+++ b/modules/core/src/test/scala/doobie/util/process.scala
@@ -30,7 +30,7 @@ object processspec extends Specification with ScalaCheck {
           h
         }
       }
-      val result = repeatEvalChunks(fa).compile.toVector.unsafeRunSync
+      val result = repeatEvalChunks(fa).runLog.unsafeRunSync
       result must_== data
     }
 

--- a/modules/docs/src/main/tut/docs/04-Selecting.md
+++ b/modules/docs/src/main/tut/docs/04-Selecting.md
@@ -172,7 +172,7 @@ And just for fun, since the `Code` values are constructed from the primary key, 
 
 ### Final Streaming
 
-In the examples above we construct a `Stream[ConnectionIO, A]` and discharge it via `.list` (which is just shorthand for `.compile.toList`), yielding a `ConnectionIO[List[A]]` which eventually becomes a `IO[List[A]]`. So the construction and execution of the `Stream` is entirely internal to the **doobie** program.
+In the examples above we construct a `Stream[ConnectionIO, A]` and discharge it via `.list` (which is just shorthand for `.runLog.map(_.toList)`), yielding a `ConnectionIO[List[A]]` which eventually becomes a `IO[List[A]]`. So the construction and execution of the `Stream` is entirely internal to the **doobie** program.
 
 However in some cases a stream is what we want as our "top level" type. For example, [http4s](https://github.com/http4s/http4s) can use a `Stream[IO, A]` directly as a response type, which could allow us to stream a resultset directly to the network socket. We can achieve this in **doobie** by calling `transact` directly on the `Stream[ConnectionIO, A]`.
 
@@ -184,7 +184,7 @@ val p = {
     .transact(xa)    // Stream[IO, Country]
  }
 
-p.take(5).compile.toVector.unsafeRunSync.foreach(println)
+p.take(5).runLog.unsafeRunSync.foreach(println)
 ```
 
 

--- a/modules/example/src/main/scala/example/StreamingCopy.scala
+++ b/modules/example/src/main/scala/example/StreamingCopy.scala
@@ -136,7 +136,7 @@ object StreamingCopy {
   // Our main program
   val io: IO[Unit] =
     for {
-      _ <- fuseMap(read, write)(pg, h2).compile.drain // do the copy with fuseMap
+      _ <- fuseMap(read, write)(pg, h2).run // do the copy with fuseMap
       n <- sql"select count(*) from city".query[Int].unique.transact(h2)
       _ <- IO(Console.println(s"Copied $n cities!"))
     } yield ()

--- a/modules/postgres/src/main/scala/doobie/postgres/hi/lostreaming.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/hi/lostreaming.scala
@@ -17,7 +17,7 @@ object lostreaming {
       Stream.bracket(openLO(oid))(
         lo => data.to(FS2IO.writeOutputStream(getOutputStream(lo))),
         closeLO
-      ).compile.drain.as(oid)
+      ).run.as(oid)
     }
 
   def createStreamFromLO(oid: Long, chunkSize: Int): Stream[ConnectionIO, Byte] =

--- a/modules/postgres/src/test/scala/doobie/postgres/lostreaming.scala
+++ b/modules/postgres/src/test/scala/doobie/postgres/lostreaming.scala
@@ -37,7 +37,7 @@ object lostreamingspec extends Specification with ScalaCheck {
       val result = Stream.bracket(PHLOS.createLOFromStream(data0))(
         oid => PHLOS.createStreamFromLO(oid, chunkSize = 1024 * 10),
         oid => PHC.pgGetLargeObjectAPI(PFLOM.unlink(oid))
-      ).compile.toVector.transact(xa).unsafeRunSync()
+      ).runLog.transact(xa).unsafeRunSync()
 
       result must_=== data.toVector
     }

--- a/modules/postgres/src/test/scala/doobie/postgres/manyrows.scala
+++ b/modules/postgres/src/test/scala/doobie/postgres/manyrows.scala
@@ -24,7 +24,7 @@ object manyrows extends Specification {
     // TODO add timeout to test the server-side cursor
     "take consistent memory" in {
       val q = sql"""select a.name, b.name from city a, city b""".query[(String, String)]
-      q.process.take(5).transact(xa).compile.drain.unsafeRunSync
+      q.process.take(5).transact(xa).run.unsafeRunSync
       true
     }
   }


### PR DESCRIPTION
Downgrades fs2 to the latest version without the [translate bug](https://github.com/functional-streams-for-scala/fs2/issues/1070).