### PR TITLE
simplify logging code

### DIFF
--- a/modules/core/src/main/scala/doobie/util/package.scala
+++ b/modules/core/src/main/scala/doobie/util/package.scala
@@ -4,10 +4,20 @@
 
 package doobie
 
+import cats.ApplicativeError
+import cats.implicits._
+
 /** Collection of modules for typeclasses and other helpful bits. */
 package object util {
 
   private[util] def void(a: Any*): Unit =
     (a, ())._2
+
+  implicit class MoreEitherOps[L, R](e: Either[L, R]) {
+    def liftOnError[F[_]](handler: L => F[Unit])(
+      implicit ev: ApplicativeError[F, L]
+    ): F[R] =
+      e.fold(l => handler(l) *> ev.raiseError[R](l), _.pure[F])
+  }
 
 }


### PR DESCRIPTION
This factors out `liftOnError` which is kind of like `pure.rethrow` but lets you observe the error. Kind of contrived but it removes some boilerplate.