### PR TITLE
Make Write stack-safe

### DIFF
--- a/modules/bench/src/main/scala/doobie/bench/write.scala
+++ b/modules/bench/src/main/scala/doobie/bench/write.scala
@@ -1,0 +1,111 @@
+// Copyright (c) 2013-2018 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.bench
+
+import java.sql.{
+  DriverManager,
+  PreparedStatement
+}
+import cats.implicits._
+import doobie.util._
+import org.openjdk.jmh.annotations._
+
+// Some huge structure
+
+final case class L1(
+  a: Int,
+  b: Option[Int],
+  c: Int,
+  d: Option[Int],
+  e: Int,
+  f: Option[Int],
+  g: Int,
+  h: Option[Int],
+  i: Int,
+  j: Option[Int]
+)
+
+final case class L2(
+  a: L1,
+  b: L1,
+  c: L1,
+  d: L1,
+  e: L1,
+  f: L1,
+  g: L1,
+  h: L1,
+  i: L1,
+  j: L1
+)
+
+final case class L3(
+  a: L2,
+  b: L2,
+  c: L2,
+  d: L2,
+  e: L2,
+  f: L2,
+  g: L2,
+  h: L2,
+  i: L2,
+  j: L2
+)
+
+// We're measuring the raw performance of `Write` - everything else is noise.
+object write {
+
+  @State(Scope.Benchmark)
+  val l3 = {
+    val l1 = L1(42, Some(42), 42, Some(42), 42, Some(42), 42, Some(42), 42, Some(42))
+    val l2 = L2(l1, l1, l1, l1, l1, l1, l1, l1, l1, l1)
+    L3(l2, l2, l2, l2, l2, l2, l2, l2, l2, l2)
+  }
+
+  // We're measuring the raw performance of `Write` - everything else is noise.
+  @State(Scope.Thread)
+  val statementForL3 = DriverManager.getConnection("jdbc:postgresql:world", "postgres", "")
+    .prepareStatement("values (" + List.fill(1000)("?").intercalate(",") + ")")
+}
+
+class write {
+
+  import write._
+
+  def doUnsafeSet[A: Write](a: A, ps: PreparedStatement)(n: Int): Int = {
+    for {
+      _ <- 0 to n
+    } Write[A].unsafeSet(ps, 1, a)
+    n
+  }
+
+  def doUnsafeSetNoStack[A: Write](
+    a: A,
+    ps: PreparedStatement
+  )(n: Int): Int = {
+    for {
+      _ <- 0 to n
+    } Write[A].unsafeSet(ps, 1, a, stackHeightLimit = 0)
+    n
+  }
+
+  def doUnsafeSetOld[A: OldWrite](a: A, ps: PreparedStatement)(n: Int): Int = {
+    for {
+      _ <- 0 to n
+    } OldWrite[A].unsafeSet(ps, 1, a)
+    n
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(1000)
+  def unsafeSet: Int = doUnsafeSet(l3, statementForL3)(1000)
+
+  @Benchmark
+  @OperationsPerInvocation(1000)
+  def unsafeSetNoStack: Int = doUnsafeSetNoStack(l3, statementForL3)(1000)
+
+  @Benchmark
+  @OperationsPerInvocation(1000)
+  def unsafeSetOld: Int = doUnsafeSetOld(l3, statementForL3)(1000)
+}

--- a/modules/bench/src/main/scala/doobie/util/oldwrite.scala
+++ b/modules/bench/src/main/scala/doobie/util/oldwrite.scala
@@ -1,0 +1,168 @@
+// Copyright (c) 2013-2018 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.util
+
+import cats.ContravariantSemigroupal
+import doobie.enum.Nullability._
+import doobie.free.{ FPS, FRS, PreparedStatementIO, ResultSetIO }
+import java.sql.{ PreparedStatement, ResultSet }
+import shapeless.{ HList, HNil, ::, Generic, Lazy, <:!< }
+import shapeless.labelled.{ FieldType }
+
+final class OldWrite[A](
+  val puts: List[(Put[_], NullabilityKnown)],
+  val toList: A => List[Any],
+  val unsafeSet: (PreparedStatement, Int, A) => Unit,
+  val unsafeUpdate: (ResultSet, Int, A) => Unit
+) {
+
+  lazy val length = puts.length
+
+  def set(n: Int, a: A): PreparedStatementIO[Unit] =
+    FPS.raw(unsafeSet(_, n, a))
+
+  def update(n: Int, a: A): ResultSetIO[Unit] =
+    FRS.raw(unsafeUpdate(_, n, a))
+
+  def contramap[B](f: B => A): OldWrite[B] =
+    new OldWrite(
+      puts,
+      b => toList(f(b)),
+      (ps, n, a) => unsafeSet(ps, n, f(a)),
+      (rs, n, a) => unsafeUpdate(rs, n, f(a))
+    )
+
+  def product[B](fb: OldWrite[B]): OldWrite[(A, B)] =
+    new OldWrite(
+      puts ++ fb.puts,
+      { case (a, b) => toList(a) ++ fb.toList(b) },
+      { case (ps, n, (a, b)) => unsafeSet(ps, n, a); fb.unsafeSet(ps, n + length, b) },
+      { case (rs, n, (a, b)) => unsafeUpdate(rs, n, a); fb.unsafeUpdate(rs, n + length, b) }
+    )
+
+}
+
+object OldWrite extends LowerPriorityOldWrite {
+
+  def apply[A](implicit A: OldWrite[A]): OldWrite[A] = A
+
+  implicit val ReadContravariantSemigroupal: ContravariantSemigroupal[OldWrite] =
+    new ContravariantSemigroupal[OldWrite] {
+      def contramap[A, B](fa: OldWrite[A])(f: B => A) = fa.contramap(f)
+      def product[A, B](fa: OldWrite[A], fb: OldWrite[B]) = fa.product(fb)
+    }
+
+  implicit val unitComposite: OldWrite[Unit] =
+    new OldWrite(Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
+
+  implicit def fromPut[A](implicit P: Put[A]): OldWrite[A] =
+    new OldWrite(
+      List((P, NoNulls)),
+      a => List(a),
+      (ps, n, a) => P.unsafeSetNonNullable(ps, n, a),
+      (rs, n, a) => P.unsafeUpdateNonNullable(rs, n, a)
+    )
+
+  implicit def fromPutOption[A](implicit P: Put[A]): OldWrite[Option[A]] =
+    new OldWrite(
+      List((P, Nullable)),
+      a => List(a),
+      (ps, n, a) => P.unsafeSetNullable(ps, n, a),
+      (rs, n, a) => P.unsafeUpdateNullable(rs, n, a)
+    )
+
+  implicit def recordOldWrite[K <: Symbol, H, T <: HList](
+    implicit H: Lazy[OldWrite[H]],
+              T: Lazy[OldWrite[T]]
+  ): OldWrite[FieldType[K, H] :: T] = {
+    new OldWrite(
+      H.value.puts ++ T.value.puts,
+      { case h :: t => H.value.toList(h) ++ T.value.toList(t) },
+      { case (ps, n, h :: t) => H.value.unsafeSet(ps, n, h); T.value.unsafeSet(ps, n + H.value.length, t) },
+      { case (rs, n, h :: t) => H.value.unsafeUpdate(rs, n, h); T.value.unsafeUpdate(rs, n + H.value.length, t) }
+    )
+  }
+
+}
+
+trait LowerPriorityOldWrite extends EvenLowerPriorityOldWrite {
+
+  implicit def product[H, T <: HList](
+    implicit H: Lazy[OldWrite[H]],
+              T: Lazy[OldWrite[T]]
+  ): OldWrite[H :: T] =
+    new OldWrite(
+      H.value.puts ++ T.value.puts,
+      { case h :: t => H.value.toList(h) ++ T.value.toList(t) },
+      { case (ps, n, h :: t) => H.value.unsafeSet(ps, n, h); T.value.unsafeSet(ps, n + H.value.length, t) },
+      { case (rs, n, h :: t) => H.value.unsafeUpdate(rs, n, h); T.value.unsafeUpdate(rs, n + H.value.length, t) }
+    )
+
+  implicit def emptyProduct: OldWrite[HNil] =
+    new OldWrite[HNil](Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
+
+  implicit def generic[B, A](implicit gen: Generic.Aux[B, A], A: Lazy[OldWrite[A]]): OldWrite[B] =
+    new OldWrite[B](
+      A.value.puts,
+      b => A.value.toList(gen.to(b)),
+      (ps, n, b) => A.value.unsafeSet(ps, n, gen.to(b)),
+      (rs, n, b) => A.value.unsafeUpdate(rs, n, gen.to(b))
+    )
+
+}
+
+trait EvenLowerPriorityOldWrite {
+
+  implicit val ohnil: OldWrite[Option[HNil]] =
+    new OldWrite[Option[HNil]](Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
+
+  implicit def ohcons1[H, T <: HList](
+    implicit H: Lazy[OldWrite[Option[H]]],
+             T: Lazy[OldWrite[Option[T]]],
+             N: H <:!< Option[α] forSome { type α }
+  ): OldWrite[Option[H :: T]] = {
+    void(N)
+
+    def split[A](i: Option[H :: T])(f: (Option[H], Option[T]) => A): A =
+      i.fold(f(None, None)) { case h :: t => f(Some(h), Some(t)) }
+
+    new OldWrite(
+      H.value.puts ++ T.value.puts,
+      split(_) { (h, t) => H.value.toList(h) ++ T.value.toList(t) },
+      (ps, n, i) => split(i) { (h, t) => H.value.unsafeSet(ps, n, h); T.value.unsafeSet(ps, n + H.value.length, t) },
+      (rs, n, i) => split(i) { (h, t) => H.value.unsafeUpdate(rs, n, h); T.value.unsafeUpdate(rs, n + H.value.length, t) }
+    )
+
+  }
+
+  implicit def ohcons2[H, T <: HList](
+    implicit H: Lazy[OldWrite[Option[H]]],
+             T: Lazy[OldWrite[Option[T]]]
+  ): OldWrite[Option[Option[H] :: T]] = {
+
+    def split[A](i: Option[Option[H] :: T])(f: (Option[H], Option[T]) => A): A =
+      i.fold(f(None, None)) { case oh :: t => f(oh, Some(t)) }
+
+    new OldWrite(
+      H.value.puts ++ T.value.puts,
+      split(_) { (h, t) => H.value.toList(h) ++ T.value.toList(t) },
+      (ps, n, i) => split(i) { (h, t) => H.value.unsafeSet(ps, n, h); T.value.unsafeSet(ps, n + H.value.length, t) },
+      (rs, n, i) => split(i) { (h, t) => H.value.unsafeUpdate(rs, n, h); T.value.unsafeUpdate(rs, n + H.value.length, t) }
+    )
+
+  }
+
+  implicit def ogeneric[B, A <: HList](
+    implicit G: Generic.Aux[B, A],
+             A: Lazy[OldWrite[Option[A]]]
+  ): OldWrite[Option[B]] =
+    new OldWrite(
+      A.value.puts,
+      b => A.value.toList(b.map(G.to)),
+      (rs, n, a) => A.value.unsafeSet(rs, n, a.map(G.to)),
+      (rs, n, a) => A.value.unsafeUpdate(rs, n, a.map(G.to))
+    )
+
+}

--- a/modules/core/src/main/scala/doobie/util/write.scala
+++ b/modules/core/src/main/scala/doobie/util/write.scala
@@ -8,115 +8,248 @@ import cats.ContravariantSemigroupal
 import doobie.enum.Nullability._
 import doobie.free.{ FPS, FRS, PreparedStatementIO, ResultSetIO }
 import java.sql.{ PreparedStatement, ResultSet }
+import scala.annotation.tailrec
 import shapeless.{ HList, HNil, ::, Generic, Lazy, <:!< }
 import shapeless.labelled.{ FieldType }
 
-final class Write[A](
-  val puts: List[(Put[_], NullabilityKnown)],
-  val toList: A => List[Any],
-  val unsafeSet: (PreparedStatement, Int, A) => Unit,
-  val unsafeUpdate: (ResultSet, Int, A) => Unit
-) {
+sealed trait Write[A] {
 
-  lazy val length = puts.length
+  import scala.collection.immutable.::
+  import Write._
 
-  def set(n: Int, a: A): PreparedStatementIO[Unit] =
+  // These are implemented as abstract methods for fastest possible traversal.
+  protected def fastUnsafeSet(ps: PreparedStatement, n: Int, a: A): Unit
+  protected def fastUnsafeUpdate(rs: ResultSet, n: Int, a: A): Unit
+
+  val puts: List[(Put[_], NullabilityKnown)]
+  val length: Int
+  protected val height: Int
+
+  final def set(n: Int, a: A): PreparedStatementIO[Unit] =
     FPS.raw(unsafeSet(_, n, a))
 
-  def update(n: Int, a: A): ResultSetIO[Unit] =
+  final def update(n: Int, a: A): ResultSetIO[Unit] =
     FRS.raw(unsafeUpdate(_, n, a))
 
-  def contramap[B](f: B => A): Write[B] =
-    new Write(
-      puts,
-      b => toList(f(b)),
-      (ps, n, a) => unsafeSet(ps, n, f(a)),
-      (rs, n, a) => unsafeUpdate(rs, n, f(a))
-    )
+  final def contramap[B](f: B => A): Write[B] =
+    Contramap(f, this)
 
-  def product[B](fb: Write[B]): Write[(A, B)] =
-    new Write(
-      puts ++ fb.puts,
-      { case (a, b) => toList(a) ++ fb.toList(b) },
-      { case (ps, n, (a, b)) => unsafeSet(ps, n, a); fb.unsafeSet(ps, n + length, b) },
-      { case (rs, n, (a, b)) => unsafeUpdate(rs, n, a); fb.unsafeUpdate(rs, n + length, b) }
-    )
+  final def product[B](fb: Write[B]): Write[(A, B)] =
+    Contramap2(Predef.identity[(A, B)], this, fb)
 
+  final def toList(a: A): List[Any] = {
+    type Item = (α, Write[α]) forSome { type α }
+
+    @tailrec
+    def worker(stack: List[Item], acc: List[Any]): List[Any] =
+      stack match {
+        case Nil => acc
+        case h :: rest => h match {
+          case (x, NonNullableColumn(_)) =>
+            worker(rest, x :: acc)
+          case (x, NullableColumn(_)) =>
+            worker(rest, x :: acc)
+          case (_, Trivial()) =>
+            worker(rest, acc)
+          case (x, Contramap(f, wy)) =>
+            worker((f(x), wy) :: rest, acc)
+          case (x, Contramap2(f, wy, wz)) =>
+            val (y, z) = f(x)
+            // Right to left to save a `.reverse`
+            worker((z, wz) :: (y, wy) :: rest, acc)
+        }
+      }
+
+    worker(List((a, this)), Nil)
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
+  final def unsafeSet(
+    ps: PreparedStatement,
+    n: Int,
+    a: A,
+    stackHeightLimit: Int = defaultStackHeightLimit
+  ): Unit = {
+    type Item = (α, Write[α]) forSome { type α }
+
+    @tailrec
+    def worker(stack: List[Item], k: Int): Unit =
+      stack match {
+        case Nil => ()
+        case h :: rest => h match {
+          case (x, wx) if wx.height < stackHeightLimit =>
+            wx.fastUnsafeSet(ps, k, x)
+            worker(rest, k + wx.length)
+          case (x, NonNullableColumn(put)) =>
+            put.unsafeSetNonNullable(ps, k, x)
+            worker(rest, k + 1)
+          case (x, NullableColumn(put)) =>
+            put.unsafeSetNullable(ps, k, x)
+            worker(rest, k + 1)
+          case (_, Trivial()) =>
+            worker(rest, k)
+          case (x, Contramap(f, wy)) =>
+            worker((f(x), wy) :: rest, k)
+          case (x, Contramap2(f, wy, wz)) =>
+            val (y, z) = f(x)
+            // Left to right
+            worker((y, wy) :: (z, wz) :: rest, k)
+        }
+      }
+
+    worker(List((a, this)), n)
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
+  final def unsafeUpdate(
+    rs: ResultSet,
+    n: Int,
+    a: A,
+    stackHeightLimit: Int = defaultStackHeightLimit
+  ): Unit = {
+    type Item = (α, Write[α]) forSome { type α }
+
+    @tailrec
+    def worker(stack: List[Item], k: Int): Unit =
+      stack match {
+        case Nil => ()
+        case h :: rest => h match {
+          case (x, wx) if wx.height < stackHeightLimit =>
+            wx.fastUnsafeUpdate(rs, k, x)
+          case (x, NonNullableColumn(put)) =>
+            put.unsafeUpdateNonNullable(rs, k, x)
+            worker(rest, k + 1)
+          case (x, NullableColumn(put)) =>
+            put.unsafeUpdateNullable(rs, k, x)
+            worker(rest, k + 1)
+          case (_, Trivial()) =>
+            worker(rest, k)
+          case (x, Contramap(f, wy)) =>
+            worker((f(x), wy) :: rest, k)
+          case (x, Contramap2(f, wy, wz)) =>
+            val (y, z) = f(x)
+            // Left to right
+            worker((y, wy) :: (z, wz) :: rest, k)
+        }
+      }
+
+    worker(List((a, this)), n)
+  }
 }
 
 object Write extends LowerPriorityWrite {
 
+  /**
+    * Subtrees with height below this limit will be processed in a stack-based
+    * fashion.
+    */
+  val defaultStackHeightLimit = 64
+
+  private final case class Trivial[A]() extends Write[A] {
+    def fastUnsafeSet(ps: PreparedStatement, n: Int, a: A): Unit = ()
+    def fastUnsafeUpdate(rs: ResultSet, n: Int, a: A): Unit = ()
+    val length = 0
+    val height = 1
+    val puts = Nil
+  }
+  private final case class NullableColumn[A](put: Put[A]) extends Write[Option[A]] {
+    def fastUnsafeSet(ps: PreparedStatement, n: Int, a: Option[A]): Unit =
+      put.unsafeSetNullable(ps, n, a)
+    def fastUnsafeUpdate(rs: ResultSet, n: Int, a: Option[A]): Unit =
+      put.unsafeUpdateNullable(rs, n, a)
+    val length = 1
+    val height = 1
+    val puts = List((put, Nullable))
+  }
+  private final case class NonNullableColumn[A](put: Put[A]) extends Write[A] {
+    def fastUnsafeSet(ps: PreparedStatement, n: Int, a: A): Unit =
+      put.unsafeSetNonNullable(ps, n, a)
+    def fastUnsafeUpdate(rs: ResultSet, n: Int, a: A): Unit =
+      put.unsafeUpdateNonNullable(rs, n, a)
+    val length = 1
+    val height = 1
+    val puts = List((put, NoNulls))
+  }
+  private final case class Contramap[A, B](
+    f: A => B,
+    wb: Write[B]
+  ) extends Write[A] {
+    def fastUnsafeSet(ps: PreparedStatement, n: Int, a: A): Unit =
+      wb.fastUnsafeSet(ps, n, f(a))
+    def fastUnsafeUpdate(rs: ResultSet, n: Int, a: A): Unit =
+      wb.fastUnsafeUpdate(rs, n, f(a))
+    val length = wb.length
+    val height = wb.height + 1
+    val puts = wb.puts
+  }
+  private final case class Contramap2[A, B, C](
+    f: C => (A, B),
+    wa: Write[A],
+    wb: Write[B]
+  ) extends Write[C] {
+    def fastUnsafeSet(ps: PreparedStatement, n: Int, c: C): Unit = {
+      val t = f(c)
+      wa.fastUnsafeSet(ps, n, t._1)
+      wb.fastUnsafeSet(ps, n + wa.length, t._2)
+    }
+    def fastUnsafeUpdate(rs: ResultSet, n: Int, c: C): Unit = {
+      val (a, b) = f(c)
+      wa.fastUnsafeUpdate(rs, n, a)
+      wb.fastUnsafeUpdate(rs, n + wa.length, b)
+    }
+    val length = wa.length + wb.length
+    val height = Math.max(wa.height, wb.height) + 1
+    val puts = wa.puts ++ wb.puts
+  }
+
   def apply[A](implicit A: Write[A]): Write[A] = A
 
-  implicit val ReadContravariantSemigroupal: ContravariantSemigroupal[Write] =
+  def contramap2[A, B, C](wa: Write[A], wb: Write[B])(f: C => (A, B)): Write[C] =
+    Contramap2(f, wa, wb)
+  def trivial[A]: Write[A] = Trivial()
+  def nullable[A](implicit put: Put[A]): Write[Option[A]] = NullableColumn(put)
+  def nonNullable[A](implicit put: Put[A]): Write[A] = NonNullableColumn(put)
+
+  implicit val WriteContravariantSemigroupal: ContravariantSemigroupal[Write] =
     new ContravariantSemigroupal[Write] {
       def contramap[A, B](fa: Write[A])(f: B => A) = fa.contramap(f)
       def product[A, B](fa: Write[A], fb: Write[B]) = fa.product(fb)
     }
 
-  implicit val unitComposite: Write[Unit] =
-    new Write(Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
+  implicit val unitWrite: Write[Unit] = trivial
 
-  implicit def fromPut[A](implicit P: Put[A]): Write[A] =
-    new Write(
-      List((P, NoNulls)),
-      a => List(a),
-      (ps, n, a) => P.unsafeSetNonNullable(ps, n, a),
-      (rs, n, a) => P.unsafeUpdateNonNullable(rs, n, a)
-    )
+  implicit def fromPut[A](implicit P: Put[A]): Write[A] = nonNullable(P)
 
-  implicit def fromPutOption[A](implicit P: Put[A]): Write[Option[A]] =
-    new Write(
-      List((P, Nullable)),
-      a => List(a),
-      (ps, n, a) => P.unsafeSetNullable(ps, n, a),
-      (rs, n, a) => P.unsafeUpdateNullable(rs, n, a)
-    )
+  implicit def fromPutOption[A](implicit P: Put[A]): Write[Option[A]] = nullable(P)
 
   implicit def recordWrite[K <: Symbol, H, T <: HList](
     implicit H: Lazy[Write[H]],
               T: Lazy[Write[T]]
-  ): Write[FieldType[K, H] :: T] = {
-    new Write(
-      H.value.puts ++ T.value.puts,
-      { case h :: t => H.value.toList(h) ++ T.value.toList(t) },
-      { case (ps, n, h :: t) => H.value.unsafeSet(ps, n, h); T.value.unsafeSet(ps, n + H.value.length, t) },
-      { case (rs, n, h :: t) => H.value.unsafeUpdate(rs, n, h); T.value.unsafeUpdate(rs, n + H.value.length, t) }
-    )
-  }
-
+  ): Write[FieldType[K, H] :: T] =
+    contramap2(H.value, T.value) { case h :: t => (h, t) }
 }
 
 trait LowerPriorityWrite extends EvenLowerPriorityWrite {
+
+  import Write._
 
   implicit def product[H, T <: HList](
     implicit H: Lazy[Write[H]],
               T: Lazy[Write[T]]
   ): Write[H :: T] =
-    new Write(
-      H.value.puts ++ T.value.puts,
-      { case h :: t => H.value.toList(h) ++ T.value.toList(t) },
-      { case (ps, n, h :: t) => H.value.unsafeSet(ps, n, h); T.value.unsafeSet(ps, n + H.value.length, t) },
-      { case (rs, n, h :: t) => H.value.unsafeUpdate(rs, n, h); T.value.unsafeUpdate(rs, n + H.value.length, t) }
-    )
+    contramap2(H.value, T.value) { case h :: t => (h, t) }
 
-  implicit def emptyProduct: Write[HNil] =
-    new Write[HNil](Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
+  implicit def emptyProduct: Write[HNil] = trivial
 
   implicit def generic[B, A](implicit gen: Generic.Aux[B, A], A: Lazy[Write[A]]): Write[B] =
-    new Write[B](
-      A.value.puts,
-      b => A.value.toList(gen.to(b)),
-      (ps, n, b) => A.value.unsafeSet(ps, n, gen.to(b)),
-      (rs, n, b) => A.value.unsafeUpdate(rs, n, gen.to(b))
-    )
-
+    A.value.contramap(gen.to)
 }
 
 trait EvenLowerPriorityWrite {
 
-  implicit val ohnil: Write[Option[HNil]] =
-    new Write[Option[HNil]](Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
+  import Write._
+
+  implicit val ohnil: Write[Option[HNil]] = trivial
 
   implicit def ohcons1[H, T <: HList](
     implicit H: Lazy[Write[Option[H]]],
@@ -125,44 +258,24 @@ trait EvenLowerPriorityWrite {
   ): Write[Option[H :: T]] = {
     void(N)
 
-    def split[A](i: Option[H :: T])(f: (Option[H], Option[T]) => A): A =
-      i.fold(f(None, None)) { case h :: t => f(Some(h), Some(t)) }
-
-    new Write(
-      H.value.puts ++ T.value.puts,
-      split(_) { (h, t) => H.value.toList(h) ++ T.value.toList(t) },
-      (ps, n, i) => split(i) { (h, t) => H.value.unsafeSet(ps, n, h); T.value.unsafeSet(ps, n + H.value.length, t) },
-      (rs, n, i) => split(i) { (h, t) => H.value.unsafeUpdate(rs, n, h); T.value.unsafeUpdate(rs, n + H.value.length, t) }
-    )
-
+    contramap2(H.value, T.value) {
+      case Some(h :: t) => (Some(h), Some(t))
+      case None => (None, None)
+    }
   }
 
   implicit def ohcons2[H, T <: HList](
     implicit H: Lazy[Write[Option[H]]],
              T: Lazy[Write[Option[T]]]
-  ): Write[Option[Option[H] :: T]] = {
-
-    def split[A](i: Option[Option[H] :: T])(f: (Option[H], Option[T]) => A): A =
-      i.fold(f(None, None)) { case oh :: t => f(oh, Some(t)) }
-
-    new Write(
-      H.value.puts ++ T.value.puts,
-      split(_) { (h, t) => H.value.toList(h) ++ T.value.toList(t) },
-      (ps, n, i) => split(i) { (h, t) => H.value.unsafeSet(ps, n, h); T.value.unsafeSet(ps, n + H.value.length, t) },
-      (rs, n, i) => split(i) { (h, t) => H.value.unsafeUpdate(rs, n, h); T.value.unsafeUpdate(rs, n + H.value.length, t) }
-    )
-
-  }
+  ): Write[Option[Option[H] :: T]] =
+    contramap2(H.value, T.value) {
+      case Some(oh :: t) => (oh, Some(t))
+      case None => (None, None)
+    }
 
   implicit def ogeneric[B, A <: HList](
     implicit G: Generic.Aux[B, A],
              A: Lazy[Write[Option[A]]]
   ): Write[Option[B]] =
-    new Write(
-      A.value.puts,
-      b => A.value.toList(b.map(G.to)),
-      (rs, n, a) => A.value.unsafeSet(rs, n, a.map(G.to)),
-      (rs, n, a) => A.value.unsafeUpdate(rs, n, a.map(G.to))
-    )
-
+    A.value.contramap(_.map(G.to))
 }

--- a/modules/core/src/test/scala/doobie/util/fragments.scala
+++ b/modules/core/src/test/scala/doobie/util/fragments.scala
@@ -5,12 +5,21 @@
 package doobie.util
 
 import cats.{ Reducible => Foldable1, _}, cats.implicits._
+import cats.data.NonEmptyList
+import cats.effect.IO
 import doobie._, doobie.implicits._
 import org.specs2.mutable.Specification
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 object fragmentsspec extends Specification {
   import Fragments._
+
+  val xa = Transactor.fromDriverManager[IO](
+    "org.h2.Driver",
+    "jdbc:h2:mem:fragmentspec;DB_CLOSE_DELAY=-1",
+    "sa",
+    ""
+  )
 
   "Fragments" >> {
 
@@ -20,6 +29,21 @@ object fragmentsspec extends Specification {
 
     "in" in {
       in(fr"foo", nel).query[Unit].sql must_== "foo IN (?, ?, ?) "
+    }
+
+    "in (stack safety)" in {
+      // #426
+      def query(ids: Option[NonEmptyList[Long]]): Query0[Long] = {
+        val q: Fragment = fr"""
+          SELECT id
+          FROM VALUES (123), (10001) AS table(id)
+        """ ++ Fragments.whereAndOpt(ids.map(Fragments.in(fr"id", _)))
+        q.query[Long]
+      }
+      val result = query(List.range(0L,10000L).toNel)
+        .to[Vector].transact(xa).unsafeRunSync
+
+      result must_== Vector(123L)
     }
 
     "notIn" in {


### PR DESCRIPTION
### Overview ###
This changes `Write` into an ADT, which we then traverse in a stack-safe fashion.

### Motivation ###
#426

### Implementation ###
Along the lines of #709, but without the dirty pattern-matching trick. `Write` itself was rewritten instead of using a separate type. The lazy `Suspend` constructor was removed - all the lazy values in the old `Write` implementation were immediately forced anyway, so there is no need to account for laziness.

Since the tail-recursive implementation replaces stack with a `List` accumulator, it is slower than the old implementation (2 times slower, according to my benchmark). That's why I kept the original stack-based traversal algorithm, using it for subtrees with height below a certain threshold. This avoids the performance penalty for most structures, while keeping stack safety. Since having this duplication adds more code, I've only used this approach for "hot" methods (`unsafeSet`, `unsafeUpdate`).

### Benchmarks ###
A benchmark for `unsafeSet` is provided with this merge request for comparison with the old implementation (which is also included for convenience). The results on my machine (for a medium-sized structure):
```
Benchmark          Mode  Cnt      Score     Error  Units
unsafeSet         thrpt  100  15493.144 ? 257.413  ops/s
unsafeSetNoStack  thrpt  100   8643.263 ?  53.938  ops/s
unsafeSetOld      thrpt  100  13155.877 ? 199.162  ops/s
```
There's a slight increase in performance in this case. I expect that for structures producing large, skewed trees (e.g. for a case class with 40+ members with the default stack depth limit) performance will start creeping down to that of the tail-recursive algorithm, but for other cases it should remain close to the original implementation.

### Possible drawbacks ###
`Write` can't use custom `unsafeSet`/`unsafeUpdate` implementations anymore, which may limit some exotic instances.