### PR TITLE
update doc for 0.5.0

### DIFF
--- a/modules/bench/src/main/scala/doobie/bench/select.scala
+++ b/modules/bench/src/main/scala/doobie/bench/select.scala
@@ -50,7 +50,7 @@ class bench {
     sql"select a.name, b.name, c.name from country a, country b, country c limit $n"
       .query[(String,String,String)]
       .process
-      .list
+      .compile.toList
       .transact(xa)
       .map(_.length)
       .unsafeRunSync

--- a/modules/core/src/main/scala/doobie/syntax/stream.scala
+++ b/modules/core/src/main/scala/doobie/syntax/stream.scala
@@ -14,9 +14,6 @@ import cats.effect.Sync
 import fs2.Stream
 
 class StreamOps[F[_], A](fa: Stream[F, A]) {
-  def vector(implicit ev: Sync[F]): F[Vector[A]] = fa.compile.toVector
-  def list(implicit ev: Sync[F]): F[List[A]] = fa.compile.toList
-  def sink(f: A => F[Unit])(implicit ev: Sync[F]): F[Unit] = fa.evalMap(f).compile.drain
   def transact[M[_]: Monad](xa: Transactor[M])(implicit ev: Stream[F, A] =:= Stream[ConnectionIO, A]): Stream[M, A] = xa.transP.apply(fa)
 }
 

--- a/modules/core/src/main/scala/doobie/util/query.scala
+++ b/modules/core/src/main/scala/doobie/util/query.scala
@@ -402,7 +402,8 @@ object query {
      * Convenience method; equivalent to `process.sink(f)`
      * @group Results
      */
-    def sink(f: B => ConnectionIO[Unit]): ConnectionIO[Unit] = process.sink(f)
+    def sink(f: B => ConnectionIO[Unit]): ConnectionIO[Unit] =
+      process.evalMap(f).compile.drain
 
     /**
      * Convenience method; equivalent to `to[List]`

--- a/modules/core/src/main/scala/doobie/util/yolo.scala
+++ b/modules/core/src/main/scala/doobie/util/yolo.scala
@@ -7,7 +7,6 @@ package doobie.util
 import cats.implicits._
 import cats.effect._
 import doobie.free.connection.{ ConnectionIO, delay }
-import doobie.syntax.stream._
 import doobie.syntax.connectionio._
 import doobie.util.analysis._
 import doobie.util.query._
@@ -112,7 +111,7 @@ object yolo {
 
     implicit class StreamYoloOps[A](pa: Stream[ConnectionIO, A]) {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
-      def quick: M[Unit] = pa.sink(a => out(a.toString)).transact(xa)
+      def quick: M[Unit] = pa.evalMap(a => out(a.toString)).compile.drain.transact(xa)
     }
 
     private def assertEmpty(name: String, es: List[AlignmentError]) =

--- a/modules/core/src/test/scala/doobie/util/strategy.scala
+++ b/modules/core/src/test/scala/doobie/util/strategy.scala
@@ -109,43 +109,43 @@ object strategyspec extends Specification {
 
     "Connection.autoCommit should be set to false" in {
       val i = new Interp
-      sql"select 1".query[Int].process.list.transact(xa(i)).unsafeRunSync
+      sql"select 1".query[Int].stream.compile.toList.transact(xa(i)).unsafeRunSync
       i.Connection.autoCommit must_== Some(false)
     }
 
     "Connection.commit should be called on success" in {
       val i = new Interp
-      sql"select 1".query[Int].process.list.transact(xa(i)).unsafeRunSync
+      sql"select 1".query[Int].stream.compile.toList.transact(xa(i)).unsafeRunSync
       i.Connection.commit must_== Some(())
     }
 
     "Connection.commit should NOT be called on failure" in {
       val i = new Interp
-      sql"abc".query[Int].process.list.transact(xa(i)).attempt.unsafeRunSync.toOption must_== None
+      sql"abc".query[Int].stream.compile.toList.transact(xa(i)).attempt.unsafeRunSync.toOption must_== None
       i.Connection.commit must_== None
     }
 
     "Connection.rollback should NOT be called on success" in {
       val i = new Interp
-      sql"select 1".query[Int].process.list.transact(xa(i)).unsafeRunSync
+      sql"select 1".query[Int].stream.compile.toList.transact(xa(i)).unsafeRunSync
       i.Connection.rollback must_== None
     }
 
     "Connection.rollback should be called on failure" in {
       val i = new Interp
-      sql"abc".query[Int].process.list.transact(xa(i)).attempt.unsafeRunSync.toOption must_== None
+      sql"abc".query[Int].stream.compile.toList.transact(xa(i)).attempt.unsafeRunSync.toOption must_== None
       i.Connection.rollback must_== Some(())
     }
 
     "Connection.close should be called on success" in {
       val i = new Interp
-      sql"select 1".query[Int].process.list.transact(xa(i)).unsafeRunSync
+      sql"select 1".query[Int].stream.compile.toList.transact(xa(i)).unsafeRunSync
       i.Connection.close must_== Some(())
     }
 
     "Connection.close should be called on failure" in {
       val i = new Interp
-      sql"abc".query[Int].process.list.transact(xa(i)).attempt.unsafeRunSync.toOption must_== None
+      sql"abc".query[Int].stream.compile.toList.transact(xa(i)).attempt.unsafeRunSync.toOption must_== None
       i.Connection.close must_== Some(())
     }
 
@@ -171,13 +171,13 @@ object strategyspec extends Specification {
 
     "PreparedStatement.close should be called on success" in {
       val i = new Interp
-      sql"select 1".query[Int].process.list.transact(xa(i)).unsafeRunSync
+      sql"select 1".query[Int].stream.compile.toList.transact(xa(i)).unsafeRunSync
       i.PreparedStatement.close must_== Some(())
     }
 
     "PreparedStatement.close should be called on failure" in {
       val i = new Interp
-      sql"select 'x'".query[Int].process.list.transact(xa(i)).attempt.unsafeRunSync.toOption must_== None
+      sql"select 'x'".query[Int].stream.compile.toList.transact(xa(i)).attempt.unsafeRunSync.toOption must_== None
       i.PreparedStatement.close must_== Some(())
     }
 
@@ -203,13 +203,13 @@ object strategyspec extends Specification {
 
     "ResultSet.close should be called on success" in {
       val i = new Interp
-      sql"select 1".query[Int].process.list.transact(xa(i)).unsafeRunSync
+      sql"select 1".query[Int].stream.compile.toList.transact(xa(i)).unsafeRunSync
       i.ResultSet.close must_== Some(())
     }
 
     "ResultSet.close should be called on failure" in {
       val i = new Interp
-      sql"select 'x'".query[Int].process.list.transact(xa(i)).attempt.unsafeRunSync.toOption must_== None
+      sql"select 'x'".query[Int].stream.compile.toList.transact(xa(i)).attempt.unsafeRunSync.toOption must_== None
       i.ResultSet.close must_== Some(())
     }
 

--- a/modules/docs/src/main/tut/docs/01-Introduction.md
+++ b/modules/docs/src/main/tut/docs/01-Introduction.md
@@ -19,7 +19,7 @@ This book is organized cookbook-style: we demonstrate a common task and then exp
 
 This library is designed for people who are interested in typed, pure functional programming. If you are not a [Cats](https://github.com/typelevel/cats) user or are not familiar with functional I/O and monadic effects, you may need to go slowly and may want to spend some time reading [Functional Programming in Scala](http://manning.com/bjarnason/), which introduces all of the ideas that you will find when exploring **doobie**.
 
-Having said this, if you find yourself confused or frustrated by this documentation or the **doobie** API, *please* ask a question on [Gitter](https://gitter.im/tpolecat/doobie), file an [issue](https://github.com/tpolecat/doobie/issues) or find **tpolecat** on [Twitter](https://twitter.com/tpolecat) and ask for help. Both the library and the documentation are young and are changing quickly, and it is inevitable that some things will be unclear. Accordingly, **this book is updated for each release** to address problems and omissions.
+Having said this, if you find yourself confused or frustrated by this documentation or the **doobie** API, *please* ask a question on [Gitter](https://gitter.im/tpolecat/doobie), file an [issue](https://github.com/tpolecat/doobie/issues) and ask for help. Both the library and the documentation are young and are changing quickly, and it is inevitable that some things will be unclear. Accordingly, **this book is updated continuously** to address problems and omissions.
 
 ### The Setup
 
@@ -81,7 +81,8 @@ libraryDependencies ++= Seq(
   "org.tpolecat" %% "doobie-specs2"   % doobieVersion
 )
 ```
-Partial unification is a type inference bug fix that makes working with functional code significantly easier. Please see the Cats [Readme](https://github.com/typelevel/cats#getting-started) for more info.
+
+The `-Ypartial-unification` compiler flag enables a bug fix that makes working with functional code significantly easier. See the Cats [Getting Started](https://github.com/typelevel/cats#getting-started) for more info on this if it interests you.
 
 If you are not using PostgreSQL you can omit `doobie-postgres` and will need to add the appropriate JDBC driver as a dependency. Note that there is a `doobie-h2` add-on if you happen to be using [H2](http://www.h2database.com/).
 
@@ -115,4 +116,4 @@ woozle(nel) // doesn't compile
 
 ### Feedback and Contributions
 
-Feedback on **doobie** or this book is genuinely welcome. Please feel free to file a [pull request](https://github.com/tpolecat/doobie) if you have a contribution, or file an [issue](https://github.com/tpolecat/doobie/issues), or find and chat with **tpolecat** as mentioned above.
+Feedback on **doobie** or this book is genuinely welcome. Please feel free to file a [pull request](https://github.com/tpolecat/doobie) if you have a contribution, or file an [issue](https://github.com/tpolecat/doobie/issues), or chat with us on [Gitter](https://gitter.im/tpolecat/doobie).

--- a/modules/docs/src/main/tut/docs/02-Toolkit.md
+++ b/modules/docs/src/main/tut/docs/02-Toolkit.md
@@ -26,7 +26,7 @@ Some patterns of composition are so common and generic that they can be provided
 
 - Performing a query and reading the results as a stream.
 - Performing an update and returning updated rows as a stream.
-- Validating a query or update in terms of the schema and JDBC ~ Scala type mappings.
+- Validating a query or update in terms of the schema and JDBC ⟷ Scala type mappings.
 
 This book largely focuses on these common interactions, but also explains their representation at lower levels in case you wish to do something other than what you get for free.
 
@@ -47,7 +47,3 @@ The **high-level API** in `doobie.hi` (implemented entirely in terms of the low-
 - Typesafe string interpolator for SQL literals.
 
 The types used for both APIs are identical; the difference lies only in the exposed constructors. This means that a program otherwise written in the `doobie.hi` API can use constructors from `doobie.free` to implement advanced or vendor-specific behavior directly, without translation or lifting.
-
-### Vendor Extensions
-
-The 0.2.0 release introduced small add-on libraries to support vendor-specific features outside the JDBC specification. Initial support libraries for [Hikari](https://github.com/brettwooldridge/HikariCP), [H2](http://h2database.com), [PostgreSQL](http://www.postgresql.org/), and [Specs2](http://etorreborre.github.io/specs2/) are available and are described in later chapters. This is an area of active development and contributions are especially welcome.

--- a/modules/docs/src/main/tut/docs/04-Selecting.md
+++ b/modules/docs/src/main/tut/docs/04-Selecting.md
@@ -6,15 +6,20 @@ title: Selecting Data
 
 ## {{page.title}}
 
-In this chapter we construct some programs that retrieve data from the database and stream it back, mapping to Scala types on the way. We also introduce YOLO mode for experimenting with **doobie** in the REPL.
+In this chapter will write some some programs to read from the database, mapping rows to Scala types on the way. We also introduce YOLO mode for experimenting with **doobie** in the REPL.
 
 ### Setting Up
 
 First let's get our imports out of the way and set up a `Transactor` as we did before. You can skip this step if you still have your REPL running from last chapter.
 
 ```tut:silent
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO, cats.implicits._
+import doobie._
+import doobie.implicits._
+import cats._
+import cats.data._
+import cats.effect.IO
+import cats.implicits._
+
 val xa = Transactor.fromDriverManager[IO](
   "org.postgresql.Driver", "jdbc:postgresql:world", "postgres", ""
 )
@@ -32,70 +37,75 @@ CREATE TABLE country (
 )
 ```
 
-### Internal Streaming
+### Reading Rows into Collections
 
 For our first query let's aim low and select some country names into a `List`, then print out the first few. There are several steps here so we have noted the types along the way.
 
 ```tut
-(sql"select name from country"
-  .query[String]     // Query0[String]
-  .list              // ConnectionIO[List[String]]
-  .transact(xa)      // IO[List[String]]
-  .unsafeRunSync   // List[String]
-  .take(5).foreach(println))
+{
+  sql"select name from country"
+    .query[String]    // Query0[String]
+    .to[List]         // ConnectionIO[List[String]]
+    .transact(xa)     // IO[List[String]]
+    .unsafeRunSync    // List[String]
+    .take(5)          // List[String]
+    .foreach(println) // Unit
+}
 ```
 
 Let's break this down a bit.
 
 - `sql"select name from country".query[String]` defines a `Query0[String]`, which is a one-column query that maps each returned row to a `String`. We will get to more interesting row types soon.
-- `.list` is a convenience method that streams the results, accumulating them in a `List`, in this case yielding a `ConnectionIO[List[String]]`. Similar methods are:
-  - `.vector`, which accumulates to a `Vector`
-  - `.to[Coll]`, which accumulates to a type `Coll`, given an implicit `CanBuildFrom`. This works with Scala standard library collections.
+- `.to[List]` is a convenience method that accumulates rows into a `List`, in this case yielding a `ConnectionIO[List[String]]`. It works with any collection type that has a `CanBuildFrom`. Similar methods are:
   - `.unique` which returns a single value, raising an exception if there is not exactly one row returned.
   - `.option` which returns an `Option`, raising an exception if there is more than one row returned.
   - `.nel` which returns an `NonEmptyList`, raising an exception if there are no rows returned.
   - See the Scaladoc for `Query0` for more information on these and other methods.
 - The rest is familar; `transact(xa)` yields a `IO[List[String]]` which we run, giving us a normal Scala `List[String]` that we print out.
 
-This is ok, but there's not much point reading all the results from the database when we only want the first few rows. So let's try a different approach.
+### Internal Streaming
+
+The example above is ok, but there's not much point reading all the results from the database when we only want the first five rows. So let's try a different approach.
 
 ```tut
-(sql"select name from country"
-  .query[String]     // Query0[String]
-  .process           // Stream[ConnectionIO, String]
-  .take(5)           // Stream[ConnectionIO, String]
-  .list              // ConnectionIO[List[String]]
-  .transact(xa)      // IO[List[String]]
-  .unsafeRunSync   // List[String]
-  .foreach(println))
+{
+  sql"select name from country"
+    .query[String]    // Query0[String]
+    .stream           // Stream[ConnectionIO, String]
+    .take(5)          // Stream[ConnectionIO, String]
+    .compile.toList   // ConnectionIO[List[String]]
+    .transact(xa)     // IO[List[String]]
+    .unsafeRunSync    // List[String]
+    .foreach(println) // Unit
+}
 ```
 
-The difference here is that `process` gives us a
-`Stream[ConnectionIO, String]` (an alias for `fs2.Stream[ConnectionIO, String]`)
-that emits the results as they arrive from the database. By applying `take(5)` we instruct the process to shut everything down (and clean everything up) after five elements have been emitted. This is much more efficient than pulling all 239 rows and then throwing most of them away.
-
-> From this point on we use the alias `Stream[A, B]` for `fs2.Stream[A, B]`
+The difference here is that `stream` gives us an [fs2](https://github.com/functional-streams-for-scala/fs2) `Stream[ConnectionIO, String]`
+that emits rows as they arrive from the database. By applying `take(5)` we instruct the process to shut everything down (and clean everything up) after five elements have been emitted. This is much more efficient than pulling all 239 rows and then throwing most of them away.
 
 Of course a server-side `LIMIT` would be an even better way to do this (for databases that support it), but in cases where you need client-side filtering or other custom postprocessing, `Stream` is a very general and powerful tool.
 For more information see the [fs2](https://github.com/functional-streams-for-scala/fs2) repo, which has a good list of learning resources.
 
 ### YOLO Mode
 
-The API we have seen so far is ok, but it's tiresome to keep saying `transact(xa)` and doing `foreach(println)` to see what the results look like. So **just for REPL exploration** there is a module of extra syntax provided on `Transactor` that you can import, and it gives you some shortcuts.
+The API we have seen so far is ok, but it's tiresome to keep saying `transact(xa)` and doing `foreach(println)` to see what the results look like. So **just for REPL exploration** there is a module of extra syntax provided on your `Transactor` that you can import.
 
 ```tut:silent
-val y = xa.yolo; import y._
+val y = xa.yolo // a stable reference is required
+import y._
 ```
 
 We can now run our previous query in an abbreviated form.
 
 ```tut
-(sql"select name from country"
-  .query[String] // Query0[String]
-  .process       // Stream[ConnectionIO, String]
-  .take(5)       // Stream[ConnectionIO, String]
-  .quick         // IO[Unit]
-  .unsafeRunSync)
+{
+  sql"select name from country"
+    .query[String] // Query0[String]
+    .stream        // Stream[ConnectionIO, String]
+    .take(5)       // Stream[ConnectionIO, String]
+    .quick         // IO[Unit]
+    .unsafeRunSync
+}
 ```
 
 This syntax allows you to quickly run a `Query0[A]` or `Stream[ConnectionIO, A]` and see the results printed to the console. This isn't a huge deal but it can save you some keystrokes when you're just messing around.
@@ -108,18 +118,28 @@ This syntax allows you to quickly run a `Query0[A]` or `Stream[ConnectionIO, A]`
 We can select multiple columns, of course, and map them to a tuple. The `gnp` column in our table is nullable so we'll select that one into an `Option[Double]`. In a later chapter we'll see how to check the types to be sure they're sensible.
 
 ```tut
-(sql"select code, name, population, gnp from country"
-  .query[(String, String, Int, Option[Double])]
-  .process.take(5).quick.unsafeRunSync)
+{
+  sql"select code, name, population, gnp from country"
+    .query[(String, String, Int, Option[Double])]
+    .stream
+    .take(5)
+    .quick
+    .unsafeRunSync
+}
 ```
-**doobie** automatically supports row mappings for atomic column types, as well as options, tuples, `HList`s, shapeless records, and case classes thereof. So let's try the same query with an `HList`:
+**doobie** supports row mappings for atomic column types, as well as options, tuples, `HList`s, shapeless records, and case classes thereof. So let's try the same query with an `HList`:
 
 ```tut
 import shapeless._
 
-(sql"select code, name, population, gnp from country"
-  .query[String :: String :: Int :: Option[Double] :: HNil]
-  .process.take(5).quick.unsafeRunSync)
+{
+  sql"select code, name, population, gnp from country"
+    .query[String :: String :: Int :: Option[Double] :: HNil]
+    .stream
+    .take(5)
+    .quick
+    .unsafeRunSync
+}
 ```
 
 And with a shapeless record:
@@ -129,9 +149,14 @@ import shapeless.record.Record
 
 type Rec = Record.`'code -> String, 'name -> String, 'pop -> Int, 'gnp -> Option[Double]`.T
 
-(sql"select code, name, population, gnp from country"
-  .query[Rec]
-  .process.take(5).quick.unsafeRunSync)
+{
+  sql"select code, name, population, gnp from country"
+    .query[Rec]
+    .stream
+    .take(5)
+    .quick
+    .unsafeRunSync
+}
 ```
 
 And again, mapping rows to a case class.
@@ -141,9 +166,14 @@ case class Country(code: String, name: String, pop: Int, gnp: Option[Double])
 ```
 
 ```tut
-(sql"select code, name, population, gnp from country"
-  .query[Country] // Query0[Country]
-  .process.take(5).quick.unsafeRunSync)
+{
+  sql"select code, name, population, gnp from country"
+    .query[Country]
+    .stream
+    .take(5)
+    .quick
+    .unsafeRunSync
+}
 ```
 
 You can also nest case classes, `HList`s, shapeless records, and/or tuples arbitrarily as long as the eventual members are of supported columns types. For instance, here we map the same set of columns to a tuple of two case classes:
@@ -154,54 +184,66 @@ case class Country(name: String, pop: Int, gnp: Option[Double])
 ```
 
 ```tut
-(sql"select code, name, population, gnp from country"
-  .query[(Code, Country)] // Query0[(Code, Country)]
-  .process.take(5).quick.unsafeRunSync)
+{
+  sql"select code, name, population, gnp from country"
+    .query[(Code, Country)]
+    .stream
+    .take(5)
+    .quick
+    .unsafeRunSync
+}
 ```
 
 And just for fun, since the `Code` values are constructed from the primary key, let's turn the results into a `Map`. Trivial but useful.
 
 ```tut
-(sql"select code, name, population, gnp from country"
-   .query[(Code, Country)] // Query0[(Code, Country)]
-   .process.take(5)        // Stream[ConnectionIO, (Code, Country)]
-   .list                   // ConnectionIO[List[(Code, Country)]]
-   .map(_.toMap)           // ConnectionIO[Map[Code, Country]]
-   .quick.unsafeRunSync)
+{
+  sql"select code, name, population, gnp from country"
+    .query[(Code, Country)]
+    .stream.take(5)
+    .compile.toList
+    .map(_.toMap)
+    .quick
+    .unsafeRunSync
+}
 ```
 
 ### Final Streaming
 
-In the examples above we construct a `Stream[ConnectionIO, A]` and discharge it via `.list` (which is just shorthand for `.compile.toList`), yielding a `ConnectionIO[List[A]]` which eventually becomes a `IO[List[A]]`. So the construction and execution of the `Stream` is entirely internal to the **doobie** program.
+In the examples above we construct a `Stream[ConnectionIO, A]` and discharge it via `.compile.toList`, yielding a `ConnectionIO[List[A]]` which eventually becomes a `IO[List[A]]`. So the construction and execution of the `Stream` is entirely internal to the **doobie** program.
 
 However in some cases a stream is what we want as our "top level" type. For example, [http4s](https://github.com/http4s/http4s) can use a `Stream[IO, A]` directly as a response type, which could allow us to stream a resultset directly to the network socket. We can achieve this in **doobie** by calling `transact` directly on the `Stream[ConnectionIO, A]`.
 
 ```tut
 val p = {
   sql"select name, population, gnp from country"
-    .query[Country]  // Query0[Country]
-    .process         // Stream[ConnectionIO, Country]
-    .transact(xa)    // Stream[IO, Country]
- }
+    .query[Country] // Query0[Country]
+    .stream         // Stream[ConnectionIO, Country]
+    .transact(xa)   // Stream[IO, Country]
+}
 
 p.take(5).compile.toVector.unsafeRunSync.foreach(println)
 ```
-
 
 ### Diving Deeper
 
 The `sql` interpolator is sugar for constructors defined in the `doobie.hi.connection` module, aliased as `HC` if you use the standard imports. Using these constructors directly, the above program would look like this:
 
-```tut:silent
+```tut
 
-val sql = "select code, name, population, gnp from country"
+val proc = HC.process[(Code, Country)](
+  "select code, name, population, gnp from country", // statement
+  ().pure[PreparedStatementIO],                      // prep (none)
+  512                                                // chunk size
+)
 
-val proc = HC.process[(Code, Country)](sql, ().pure[PreparedStatementIO], 512) // chunk size
-
-(proc.take(5)        // Stream[ConnectionIO, (Code, Country)]
-     .list           // ConnectionIO[List[(Code, Country)]]
-     .map(_.toMap)   // ConnectionIO[Map[Code, Country]]
-  .quick.unsafeRunSync)
+{
+  proc.take(5)        // Stream[ConnectionIO, (Code, Country)]
+      .compile.toList // ConnectionIO[List[(Code, Country)]]
+      .map(_.toMap)   // ConnectionIO[Map[Code, Country]]
+      .quick
+      .unsafeRunSync
+}
 ```
 
 The `process` combinator is parameterized on the process element type and consumes an sql statement and a program in `PreparedStatementIO` that sets input parameters and any other pre-execution configuration. In this case the "prepare" program is a no-op.

--- a/modules/docs/src/main/tut/docs/06-Checking.md
+++ b/modules/docs/src/main/tut/docs/06-Checking.md
@@ -13,12 +13,19 @@ In this chapter we learn how to use YOLO mode to validate queries against the da
 Our setup here is the same as last chapter, so if you're still running from last chapter you can skip this section. Otherwise: imports, `Transactor`, and YOLO mode.
 
 ```tut:silent
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO, cats.implicits._
+import doobie._
+import doobie.implicits._
+import cats._
+import cats.data._
+import cats.effect.IO
+import cats.implicits._
+
 val xa = Transactor.fromDriverManager[IO](
   "org.postgresql.Driver", "jdbc:postgresql:world", "postgres", ""
 )
-val y = xa.yolo; import y._
+
+val y = xa.yolo
+import y._
 ```
 
 And again, we're playing with the `country` table, shown here for reference.
@@ -45,11 +52,12 @@ case class Country(code: Int, name: String, pop: Int, gnp: Double)
 Here's our parameterized query from last chapter, but with the new `Country` definition and the `minPop` parameter changed to a `Short`.
 
 ```tut:silent
-def biggerThan(minPop: Short) = sql"""
-  select code, name, population, gnp, indepyear
-  from country
-  where population > $minPop
-""".query[Country]
+def biggerThan(minPop: Short) =
+  sql"""
+    select code, name, population, gnp, indepyear
+    from country
+    where population > $minPop
+  """.query[Country]
 ```
 
 Now let's try the `check` method provided by YOLO and see what happens.
@@ -65,25 +73,26 @@ Yikes, there are quite a few problems, in several categories. In this case **doo
 - a column nullability mismatch, where a column that is *provably* nullable is read into a non-`Option` type;
 - and an unused column.
 
-Suggested fixes are given in terms of both JDBC and vendor-specific schema types and include known custom types like **doobie**'s enumerated `JdbcType`.  Currently this is based on instantiated `Meta` instances, which is not ideal; hopefully in the next release the tooling will improve to support all instances in scope.
+Suggested fixes are given in terms of both JDBC and vendor-specific schema types and include known custom types like **doobie**'s enumerated `JdbcType`.  Currently this is based on instantiated `Meta` instances, which is not ideal; hopefully tooling can improve to support all instances in scope.
 
 Anyway, if we fix all of these problems and try again, we get a clean bill of health.
 
 ```tut:silent
 case class Country(code: String, name: String, pop: Int, gnp: Option[BigDecimal])
 
-def biggerThan(minPop: Int) = sql"""
-  select code, name, population, gnp
-  from country
-  where population > $minPop
-""".query[Country]
+def biggerThan(minPop: Int) =
+  sql"""
+    select code, name, population, gnp
+    from country
+    where population > $minPop
+  """.query[Country]
 ```
 
 ```tut:plain
 biggerThan(0).check.unsafeRunSync
 ```
 
-**doobie** supports `check` for queries and updates in three ways: programmatically, via YOLO mode in the REPL, and via the `doobie-specs2` package, which allows checking to become part of your unit test suite. We will investigate this in the chapter on testing.
+**doobie** supports `check` for queries and updates in three ways: programmatically, via YOLO mode in the REPL, and via the `doobie-specs2` and `doobie-scalatest` packages, which allow checking to become part of your unit test suite. We will investigate this in the chapter on testing.
 
 ### Working Around Bad Metadata
 
@@ -95,11 +104,9 @@ However a common case is that *parameter* metadata is unavailable but *output co
 biggerThan(0).checkOutput.unsafeRunSync
 ```
 
-This option is also available in the `doobie-specs2` package.
-
 ### Diving Deeper
 
-The `check` logic requires both a database connection and concrete `Meta` instances that define column-level JDBC mappings. This could in principle happen at compile-time, but it's not clear that this is what you always want and it's potentially hairy to implement. So for now checking happens at unit-test time.
+The `check` logic requires both a database connection and concrete `Meta` instances that define column-level JDBC mappings.
 
 The way this works is that a `Query` value has enough type information to describe all parameter and column mappings, as well as the SQL literal itself (with interpolated parameters erased into `?`). From here it is straightforward to prepare the statement, pull the `ResultsetMetaData` and `DatabaseMetaData` and work out whether things are aligned correctly (and if not, determine how misalignments might be fixed). The `Anaylsis` class consumes this metadata and is able to provide the following diagnostics:
 

--- a/modules/docs/src/main/tut/docs/08-Fragments.md
+++ b/modules/docs/src/main/tut/docs/08-Fragments.md
@@ -13,12 +13,19 @@ In this chapter we discuss how to construct SQL statements at runtime.
 Same as last chapter, so if you're still set up you can skip this section. Otherwise let's set up a `Transactor` and YOLO mode.
 
 ```tut:silent
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO, cats.implicits._
+import doobie._
+import doobie.implicits._
+import cats._
+import cats.data._
+import cats.effect.IO
+import cats.implicits._
+
 val xa = Transactor.fromDriverManager[IO](
   "org.postgresql.Driver", "jdbc:postgresql:world", "postgres", ""
 )
-val y = xa.yolo; import y._
+
+val y = xa.yolo
+import y._
 ```
 
 We're still playing with the `country` table, shown here for reference.
@@ -35,7 +42,7 @@ CREATE TABLE country (
 
 ### Composing SQL literals
 
-SQL literals constructed with the `fr` interpolator behave just like the `sql` interpolator and can be composed by concatenation.
+You can construct a SQL `Fragment` using the `fr` interpolator, which behaves just like the `sql` interpolator. Fragments are concatenated with `++`.
 
 ```tut
 val a = fr"select name from country"
@@ -44,7 +51,7 @@ val c = a ++ b // concatenation by ++
 c.query[String].unique.quick.unsafeRunSync
 ```
 
-Fragments can capture arguments of any type with a `Param` instance, just as the `sql` interpolator does.
+Fragments can capture arguments of any type with a `Meta` instance, just as the `sql` interpolator does.
 
 ```tut
 def whereCode(s: String) = fr"where code = $s"
@@ -59,6 +66,7 @@ def count(table: String) = (fr"select count(*) from" ++ Fragment.const(table)).q
 count("city").quick.unsafeRunSync
 ```
 
+> Note that `Fragment.const` performs no escaping of passed strings. Passing user-supplied data is an **injection risk**.
 
 ### Whitespace handling
 

--- a/modules/docs/src/main/tut/docs/10-Logging.md
+++ b/modules/docs/src/main/tut/docs/10-Logging.md
@@ -13,8 +13,13 @@ In this chapter we discuss how to log statement execution and timing.
 Once again we will set up our REPL with a transactor.
 
 ```tut:silent
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO, cats.implicits._
+import doobie._
+import doobie.implicits._
+import cats._
+import cats.data._
+import cats.effect.IO
+import cats.implicits._
+
 val xa = Transactor.fromDriverManager[IO](
   "org.postgresql.Driver", "jdbc:postgresql:world", "postgres", ""
 )
@@ -86,7 +91,7 @@ def byName(pat: String) = {
 }
 ```
 
-### Writing Your `LogHandler`
+### Writing Your Own `LogHandler`
 
 If you use the `jdkLogHandler` you will be warned that it's just an example, write your own! So let's do that. `LogHandler` is a very simple data type:
 
@@ -161,7 +166,7 @@ val jdkLogHandler: LogHandler = {
 
 ### Caveats
 
-Logging is not yet supported for streaming (`.process` or YOLO mode's `.quick`).
+Logging is not yet supported for streaming (`.stream` or YOLO mode's `.quick`).
 
 Note that the `LogHandler` invocation is part of your `ConnectionIO` program, and it is called synchronously. Most back-end loggers are asynchronous so this is unlikely to be an issue, but do take care not to spend too much time in your handler.
 

--- a/modules/docs/src/main/tut/docs/11-Arrays.md
+++ b/modules/docs/src/main/tut/docs/11-Arrays.md
@@ -13,13 +13,21 @@ This chapter shows how we can map Scala sequence types to SQL `ARRAY` types, for
 Again we set up a transactor and pull in YOLO mode. We also need an import to get PostgreSQL-specific type mappings.
 
 ```tut:silent
-import doobie._, doobie.implicits._
-import doobie.postgres._, doobie.postgres.implicits._
-import cats._, cats.data._, cats.effect.IO, cats.implicits._
+import doobie._
+import doobie.implicits._
+import doobie.postgres._
+import doobie.postgres.implicits._
+import cats._
+import cats.data._
+import cats.effect.IO
+import cats.implicits._
+
 val xa = Transactor.fromDriverManager[IO](
   "org.postgresql.Driver", "jdbc:postgresql:world", "postgres", ""
 )
-val y = xa.yolo; import y._
+
+val y = xa.yolo
+import y._
 ```
 
 ### Reading and Writing Arrays
@@ -50,7 +58,8 @@ case class Person(id: Long, name: String, pets: List[String])
 
 def insert(name: String, pets: List[String]): ConnectionIO[Person] = {
   sql"insert into person (name, pets) values ($name, $pets)"
-    .update.withUniqueGeneratedKeys("id", "name", "pets")
+    .update
+    .withUniqueGeneratedKeys("id", "name", "pets")
 }
 ```
 

--- a/modules/docs/src/main/tut/docs/13-Unit-Testing.md
+++ b/modules/docs/src/main/tut/docs/13-Unit-Testing.md
@@ -13,8 +13,13 @@ The YOLO-mode query checking feature demonstated in an earlier chapter is also a
 As with earlier chapters we set up a `Transactor` and YOLO mode. We will also use the `doobie-specs2` and `doobie-scalatest` add-ons.
 
 ```tut:silent
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO, cats.implicits._
+import doobie._
+import doobie.implicits._
+import cats._
+import cats.data._
+import cats.effect.IO
+import cats.implicits._
+
 val xa = Transactor.fromDriverManager[IO](
   "org.postgresql.Driver", "jdbc:postgresql:world", "postgres", ""
 )
@@ -38,19 +43,22 @@ So here are a few queries we would like to check. Note that we can only check va
 ```tut:silent
 case class Country(code: Int, name: String, pop: Int, gnp: Double)
 
-val trivial = sql"""
-  select 42, 'foo'::varchar
-""".query[(Int, String)]
+val trivial =
+  sql"""
+    select 42, 'foo'::varchar
+  """.query[(Int, String)]
 
-def biggerThan(minPop: Short) = sql"""
-  select code, name, population, gnp, indepyear
-  from country
-  where population > $minPop
-""".query[Country]
+def biggerThan(minPop: Short) =
+  sql"""
+    select code, name, population, gnp, indepyear
+    from country
+    where population > $minPop
+  """.query[Country]
 
-def update(oldName: String, newName: String) = sql"""
-  update country set name = $newName where name = $oldName
-""".update
+def update(oldName: String, newName: String) =
+  sql"""
+    update country set name = $newName where name = $oldName
+  """.update
 ```
 
 ### The Specs2 Package

--- a/modules/docs/src/main/tut/docs/15-Extensions-PostgreSQL.md
+++ b/modules/docs/src/main/tut/docs/15-Extensions-PostgreSQL.md
@@ -12,25 +12,33 @@ In this chapter we discuss the extended support that **doobie** offers for users
 libraryDependencies += "org.tpolecat" %% "doobie-postgres" % "{{site.doobieVersion}}"
 ```
 
-This library pulls in [PostgreSQL JDBC Driver 9.4](https://jdbc.postgresql.org/documentation/94/index.html) as a transitive dependency.
+This library pulls in [PostgreSQL JDBC Driver](https://jdbc.postgresql.org) as a transitive dependency.
 
 ### Setting Up
 
 The following examples require a few imports.
 
 ```tut:silent
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO, cats.implicits._
+import cats._
+import cats.data._
+import cats.effect.IO
+import cats.implicits._
+import doobie._
+import doobie.implicits._
+
 val xa = Transactor.fromDriverManager[IO](
   "org.postgresql.Driver", "jdbc:postgresql:world", "postgres", ""
 )
-val y = xa.yolo; import y._
+
+val y = xa.yolo
+import y._
 ```
 
 **doobie** adds support for a large number of extended types that are not supported directly by JDBC. All mappings (except postgis) are provided in the `pgtypes` module.
 
 ```tut:silent
-import doobie.postgres._, doobie.postgres.implicits._
+import doobie.postgres._
+import doobie.postgres.implicits._
 ```
 
 ### Array Types

--- a/modules/docs/src/main/tut/docs/16-Extensions-H2.md
+++ b/modules/docs/src/main/tut/docs/16-Extensions-H2.md
@@ -12,7 +12,7 @@ In this chapter we discuss the extended support that **doobie** offers for users
 libraryDependencies += "org.tpolecat" %% "doobie-h2" % doobieVersion
 ```
 
-This library pulls in [H2 Version 1.3.170](http://www.h2database.com/html/main.html) as a transitive dependency.
+This library pulls in H2 as a transitive dependency.
 
 ### Array Types
 
@@ -20,8 +20,8 @@ This library pulls in [H2 Version 1.3.170](http://www.h2database.com/html/main.h
 
 - `Boolean`
 - `Int`
-- `Long`   
-- `Float`  
+- `Long`
+- `Float`
 - `Double`
 - `String`
 
@@ -39,8 +39,10 @@ See the previous chapter on **SQL Arrays** for usage examples.
 
 ```tut:silent
 import cats.effect.IO
-import doobie._, doobie.implicits._
-import doobie.h2._, doobie.h2.implicits._
+import doobie._
+import doobie.h2._
+import doobie.h2.implicits._
+import doobie.implicits._
 
 val q = sql"select 42".query[Int].unique
 

--- a/modules/docs/src/main/tut/migration.md
+++ b/modules/docs/src/main/tut/migration.md
@@ -13,6 +13,21 @@ position: 2
 
 This guide covers the changes that are specific to **doobie**, but you will also need to deal with changes between cats 0.9 and cats 1.0 (the provided Scalafix rules may be helpful) and between fs2 0.9 and fs2 0.10. Please join the [gitter channel](https://gitter.im/tpolecat/doobie) if you run into trouble. We will update this document to reflect common issues as they arise.
 
+## Artifacts
+
+Artifact names have changed. The `-cats` segment is now redundant and has been removed.
+
+| 0.4.x Artifact          | 0.5.x Artifact     |
+|-------------------------|--------------------|
+| `"doobie-core-cats"`      | `"doobie-core"`      |
+| `"doobie-h2-cats"`        | `"doobie-h2"`        |
+| `"doobie-hikari-cats"`    | `"doobie-hikari"`    |
+| `"doobie-postgres-cats"`  | `"doobie-postgres"`  |
+| `"doobie-refined-cats"`   | `"doobie-refined"`   |
+| `"doobie-scalatest-cats"` | `"doobie-scalatest"` |
+| `"doobie-specs2-cats"`    | `"doobie-specs2"`    |
+
+
 ## Imports
 
 Doobie imports have been split into normal and implicit slices, to mirror the pattern in cats (old imports will work but are deprecated) and a few things have been renamed. fs2's interop layer for cats is gone.

--- a/modules/example/src/main/scala/example/FirstExample.scala
+++ b/modules/example/src/main/scala/example/FirstExample.scala
@@ -44,18 +44,18 @@ object FirstExample {
       _  <- putStrLn(s"Inserted $ns suppliers and $nc coffees.")
 
       // Select and stream the coffees to stdout
-      _ <- DAO.allCoffees.sink(c => putStrLn(s"$c"))
+      _ <- DAO.allCoffees.evalMap(c => putStrLn(s"$c")).compile.drain
 
       // Get the names and supplier names for all coffees costing less than $9.00,
       // again streamed directly to stdout
-      _ <- DAO.coffeesLessThan(9.0).sink(p => putStrLn(s"$p"))
+      _ <- DAO.coffeesLessThan(9.0).evalMap(p => putStrLn(s"$p")).compile.drain
 
       // Same thing, but read into a list this time
-      l <- DAO.coffeesLessThan(9.0).list
+      l <- DAO.coffeesLessThan(9.0).compile.toList
       _ <- putStrLn(l.toString)
 
       // Read into a vector this time, with some stream processing
-      v <- DAO.coffeesLessThan(9.0).take(2).map(p => p._1 + "*" + p._2).vector
+      v <- DAO.coffeesLessThan(9.0).take(2).map(p => p._1 + "*" + p._2).compile.toVector
       _ <- putStrLn(v.toString)
 
     } yield "All done!"

--- a/modules/example/src/main/scala/example/GenericStream.scala
+++ b/modules/example/src/main/scala/example/GenericStream.scala
@@ -76,7 +76,7 @@ object GenericStream {
 
   def runl(args: List[String]): IO[Unit] =
     args match {
-      case sql :: Nil => processGeneric(sql, ().pure[PreparedStatementIO], 100).transact(xa).sink(m => IO(Console.println(m)))
+      case sql :: Nil => processGeneric(sql, ().pure[PreparedStatementIO], 100).transact(xa).evalMap(m => IO(Console.println(m))).compile.drain
       case _          => IO(Console.println("expected on arg, a query"))
     }
 

--- a/modules/example/src/main/scala/example/HiUsage.scala
+++ b/modules/example/src/main/scala/example/HiUsage.scala
@@ -23,7 +23,7 @@ object HiUsage {
 
   // An example action. Streams results to stdout
   lazy val example: ConnectionIO[Unit] =
-    speakerQuery("English", 10).sink(c => FC.delay(println("~> " + s"$c")))
+    speakerQuery("English", 10).evalMap(c => FC.delay(println("~> " + s"$c"))).compile.drain
 
   // Construct an action to find countries where more than `pct` of the population speaks `lang`.
   // The result is a scalaz.stream.Process that can be further manipulated by the caller.

--- a/modules/example/src/main/scala/example/PostgresNotify.scala
+++ b/modules/example/src/main/scala/example/PostgresNotify.scala
@@ -55,7 +55,7 @@ object PostgresNotify {
     notificationStream("foo", 1000)
       .map(n => s"${n.getPID} ${n.getName} ${n.getParameter}")
       .take(5)
-      .sink(s => HC.delay(Console.println(s)))
+      .evalMap(s => HC.delay(Console.println(s))).compile.drain
       .transact(xa)
       .void
       .unsafeRunSync()


### PR DESCRIPTION
This is a lot of little changes but I think it covers all the important stuff. No more mentions of `Catchable`, `Suspend`, `Process`, etc. It also gets rid of the `Stream` syntax other than `.transact` ... we don't need to be in the business of providing general-purpose syntax for fs2.