### PR TITLE
fix MAIN_SCALA_VERSION in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ scala:
 
 env:
   global:
-    - MAIN_SCALA_VERSION=2.12.4
+    - MAIN_SCALA_VERSION=2.12.5
 
 before_install:
  - export PATH=${PATH}:./vendor/bundle


### PR DESCRIPTION
I'm kind of assuming it won't build now because we accidentally broke bincompat because it wasn't being checked. Let's see...