### PR TITLE
process → stream

### DIFF
--- a/modules/bench/src/main/scala/doobie/bench/select.scala
+++ b/modules/bench/src/main/scala/doobie/bench/select.scala
@@ -45,11 +45,11 @@ class bench {
     }
   }
 
-  // Reading via .process, which adds a fair amount of overhead
+  // Reading via .stream, which adds a fair amount of overhead
   def doobieBenchP(n: Int): Int =
     sql"select a.name, b.name, c.name from country a, country b, country c limit $n"
       .query[(String,String,String)]
-      .process
+      .stream
       .compile.toList
       .transact(xa)
       .map(_.length)
@@ -59,7 +59,7 @@ class bench {
   def doobieBench(n: Int): Int =
     sql"select a.name, b.name, c.name from country a, country b, country c limit $n"
       .query[(String,String,String)]
-      .list
+      .to[List]
       .transact(xa)
       .map(_.length)
       .unsafeRunSync
@@ -68,7 +68,7 @@ class bench {
   def doobieBenchV(n: Int): Int =
     sql"select a.name, b.name, c.name from country a, country b, country c limit $n"
       .query[(String,String,String)]
-      .vector
+      .to[Vector]
       .transact(xa)
       .map(_.length)
       .unsafeRunSync

--- a/modules/core/src/main/scala/doobie/hi/connection.scala
+++ b/modules/core/src/main/scala/doobie/hi/connection.scala
@@ -67,7 +67,7 @@ object connection {
    * action, and return results via a `Stream`.
    * @group Prepared Statements
    */
-  def process[A: Composite](sql: String, prep: PreparedStatementIO[Unit], chunkSize: Int): Stream[ConnectionIO, A] =
+  def stream[A: Composite](sql: String, prep: PreparedStatementIO[Unit], chunkSize: Int): Stream[ConnectionIO, A] =
     liftStream(chunkSize, FC.prepareStatement(sql), prep, FPS.executeQuery)
 
   /**

--- a/modules/core/src/main/scala/doobie/hi/preparedstatement.scala
+++ b/modules/core/src/main/scala/doobie/hi/preparedstatement.scala
@@ -46,7 +46,7 @@ object preparedstatement {
     repeatEvalChunks(FPS.embed(rs, resultset.getNextChunk[A](chunkSize)))
 
   /** @group Execution */
-  def process[A: Composite](chunkSize: Int): Stream[PreparedStatementIO, A] =
+  def stream[A: Composite](chunkSize: Int): Stream[PreparedStatementIO, A] =
     bracket(FPS.executeQuery)(unrolled[A](_, chunkSize), FPS.embed(_, FRS.close))
 
   /**

--- a/modules/core/src/main/scala/doobie/hi/resultset.scala
+++ b/modules/core/src/main/scala/doobie/hi/resultset.scala
@@ -223,7 +223,7 @@ object resultset {
    * mechanism for dealing with query results.
    * @group Results
    */
-  def process[A: Composite](chunkSize: Int): Stream[ResultSetIO, A] =
+  def stream[A: Composite](chunkSize: Int): Stream[ResultSetIO, A] =
     repeatEvalChunks(getNextChunk[A](chunkSize))
 
   /** @group Properties */

--- a/modules/core/src/main/scala/doobie/util/query.scala
+++ b/modules/core/src/main/scala/doobie/util/query.scala
@@ -109,21 +109,24 @@ object query {
     def outputAnalysis: ConnectionIO[Analysis] =
       HC.prepareQueryAnalysis0[O](sql)
 
+    /** @group Deprecated Methods */
+    @deprecated("use .streamWithChunkSize", "0.5.0")
+    def processWithChunkSize(a: A, chunkSize: Int): Stream[ConnectionIO, B] =
+      streamWithChunkSize(a, chunkSize)
+
     /**
      * Apply the argument `a` to construct a `Stream` with the given chunking factor, with
      * effect type  `[[doobie.free.connection.ConnectionIO ConnectionIO]]` yielding elements of
      * type `B`.
      * @group Results
      */
-    def processWithChunkSize(a: A, chunkSize: Int): Stream[ConnectionIO, B] =
-      HC.process[O](sql, HPS.set(ai(a)), chunkSize).map(ob)
-
-    /**
-     * FS2 Friendly Alias for processWithChunkSize.
-     * @group Results
-     */
     def streamWithChunkSize(a: A, chunkSize: Int): Stream[ConnectionIO, B] =
-      processWithChunkSize(a, chunkSize)
+      HC.stream[O](sql, HPS.set(ai(a)), chunkSize).map(ob)
+
+    /** @group Deprecated Methods */
+    @deprecated("use .stream", "0.5.0")
+    def process(a: A): Stream[ConnectionIO, B] =
+      stream(a)
 
     /**
      * Apply the argument `a` to construct a `Stream` with `DefaultChunkSize`, with
@@ -131,15 +134,9 @@ object query {
      * type `B`.
      * @group Results
      */
-    def process(a: A): Stream[ConnectionIO, B] =
-      processWithChunkSize(a, DefaultChunkSize)
-
-    /**
-     * FS2 Friendly Alias for process.
-     * @group Results
-     */
     def stream(a: A): Stream[ConnectionIO, B] =
-      process(a)
+      streamWithChunkSize(a, DefaultChunkSize)
+
 
     /**
      * Apply the argument `a` to construct a program in
@@ -186,16 +183,12 @@ object query {
     def nel(a: A): ConnectionIO[NonEmptyList[B]] =
       HC.prepareStatement(sql)(HPS.set(ai(a)) *> executeQuery(a, HRS.nel[O])).map(_.map(ob))
 
-    /**
-     * Convenience method; equivalent to `to[List]`
-     * @group Results
-     */
+    /** @group Deprecated Methods */
+    @deprecated("use .to[List]", "0.5.0")
     def list(a: A): ConnectionIO[List[B]] = to[List](a)
 
-    /**
-     * Convenience method; equivalent to `to[Vector]`
-     * @group Results
-     */
+    /** @group Deprecated Methods */
+    @deprecated("use .to[Vector]", "0.5.0")
     def vector(a: A): ConnectionIO[Vector[B]] = to[Vector](a)
 
     /** @group Transformations */
@@ -238,7 +231,7 @@ object query {
         def toFragment = outer.toFragment(a)
         def analysis = outer.analysis
         def outputAnalysis = outer.outputAnalysis
-        def processWithChunkSize(n: Int) = outer.processWithChunkSize(a, n)
+        def streamWithChunkSize(n: Int) = outer.streamWithChunkSize(a, n)
         def accumulate[F[_]: Alternative] = outer.accumulate[F](a)
         def to[F[_]](implicit cbf: CanBuildFrom[Nothing, B, F[B]]) = outer.to[F](a)
         def unique = outer.unique(a)
@@ -330,34 +323,30 @@ object query {
      */
     def outputAnalysis: ConnectionIO[Analysis]
 
+    /** @group Deprecated Methods */
+    @deprecated("use .stream", "0.5.0")
+    def process: Stream[ConnectionIO, B] =
+      stream
+
     /**
      * `Stream` with default chunk factor, with effect type
      * `[[doobie.free.connection.ConnectionIO ConnectionIO]]` yielding  elements of type `B`.
      * @group Results
      */
-    def process: Stream[ConnectionIO, B] =
-      processWithChunkSize(DefaultChunkSize)
-
-    /**
-     * FS2 Friendly Alias for process.
-     * @group Results
-     */
     def stream : Stream[ConnectionIO, B] =
-      process
+      streamWithChunkSize(DefaultChunkSize)
+
+    /** @group Deprecated Methods */
+    @deprecated("use .streamWithChunkSize", "0.5.0")
+    def processWithChunkSize(n: Int): Stream[ConnectionIO, B] =
+      streamWithChunkSize(n)
 
     /**
      * `Stream` with given chunk factor, with effect type
      * `[[doobie.free.connection.ConnectionIO ConnectionIO]]` yielding  elements of type `B`.
      * @group Results
      */
-    def processWithChunkSize(n: Int): Stream[ConnectionIO, B]
-
-    /**
-     * FS2 Friendly Alias for processWithChunkSize.
-     * @group Results
-     */
-    def streamWithChunkSize(n: Int): Stream[ConnectionIO, B] =
-      processWithChunkSize(n)
+    def streamWithChunkSize(n: Int): Stream[ConnectionIO, B]
 
     /**
      * Program in `[[doobie.free.connection.ConnectionIO ConnectionIO]]` yielding an `F[B]`
@@ -403,18 +392,14 @@ object query {
      * @group Results
      */
     def sink(f: B => ConnectionIO[Unit]): ConnectionIO[Unit] =
-      process.evalMap(f).compile.drain
+      stream.evalMap(f).compile.drain
 
-    /**
-     * Convenience method; equivalent to `to[List]`
-     * @group Results
-     */
+    /** @group Deprecated Methods */
+    @deprecated("use .to[List]", "0.5.0")
     def list: ConnectionIO[List[B]] = to[List]
 
-    /**
-     * Convenience method; equivalent to `to[Vector]`
-     * @group Results
-     */
+    /** @group Deprecated Methods */
+    @deprecated("use .to[Vector]", "0.5.0")
     def vector: ConnectionIO[Vector[B]] = to[Vector]
 
   }

--- a/modules/core/src/test/scala/doobie/util/query.scala
+++ b/modules/core/src/test/scala/doobie/util/query.scala
@@ -67,7 +67,7 @@ object queryspec extends Specification {
       q.toQuery0("foo").option.transact(xa).unsafeRunSync must_=== Some(123)
     }
     "map" in {
-      q.toQuery0("foo").map(_ * 2).list.transact(xa).unsafeRunSync must_=== List(246)
+      q.toQuery0("foo").map(_ * 2).to[List].transact(xa).unsafeRunSync must_=== List(246)
     }
   }
 
@@ -82,7 +82,7 @@ object queryspec extends Specification {
       q.toQuery0("bar").option.transact(xa).unsafeRunSync must_=== None
     }
     "map" in {
-      q.toQuery0("bar").map(_ * 2).list.transact(xa).unsafeRunSync must_=== Nil
+      q.toQuery0("bar").map(_ * 2).to[List].transact(xa).unsafeRunSync must_=== Nil
     }
   }
 
@@ -99,7 +99,7 @@ object queryspec extends Specification {
       q0n.option.transact(xa).unsafeRunSync must_=== Some(123)
     }
     "map" in {
-      q0n.map(_ * 2).list.transact(xa).unsafeRunSync must_=== List(246)
+      q0n.map(_ * 2).to[List].transact(xa).unsafeRunSync must_=== List(246)
     }
   }
 
@@ -116,7 +116,7 @@ object queryspec extends Specification {
       q0e.option.transact(xa).unsafeRunSync must_=== None
     }
     "map" in {
-      q0e.map(_ * 2).list.transact(xa).unsafeRunSync must_=== Nil
+      q0e.map(_ * 2).to[List].transact(xa).unsafeRunSync must_=== Nil
     }
   }
 

--- a/modules/docs/src/main/tut/docs/04-Selecting.md
+++ b/modules/docs/src/main/tut/docs/04-Selecting.md
@@ -81,7 +81,7 @@ The example above is ok, but there's not much point reading all the results from
 ```
 
 The difference here is that `stream` gives us an [fs2](https://github.com/functional-streams-for-scala/fs2) `Stream[ConnectionIO, String]`
-that emits rows as they arrive from the database. By applying `take(5)` we instruct the process to shut everything down (and clean everything up) after five elements have been emitted. This is much more efficient than pulling all 239 rows and then throwing most of them away.
+that emits rows as they arrive from the database. By applying `take(5)` we instruct the stream to shut everything down (and clean everything up) after five elements have been emitted. This is much more efficient than pulling all 239 rows and then throwing most of them away.
 
 Of course a server-side `LIMIT` would be an even better way to do this (for databases that support it), but in cases where you need client-side filtering or other custom postprocessing, `Stream` is a very general and powerful tool.
 For more information see the [fs2](https://github.com/functional-streams-for-scala/fs2) repo, which has a good list of learning resources.
@@ -231,7 +231,7 @@ The `sql` interpolator is sugar for constructors defined in the `doobie.hi.conne
 
 ```tut
 
-val proc = HC.process[(Code, Country)](
+val proc = HC.stream[(Code, Country)](
   "select code, name, population, gnp from country", // statement
   ().pure[PreparedStatementIO],                      // prep (none)
   512                                                // chunk size
@@ -246,4 +246,4 @@ val proc = HC.process[(Code, Country)](
 }
 ```
 
-The `process` combinator is parameterized on the process element type and consumes an sql statement and a program in `PreparedStatementIO` that sets input parameters and any other pre-execution configuration. In this case the "prepare" program is a no-op.
+The `stream` combinator is parameterized on the element type and consumes a statement and a program in `PreparedStatementIO` that sets input parameters and any other pre-execution configuration. In this case the "prepare" program is a no-op.

--- a/modules/docs/src/main/tut/docs/05-Parameterized.md
+++ b/modules/docs/src/main/tut/docs/05-Parameterized.md
@@ -129,7 +129,7 @@ populationIn(100000000 to 300000000, NonEmptyList.of("USA", "BRA", "PAK", "GBR")
 
 ### Diving Deeper
 
-In the previous chapter's *Diving Deeper* we saw how a query constructed with the `sql` interpolator is just sugar for the `process` constructor defined in the `doobie.hi.connection` module (aliased as `HC`). Here we see that the second parameter, a `PreparedStatementIO` program, is used to set the query parameters. The third parameter specifies a chunking factor; rows are buffered in chunks of the specified size.
+In the previous chapter's *Diving Deeper* we saw how a query constructed with the `sql` interpolator is just sugar for the `stream` constructor defined in the `doobie.hi.connection` module (aliased as `HC`). Here we see that the second parameter, a `PreparedStatementIO` program, is used to set the query parameters. The third parameter specifies a chunking factor; rows are buffered in chunks of the specified size.
 
 ```tut:silent
 import fs2.Stream
@@ -142,7 +142,7 @@ val q = """
   """
 
 def proc(range: Range): Stream[ConnectionIO, Country] =
-  HC.process[Country](q, HPS.set((range.min, range.max)), 512)
+  HC.stream[Country](q, HPS.set((range.min, range.max)), 512)
 ```
 
 Which produces the same output.

--- a/modules/docs/src/main/tut/docs/10-Logging.md
+++ b/modules/docs/src/main/tut/docs/10-Logging.md
@@ -47,7 +47,7 @@ When we construct a `Query0` or `Update0` we can provide an optional `LogHandler
 def byName(pat: String) = {
   sql"select name, code from country where name like $pat"
     .queryWithLogHandler[(String, String)](LogHandler.jdkLogHandler)
-    .list
+    .to[List]
     .transact(xa)
 }
 ```
@@ -86,7 +86,7 @@ implicit val han = LogHandler.jdkLogHandler
 def byName(pat: String) = {
   sql"select name, code from country where name like $pat"
     .query[(String, String)] // handler will be picked up here
-    .list
+    .to[List]
     .transact(xa)
 }
 ```

--- a/modules/docs/src/main/tut/docs/17-FAQ.md
+++ b/modules/docs/src/main/tut/docs/17-FAQ.md
@@ -90,8 +90,8 @@ cities(Code("USA"), true).check.unsafeRunSync
 And it works!
 
 ```tut
-cities(Code("USA"), true).process.take(5).quick.unsafeRunSync
-cities(Code("USA"), false).process.take(5).quick.unsafeRunSync
+cities(Code("USA"), true).stream.take(5).quick.unsafeRunSync
+cities(Code("USA"), false).stream.take(5).quick.unsafeRunSync
 ```
 
 ### How do I handle outer joins?

--- a/modules/docs/src/main/tut/migration.md
+++ b/modules/docs/src/main/tut/migration.md
@@ -64,3 +64,10 @@ The typeclass hierarchy in fs2 has been removed.
 
 **doobie**'s provided `ensuring` combinator has been renamed to `guarantee` to avoid conflicts with Scala's standard library. The combinators for `Catchable` have been removed; use `ApplicativeError` and `MonadError` instead.
 
+## Miscellaneous Changes
+
+In no particular order:
+
+- All `.process` combinators and constructors are deprecated in the `Query/Update` API and removed in the lower-level APIs; use the `.stream` equivalents.
+- The `.list` and `.vector` methods on `Query/Query0` are deprecated in favor of `.to[List]` and `.to[Vector]` respectively.
+

--- a/modules/example/src/main/scala/example/Coproduct.scala
+++ b/modules/example/src/main/scala/example/Coproduct.scala
@@ -55,7 +55,7 @@ object coproduct {
   // work but is too low-level to be useful).
   class ConnectionOps[F[_]](implicit ev: InjectK[ConnectionOp, F]) {
     def select(pat: String): Free[F, List[String]] =
-      sql"select name from country where name like $pat".query[String].list.inject[F]
+      sql"select name from country where name like $pat".query[String].to[List].inject[F]
   }
   object ConnectionOps {
     implicit def instance[F[_]](implicit ev: InjectK[ConnectionOp, F]): ConnectionOps[F] = new ConnectionOps

--- a/modules/example/src/main/scala/example/FirstExample.scala
+++ b/modules/example/src/main/scala/example/FirstExample.scala
@@ -73,7 +73,7 @@ object FirstExample {
   object DAO {
 
     def coffeesLessThan(price: Double): Stream[ConnectionIO, (String, String)] =
-      Queries.coffeesLessThan(price).process
+      Queries.coffeesLessThan(price).stream
 
     def insertSuppliers(ss: List[Supplier]): ConnectionIO[Int] =
       Queries.insertSupplier.updateMany(ss) // bulk insert (!)
@@ -82,7 +82,7 @@ object FirstExample {
       Queries.insertCoffee.updateMany(cs)
 
     def allCoffees: Stream[ConnectionIO, Coffee] =
-      Queries.allCoffees.process
+      Queries.allCoffees.stream
 
     def create: ConnectionIO[Unit] =
       Queries.create.run.void

--- a/modules/example/src/main/scala/example/GenericStream.scala
+++ b/modules/example/src/main/scala/example/GenericStream.scala
@@ -14,7 +14,7 @@ import java.sql.{ PreparedStatement, ResultSet }
 import doobie.util.stream.repeatEvalChunks
 
 /**
- * From a user question on Gitter, how can we have an equivalent to `process[A]` that constructs a
+ * From a user question on Gitter, how can we have an equivalent to `Stream[A]` that constructs a
  * stream of untyped maps.
  */
 object GenericStream {

--- a/modules/example/src/main/scala/example/HiUsage.scala
+++ b/modules/example/src/main/scala/example/HiUsage.scala
@@ -28,6 +28,6 @@ object HiUsage {
   // Construct an action to find countries where more than `pct` of the population speaks `lang`.
   // The result is a scalaz.stream.Process that can be further manipulated by the caller.
   def speakerQuery(lang: String, pct: Double): Stream[ConnectionIO,CountryCode] =
-  sql"SELECT COUNTRYCODE FROM COUNTRYLANGUAGE WHERE LANGUAGE = $lang AND PERCENTAGE > $pct".query[CountryCode].process
+  sql"SELECT COUNTRYCODE FROM COUNTRYLANGUAGE WHERE LANGUAGE = $lang AND PERCENTAGE > $pct".query[CountryCode].stream
 
 }

--- a/modules/example/src/main/scala/example/PostgresPoint.scala
+++ b/modules/example/src/main/scala/example/PostgresPoint.scala
@@ -25,7 +25,7 @@ object PostgresPoint extends App {
 
   // Point is now a perfectly cromulent input/output type
   val q = sql"select '(1, 2)'::point".query[Point]
-  val a = q.list.transact(xa).unsafeRunSync
+  val a = q.to[List].transact(xa).unsafeRunSync
   Console.println(a) // List(Point(1.0,2.0))
 
   // Just to be clear; the Composite instance has width 1, not 2

--- a/modules/postgres/src/test/scala/doobie/postgres/manyrows.scala
+++ b/modules/postgres/src/test/scala/doobie/postgres/manyrows.scala
@@ -24,7 +24,7 @@ object manyrows extends Specification {
     // TODO add timeout to test the server-side cursor
     "take consistent memory" in {
       val q = sql"""select a.name, b.name from city a, city b""".query[(String, String)]
-      q.process.take(5).transact(xa).compile.drain.unsafeRunSync
+      q.stream.take(5).transact(xa).compile.drain.unsafeRunSync
       true
     }
   }


### PR DESCRIPTION
This deprecates `process` in the highest-level API and just renames it in the lower APIs. Also deprecates `.list` and `.vector` to encourage users to use the more general `.to[F]`.