### PR TITLE
WIP/experiment: stacksafe fragment

### DIFF
--- a/modules/core/src/main/scala/doobie/aliases.scala
+++ b/modules/core/src/main/scala/doobie/aliases.scala
@@ -4,6 +4,8 @@
 
 package doobie
 
+import shapeless.HList
+
 /** Mixin containing aliases for the most commonly used types and modules from doobie-core. */
 trait Aliases extends Types with Modules
 
@@ -19,7 +21,7 @@ trait Types {
   /** @group Type Aliases - Core */ type Query0[A]                = doobie.util.query.Query0[A]
   /** @group Type Aliases - Core */ type Update0                  = doobie.util.update.Update0
   /** @group Type Aliases - Core */ type SqlState                 = doobie.enum.SqlState
-  /** @group Type Aliases - Core */ type Param[A]                 = doobie.util.param.Param[A]
+  /** @group Type Aliases - Core */ type Param[A <: HList]        = doobie.util.param.Param[A]
   /** @group Type Aliases - Core */ type Transactor[M[_]]         = doobie.util.transactor.Transactor[M]
   /** @group Type Aliases - Core */ type LogHandler               = doobie.util.log.LogHandler
   /** @group Type Aliases - Core */ type Fragment                 = doobie.util.fragment.Fragment

--- a/modules/core/src/main/scala/doobie/syntax/string.scala
+++ b/modules/core/src/main/scala/doobie/syntax/string.scala
@@ -7,7 +7,7 @@ package doobie.syntax
 import doobie.util.param.Param
 import doobie.util.pos.Pos
 import doobie.util.fragment.Fragment
-import shapeless.ProductArgs
+import shapeless.{ HList, ProductArgs }
 
 /**
  * String interpolator for SQL literals. An expression of the form `sql".. $a ... $b ..."` with
@@ -16,9 +16,9 @@ import shapeless.ProductArgs
  */
 final class SqlInterpolator(private val sc: StringContext)(implicit pos: Pos) {
 
-  private def mkFragment[A](a: A, token: Boolean)(implicit ev: Param[A]): Fragment = {
+  private def mkFragment[A <: HList](a: A, token: Boolean)(implicit ev: Param[A]): Fragment = {
     val sql = sc.parts.mkString("", "?", if (token) " " else "")
-    Fragment(sql, a, Some(pos))(ev.write)
+    Fragment(sql, ev.elems(a), Some(pos))
   }
 
   /**
@@ -28,7 +28,7 @@ final class SqlInterpolator(private val sc: StringContext)(implicit pos: Pos) {
    * think about intervening whitespace. If you do not want this behavior, use `fr0`.
    */
   object fr extends ProductArgs {
-    def applyProduct[A: Param](a: A): Fragment = mkFragment(a, true)
+    def applyProduct[A <: HList : Param](a: A): Fragment = mkFragment(a, true)
   }
 
   /** Alternative name for the `fr0` interpolator. */
@@ -39,7 +39,7 @@ final class SqlInterpolator(private val sc: StringContext)(implicit pos: Pos) {
    * attempt is made to be helpful with respect to whitespace.
    */
   object fr0 extends ProductArgs {
-    def applyProduct[A: Param](a: A): Fragment = mkFragment(a, false)
+    def applyProduct[A <: HList : Param](a: A): Fragment = mkFragment(a, false)
   }
 
 }

--- a/modules/core/src/main/scala/doobie/util/fragment.scala
+++ b/modules/core/src/main/scala/doobie/util/fragment.scala
@@ -9,10 +9,10 @@ import cats.implicits._
 
 import doobie._, doobie.implicits._
 import doobie.util.pos.Pos
-
+import doobie.util.param.Param.Elem
+import doobie.enum.Nullability._
+import java.sql.{ PreparedStatement, ResultSet }
 import scala.Predef.wrapString
-
-import shapeless.HNil
 
 /** Module defining the `Fragment` data type. */
 object fragment {
@@ -23,43 +23,59 @@ object fragment {
    * constructed a `Fragment` is opaque; it has no externally observable properties. Fragments are
    * eventually used to construct a [[Query0]] or [[Update0]].
    */
-  sealed trait Fragment { fa =>
+  final class Fragment(
+    protected val sql: String,
+    protected val elems: List[Elem],
+    protected val pos: Option[Pos]
+  ) {
 
-    protected type A                // type of interpolated argument (existential, HNil for none)
-    protected def a: A              // the interpolated argument itself
-    protected def ca: Write[A]  // proof that we can map the argument to parameters
-    protected def sql: String       // snipped of SQL with `ca.length` placeholders
+    // Unfortunately we need to produce a Write for our list of elems, which is a bit of a grunt
+    // but straightforward nonetheless. And it's stacksafe!
+    private implicit lazy val write: Write[elems.type] = {
+      import Elem._
+
+      val puts: List[(Put[_], NullabilityKnown)] =
+        elems.map {
+          case Arg(_, p) => (p, NoNulls)
+          case Opt(_, p) => (p, Nullable)
+        }
+
+      val toList: elems.type => List[Any] = elems =>
+        elems.map {
+          case Arg(a, _) => a
+          case Opt(a, _) => a
+        }
+
+      val unsafeSet: (PreparedStatement, Int, elems.type) => Unit = (ps, n, elems) =>
+        elems.zipWithIndex.foreach {
+          case (Arg(a, p), i) => p.unsafeSetNonNullable(ps, i + n, a)
+          case (Opt(a, p), i) => p.unsafeSetNullable(ps, i + n, a)
+        }
+
+      val unsafeUpdate: (ResultSet, Int, elems.type) => Unit = (ps, n, elems) =>
+        elems.zipWithIndex.foreach {
+          case (Arg(a, p), i) => p.unsafeUpdateNonNullable(ps, i + n, a)
+          case (Opt(a, p), i) => p.unsafeUpdateNullable(ps, i + n, a)
+        }
+
+      new Write(puts, toList, unsafeSet, unsafeUpdate)
+
+    }
 
     /**
      * Construct a program in ConnectionIO that constructs and prepares a PreparedStatement, with
      * further handling delegated to the provided program.
      */
     def execWith[B](fa: PreparedStatementIO[B]): ConnectionIO[B] =
-      HC.prepareStatement(sql)(ca.set(1, a) *> fa)
-
-    // Stack frame, used by the query checker to guess the source position. This will go away at
-    // some point, possibly in favor of Haoyi's source position doodad.
-    protected def pos: Option[Pos]
+      HC.prepareStatement(sql)(write.set(1, elems) *> fa)
 
     /** Concatenate this fragment with another, yielding a larger fragment. */
     def ++(fb: Fragment): Fragment =
-      new Fragment {
-        type A  = (fa.A, fb.A)
-        val ca  = fa.ca product fb.ca
-        val a   = (fa.a, fb.a)
-        val sql = fa.sql + fb.sql
-        val pos = fa.pos orElse fb.pos
-      }
+      new Fragment(sql + fb.sql, elems ++ fb.elems, pos orElse fb.pos)
 
     @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
     def stripMargin(marginChar: Char): Fragment =
-      new Fragment {
-        type A = fa.A
-        val a = fa.a
-        val sql = fa.sql.stripMargin(marginChar)
-        val pos = fa.pos
-        val ca = fa.ca
-      }
+      new Fragment(sql.stripMargin(marginChar), elems, pos)
 
     @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
     def stripMargin: Fragment = stripMargin('|')
@@ -74,7 +90,7 @@ object fragment {
      * `LogHandler`.
      */
     def queryWithLogHandler[B](h: LogHandler)(implicit cb: Read[B]): Query0[B] =
-      Query[A, B](sql, pos, h)(ca, cb).toQuery0(a)
+      Query[elems.type, B](sql, pos, h).toQuery0(elems)
 
     /** Construct an [[Update0]] from this fragment. */
     @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
@@ -83,36 +99,34 @@ object fragment {
 
     /** Construct an [[Update0]] from this fragment with the given `LogHandler`. */
     def updateWithLogHandler(h: LogHandler): Update0 =
-      Update[A](sql, pos, h)(ca).toUpdate0(a)
+      Update[elems.type](sql, pos, h).toUpdate0(elems)
 
     override def toString =
       s"""Fragment("$sql")"""
 
-    /** Used only for testing; this uses universal equality on the captured argument. */
+    /** Used only for testing; this pulls out the arguments as an untyped list. */
+    private def args: List[Any] =
+      elems.map {
+        case Elem.Arg(a, _) => a
+        case Elem.Opt(a, _) => a
+      }
+
+    /** Used only for testing; this uses universal equality on the captured arguments. */
     @SuppressWarnings(Array("org.wartremover.warts.Equals"))
     private[util] def unsafeEquals(fb: Fragment): Boolean =
-      fa.a == fb.a && fa.sql == fb.sql
+      sql == fb.sql && args == fb.args
 
   }
-
   object Fragment {
 
     /**
      * Construct a statement fragment with the given SQL string, which must contain sufficient `?`
-     * placeholders to accommodate the fields of the given interpolated value. This is normally
+     * placeholders to accommodate the given list of interpolated elements. This is normally
      * accomplished via the string interpolator rather than direct construction.
      */
     @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
-    def apply[A0](sql0: String, a0: A0, pos0: Option[Pos] = None)(
-      implicit ev: Write[A0]
-    ): Fragment =
-      new Fragment {
-        type A  = A0
-        val ca  = ev
-        val a   = a0
-        val sql = sql0
-        val pos = pos0
-      }
+    def apply(sql: String, elems: List[Elem], pos: Option[Pos] = None): Fragment =
+      new Fragment(sql, elems, pos)
 
     /**
      * Construct a statement fragment with no interpolated values and no trailing space; the
@@ -120,7 +134,7 @@ object fragment {
      */
     @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
     def const0(sql: String, pos: Option[Pos] = None): Fragment =
-      Fragment[HNil](sql, HNil, pos)
+      new Fragment(sql, Nil, pos)
 
     /**
      * Construct a statement fragment with no interpolated values and a trailing space; the

--- a/modules/core/src/main/scala/doobie/util/fragment.scala
+++ b/modules/core/src/main/scala/doobie/util/fragment.scala
@@ -11,6 +11,7 @@ import doobie._, doobie.implicits._
 import doobie.util.pos.Pos
 import doobie.util.param.Param.Elem
 import doobie.enum.Nullability._
+import fs2.Catenable
 import java.sql.{ PreparedStatement, ResultSet }
 import scala.Predef.wrapString
 
@@ -25,7 +26,7 @@ object fragment {
    */
   final class Fragment(
     protected val sql: String,
-    protected val elems: List[Elem],
+    protected val elems: Catenable[Elem],
     protected val pos: Option[Pos]
   ) {
 
@@ -38,25 +39,37 @@ object fragment {
         elems.map {
           case Arg(_, p) => (p, NoNulls)
           case Opt(_, p) => (p, Nullable)
-        }
+        } .toList
 
       val toList: elems.type => List[Any] = elems =>
         elems.map {
           case Arg(a, _) => a
           case Opt(a, _) => a
-        }
+        } .toList
 
-      val unsafeSet: (PreparedStatement, Int, elems.type) => Unit = (ps, n, elems) =>
-        elems.zipWithIndex.foreach {
-          case (Arg(a, p), i) => p.unsafeSetNonNullable(ps, i + n, a)
-          case (Opt(a, p), i) => p.unsafeSetNullable(ps, i + n, a)
+      @SuppressWarnings(Array("org.wartremover.warts.Var"))
+      val unsafeSet: (PreparedStatement, Int, elems.type) => Unit = { (ps, n, elems) =>
+        var index = n
+        elems.foreach { e =>
+          e match {
+            case Arg(a, p) => p.unsafeSetNonNullable(ps, index, a)
+            case Opt(a, p) => p.unsafeSetNullable(ps, index, a)
+          }
+          index += 1
         }
+      }
 
-      val unsafeUpdate: (ResultSet, Int, elems.type) => Unit = (ps, n, elems) =>
-        elems.zipWithIndex.foreach {
-          case (Arg(a, p), i) => p.unsafeUpdateNonNullable(ps, i + n, a)
-          case (Opt(a, p), i) => p.unsafeUpdateNullable(ps, i + n, a)
+      @SuppressWarnings(Array("org.wartremover.warts.Var"))
+      val unsafeUpdate: (ResultSet, Int, elems.type) => Unit = { (ps, n, elems) =>
+        var index = n
+        elems.foreach { e =>
+          e match {
+            case Arg(a, p) => p.unsafeUpdateNonNullable(ps, index, a)
+            case Opt(a, p) => p.unsafeUpdateNullable(ps, index, a)
+          }
+          index += 1
         }
+      }
 
       new Write(puts, toList, unsafeSet, unsafeUpdate)
 
@@ -106,7 +119,7 @@ object fragment {
 
     /** Used only for testing; this pulls out the arguments as an untyped list. */
     private def args: List[Any] =
-      elems.map {
+      elems.toList.map {
         case Elem.Arg(a, _) => a
         case Elem.Opt(a, _) => a
       }
@@ -126,7 +139,7 @@ object fragment {
      */
     @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
     def apply(sql: String, elems: List[Elem], pos: Option[Pos] = None): Fragment =
-      new Fragment(sql, elems, pos)
+      new Fragment(sql, Catenable.fromSeq(elems), pos)
 
     /**
      * Construct a statement fragment with no interpolated values and no trailing space; the
@@ -134,7 +147,7 @@ object fragment {
      */
     @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
     def const0(sql: String, pos: Option[Pos] = None): Fragment =
-      new Fragment(sql, Nil, pos)
+      new Fragment(sql, Catenable.empty, pos)
 
     /**
      * Construct a statement fragment with no interpolated values and a trailing space; the

--- a/modules/core/src/main/scala/doobie/util/fragments.scala
+++ b/modules/core/src/main/scala/doobie/util/fragments.scala
@@ -13,11 +13,11 @@ import cats.implicits._
 object fragments {
 
   /** Returns `f IN (fs0, fs1, ...)`. */
-  def in[F[_]: Reducible, A: Param](f: Fragment, fs: F[A]): Fragment =
+  def in[F[_]: Reducible, A: Put](f: Fragment, fs: F[A]): Fragment =
     fs.toList.map(a => fr0"$a").foldSmash1(f ++ fr0"IN (", fr",", fr")")
 
   /** Returns `f NOT IN (fs0, fs1, ...)`. */
-  def notIn[F[_]: Reducible, A: Param](f: Fragment, fs: F[A]): Fragment =
+  def notIn[F[_]: Reducible, A: Put](f: Fragment, fs: F[A]): Fragment =
     fs.toList.map(a => fr0"$a").foldSmash1(f ++ fr0"NOT IN (", fr",", fr")")
 
   /** Returns `f1 AND f2 AND ... fn`. */

--- a/modules/core/src/main/scala/doobie/util/param.scala
+++ b/modules/core/src/main/scala/doobie/util/param.scala
@@ -12,9 +12,7 @@ import shapeless.{ HNil, HList, :: }
 object param {
 
   /**
-   * Typeclass for a flat vector of `Put`s, analogous to `Write` but with no nesting or
-   * generalization to product types. Each element expands to some nonzero number of `?`
-   * placeholders in the SQL literal, and the param vector itself has a `Write` instance.
+   * Witness that the elements of an HList each have an applicable Put instance.
    */
   @implicitNotFound("""
 Cannot construct a parameter vector of the following type:
@@ -29,31 +27,43 @@ instance in scope. Try them one by one in the REPL or in your code:
 and find the one that has no instance, then construct one as needed. Refer to
 Chapter 12 of the book of doobie for more information.
 """)
-  final class Param[A](val write: Write[A])
+  sealed trait Param[A <: HList] {
+    def elems(a: A): List[Param.Elem]
+  }
 
-  /**
-   * Derivations for `Param`, which disallow embedding. Each interpolated query argument corresponds
-   * with a type with a `Put` instance, or an `Option` thereof.
-   */
   object Param {
 
-    def apply[A](implicit ev: Param[A]): Param[A] = ev
+    sealed trait Elem
+    object Elem {
+      final case class Arg[A](a: A, p: Put[A]) extends Elem
+      final case class Opt[A](a: Option[A], p: Put[A]) extends Elem
+    }
 
-    /** Each `Put[A]` gives rise to a `Param[A]`. */
-    implicit def fromPut[A: Put]: Param[A] =
-      new Param[A](Write.fromPut[A])
-
-    /** Each `Put[A]` gives rise to a `Param[Option[A]]`. */
-    implicit def fromPutOption[A: Put]: Param[Option[A]] =
-      new Param[Option[A]](Write.fromPutOption[A])
+    def apply[L <: HList](implicit ev: Param[L]): Param[L] = ev
 
     /** There is an empty `Param` for `HNil`. */
-    implicit val ParamHNil: Param[HNil] =
-      new Param[HNil](Write.emptyProduct)
+    implicit val hnil: Param[HNil] =
+      new Param[HNil] {
+        def elems(a: HNil) = Nil
+      }
 
-    /** Inductively we can cons a new `Param` onto the head of a `Param` of an `HList`. */
-    implicit def ParamHList[H, T <: HList](implicit ph: Param[H], pt: Param[T]): Param[H :: T] =
-      new Param[H :: T](Write.product[H,T](ph.write, pt.write))
+    implicit def hcons[H, T <: HList](
+      implicit pa: Put[H],
+               pt: Param[T]
+    ): Param[H :: T] =
+      new Param[H :: T] {
+        def elems(a: H :: T) =
+          Elem.Arg(a.head, pa) :: pt.elems(a.tail)
+      }
+
+    implicit def hconsOpt[H, T <: HList](
+      implicit pa: Put[H],
+               pt: Param[T]
+    ): Param[Option[H] :: T] =
+      new Param[Option[H] :: T] {
+        def elems(a: Option[H] :: T) =
+          Elem.Opt(a.head, pa) :: pt.elems(a.tail)
+      }
 
   }
 

--- a/modules/core/src/main/scala/doobie/util/query.scala
+++ b/modules/core/src/main/scala/doobie/util/query.scala
@@ -79,9 +79,9 @@ object query {
      */
     def pos: Option[Pos]
 
-    /** Turn this `Query` into a `Fragment`, given an argument. */
-    def toFragment(a: A): Fragment =
-      Fragment(sql, a, pos)
+    // /** Turn this `Query` into a `Fragment`, given an argument. */
+    // def toFragment(a: A): Fragment =
+    //   Fragment(sql, ai(a), pos)
 
     /**
      * Program to construct an analysis of this query's SQL statement and asserted parameter and
@@ -189,7 +189,7 @@ object query {
       new Query0[B] {
         def sql = outer.sql
         def pos = outer.pos
-        def toFragment = outer.toFragment(a)
+        // def toFragment = outer.toFragment(a)
         def analysis = outer.analysis
         def outputAnalysis = outer.outputAnalysis
         def streamWithChunkSize(n: Int) = outer.streamWithChunkSize(a, n)
@@ -264,8 +264,8 @@ object query {
      */
     def pos: Option[Pos]
 
-    /** Turn this `Query0` into a `Fragment`. */
-    def toFragment: Fragment
+    // /** Turn this `Query0` into a `Fragment`. */
+    // def toFragment: Fragment
 
     /**
      * Program to construct an analysis of this query's SQL statement and asserted parameter and

--- a/modules/core/src/main/scala/doobie/util/update.scala
+++ b/modules/core/src/main/scala/doobie/util/update.scala
@@ -79,9 +79,9 @@ object update {
      */
     val pos: Option[Pos]
 
-    /** Turn this `Update` into a `Fragment`, given an argument. */
-    def toFragment(a: A): Fragment =
-      Fragment(sql, a, pos)
+    // /** Turn this `Update` into a `Fragment`, given an argument. */
+    // def toFragment(a: A): Fragment =
+    //   Fragment(sql, ai(a), pos)
 
     /**
      * Program to construct an analysis of this query's SQL statement and asserted parameter types.
@@ -166,7 +166,7 @@ object update {
       new Update0 {
         val sql = u.sql
         val pos = u.pos
-        def toFragment = u.toFragment(a)
+        // def toFragment = u.toFragment(a)
         def analysis = u.analysis
         def run = u.run(a)
         def withGeneratedKeysWithChunkSize[K: Read](columns: String*)(chunkSize: Int) =
@@ -222,8 +222,8 @@ object update {
      */
     val pos: Option[Pos]
 
-    /** Turn this `Update`0 into a `Fragment`. */
-    def toFragment: Fragment
+    // /** Turn this `Update`0 into a `Fragment`. */
+    // def toFragment: Fragment
 
     /**
      * Program to construct an analysis of this query's SQL statement and asserted parameter types.

--- a/modules/core/src/test/scala/doobie/util/fragment.scala
+++ b/modules/core/src/test/scala/doobie/util/fragment.scala
@@ -58,15 +58,15 @@ object fragmentspec extends Specification {
       s.query[(Int, String, Boolean)].unique.transact(xa).unsafeRunSync must_== ((a, b, c))
     }
 
-    "translate to and from Query0" in {
-      val f = fr"bar $a $b $c baz"
-      f.query[HNil].toFragment unsafeEquals f
-    }
+    // "translate to and from Query0" in {
+    //   val f = fr"bar $a $b $c baz"
+    //   f.query[HNil].toFragment unsafeEquals f
+    // }
 
-    "translate to and from Update0" in {
-      val f = fr"bar $a $b $c baz"
-      f.update.toFragment unsafeEquals f
-    }
+    // "translate to and from Update0" in {
+    //   val f = fr"bar $a $b $c baz"
+    //   f.update.toFragment unsafeEquals f
+    // }
 
     "Add a trailing space when constructed with .const" in {
       Fragment.const("foo").query[Int].sql must_== "foo "

--- a/modules/core/src/test/scala/doobie/util/param.scala
+++ b/modules/core/src/test/scala/doobie/util/param.scala
@@ -21,16 +21,15 @@ object paramspec extends Specification {
       true
     }
 
-    "exist for any Put" in {
-      def foo[A: Put] = Param[A]
-      true
-    }
+    // "exist for any Put" in {
+    //   def foo[A: Put] = Param[A]
+    //   true
+    // }
 
-    "exist for any Option of Put" in {
-      def foo[A: Put] = Param[Option[A]]
-      true
-    }
-
+    // "exist for any Option of Put" in {
+    //   def foo[A: Put] = Param[Option[A]]
+    //   true
+    // }
 
     "exist for any HList with Put for head" in {
       def foo[A: Put, B <: HList : Param] = Param[A :: B]

--- a/modules/h2/src/test/scala/doobie/h2/h2types.scala
+++ b/modules/h2/src/test/scala/doobie/h2/h2types.scala
@@ -20,11 +20,18 @@ object h2typesspec extends Specification {
     "sa", ""
   )
 
-  def inOut[A: Param: Read](col: String, a: A) =
+  def inOut[A: Put: Get](col: String, a: A): ConnectionIO[A] =
     for {
       _  <- Update0(s"CREATE LOCAL TEMPORARY TABLE TEST (value $col)", None).run
       _  <- sql"INSERT INTO TEST VALUES ($a)".update.run
       a0 <- sql"SELECT value FROM TEST".query[A].unique
+    } yield (a0)
+
+  def inOutOpt[A: Put: Get](col: String, a: Option[A]): ConnectionIO[Option[A]] =
+    for {
+      _  <- Update0(s"CREATE LOCAL TEMPORARY TABLE TEST (value $col)", None).run
+      _  <- sql"INSERT INTO TEST VALUES ($a)".update.run
+      a0 <- sql"SELECT value FROM TEST".query[Option[A]].unique
     } yield (a0)
 
   def testInOut[A](col: String, a: A)(implicit m: Get[A], p: Put[A]) =
@@ -33,10 +40,10 @@ object h2typesspec extends Specification {
         inOut(col, a).transact(xa).attempt.unsafeRunSync must_== Right(a)
       }
       s"write+read $col as Option[${m.typeStack}] (Some)" in {
-        inOut[Option[A]](col, Some(a)).transact(xa).attempt.unsafeRunSync must_== Right(Some(a))
+        inOutOpt[A](col, Some(a)).transact(xa).attempt.unsafeRunSync must_== Right(Some(a))
       }
       s"write+read $col as Option[${m.typeStack}] (None)" in {
-        inOut[Option[A]](col, None).transact(xa).attempt.unsafeRunSync must_== Right(None)
+        inOutOpt[A](col, None).transact(xa).attempt.unsafeRunSync must_== Right(None)
       }
     }
 


### PR DESCRIPTION
@nigredo-tori this is another approach that doesn't change `Write`, it just changes the encoding of `Fragment` to use a `List[(A, Put[A])]` which stays flat on concatenation. Yours may end up looking better but I thought I would see what this approach looked like.