### PR TITLE
Print either result in first example

### DIFF
--- a/modules/example/src/main/scala/example/FirstExample.scala
+++ b/modules/example/src/main/scala/example/FirstExample.scala
@@ -65,7 +65,7 @@ object FirstExample {
     val db = Transactor.fromDriverManager[IO]("org.h2.Driver", "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", "sa", "")
     for {
       a <- examples.transact(db).attempt
-      _ <- IO(s"$a")
+      _ <- IO(println(s"$a"))
     } yield ()
   }
 


### PR DESCRIPTION
If you're like me, you probably messed something up with your
dependencies or the database parameters while trying to run the first
example, but confusingly it gives no output.

    sbt:doobie> example/runMain example.FirstExample
    [info] Running example.FirstExample
    [success] Total time: 9 s, completed Mar 16, 2018 12:16:28 AM

I changed the last statement to

    IO(println(str)).

Instead of,

    IO(str)

An error produces the following output:

    sbt:doobie> example/runMain example.FirstExample
    [info] Running example.FirstExample
    Left(No suitable driver found)
    [success] Total time: 18 s, completed Mar 16, 2018 12:17:32 AM

And on success,

    sbt:doobie> example/runMain example.FirstExample
    [info] Running example.FirstExample 
    Inserted 3 suppliers and 5 coffees.
    Coffee(Colombian,101,7.99,0,0)
    ...
    List((Colombian,Acme, Inc.), (French_Roast,Superior Coffee), (Colombian_Decaf,Acme, Inc.))
    Vector(Colombian*Acme, Inc., French_Roast*Superior Coffee)
    Right(All done!)