### PR TITLE
misc. simplifications

### DIFF
--- a/modules/core/src/main/scala/doobie/syntax/foldable.scala
+++ b/modules/core/src/main/scala/doobie/syntax/foldable.scala
@@ -8,7 +8,6 @@ import cats._
 import doobie.util.{ foldable => F }
 
 class FoldableOps[F[_]: Foldable, A: Monoid](self: F[A]) {
-  def foldSmash(prefix: A, delim: A, suffix: A): A = F.foldSmash(self)(prefix, delim, suffix)
   def foldSmash1(prefix: A, delim: A, suffix: A): A = F.foldSmash1(self)(prefix, delim, suffix)
 }
 

--- a/modules/core/src/main/scala/doobie/util/foldable.scala
+++ b/modules/core/src/main/scala/doobie/util/foldable.scala
@@ -9,12 +9,8 @@ import cats._, cats.implicits._
 /** Module of additional functions for `Foldable`. */
 object foldable {
 
-  /** Generalization of `mkString` for any monoid. */
-  def foldSmash[F[_]: Foldable, A](fa: F[A])(prefix: A, delim: A, suffix: A)(implicit ev: Monoid[A]): A =
-    ev.combine(prefix, ev.combine(fa.intercalate(delim), suffix))
-
   /** Like `foldSmash` but returns monoidal zero if the foldable is empty. */
   def foldSmash1[F[_]: Foldable, A](fa: F[A])(prefix: A, delim: A, suffix: A)(implicit A: Monoid[A]): A =
-    if (fa.isEmpty) A.empty else foldSmash(fa)(prefix, delim, suffix)
+    if (fa.isEmpty) A.empty else fa.foldSmash(prefix, delim, suffix)
 
 }

--- a/modules/core/src/main/scala/doobie/util/package.scala
+++ b/modules/core/src/main/scala/doobie/util/package.scala
@@ -4,22 +4,10 @@
 
 package doobie
 
-import cats._, cats.data._, cats.implicits._
-
-/**
- * Collection of modules for typeclasses and other helpful bits.
- */
+/** Collection of modules for typeclasses and other helpful bits. */
 package object util {
 
-  private[util] implicit class MoreFoldableOps[F[_], A: Eq](fa: F[A])(implicit f: Foldable[F]) {
-    def element(a: A): Boolean =
-      f.exists(fa)(_ === a)
-  }
-
-  private[util] implicit class NelOps[A](as: NonEmptyList[A]) {
-    def list: List[A] = as.head :: as.tail
-  }
-
-  private[util] def void(a: Any*): Unit = (a, ())._2
+  private[util] def void(a: Any*): Unit =
+    (a, ())._2
 
 }

--- a/modules/core/src/main/scala/doobie/util/yolo.scala
+++ b/modules/core/src/main/scala/doobie/util/yolo.scala
@@ -30,7 +30,12 @@ object yolo {
 
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def quick: M[Unit] =
-        q.sink(a => out(a.toString)).transact(xa)
+        q.stream
+         .map(_.toString)
+         .evalMap(out)
+         .compile
+         .drain
+         .transact(xa)
 
       def check: M[Unit] =
         doCheck(q.analysis)


### PR DESCRIPTION
This removes some code that has become unnecessary.
- Removed `Foldable.foldSmash` as it's now provided by Cats.
- Removed `Foldable.element` as it's now provide by Cats as `contains_`.
- Removed `NonEmptyList.list` in favor of `toList`.
- Simplified `Query` and `Update1:
  - Removed explicit `MonadError` missing syntax workaround that's no longer needed.
  - Removed built-in coyoneda stuff which is no longer necessary due to `Read` and `Write` being independent now.
  - Deprecated `Query0.sink` (should have been done earlier, oops) and removed usage in `Yolo`.
  - Removed methods deprecated in 0.5.x

