### PR TITLE
fs2 1.0.0-M1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,19 +7,19 @@ resolvers in Global += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/con
 // Library versions all in one place, for convenience and sanity.
 lazy val catsVersion          = "1.1.0"
 lazy val circeVersion         = "0.9.3"
-lazy val fs2CoreVersion       = "0.10.5"
+lazy val fs2CoreVersion       = "1.0.0-M1"
 lazy val h2Version            = "1.4.197"
 lazy val hikariVersion        = "3.2.0"
 lazy val kindProjectorVersion = "0.9.7"
 lazy val monixVersion         = "3.0.0-M3"
 lazy val postGisVersion       = "2.2.1"
 lazy val postgresVersion      = "42.2.2"
-lazy val refinedVersion       = "0.9.0"
+lazy val refinedVersion       = "0.9.1"
 lazy val scalaCheckVersion    = "1.14.0"
 lazy val scalatestVersion     = "3.0.5"
 lazy val shapelessVersion     = "2.3.3"
 lazy val sourcecodeVersion    = "0.1.4"
-lazy val specs2Version        = "4.2.0"
+lazy val specs2Version        = "4.3.0"
 lazy val scala211Version      = "2.11.12"
 lazy val scala212Version      = "2.12.6"
 
@@ -44,11 +44,11 @@ lazy val doobieWarts =
 // This is used in a couple places. Might be nice to separate these things out.
 lazy val postgisDep = "net.postgis" % "postgis-jdbc" % postGisVersion
 
-// check for library updates whenever the project is [re]load
-onLoad in Global := { s =>
-  if (sys.props.contains("doobie.skipDependencyUpdates")) s
-  else "dependencyUpdates" :: s
-}
+// // check for library updates whenever the project is [re]load
+// onLoad in Global := { s =>
+//   if (sys.props.contains("doobie.skipDependencyUpdates")) s
+//   else "dependencyUpdates" :: s
+// }
 
 lazy val compilerFlags = Seq(
   scalacOptions ++= (

--- a/modules/core/src/main/scala/doobie/hi/connection.scala
+++ b/modules/core/src/main/scala/doobie/hi/connection.scala
@@ -52,10 +52,10 @@ object connection {
       repeatEvalChunks(FC.embed(rs, resultset.getNextChunk[A](chunkSize)))
 
     val preparedStatement: Stream[ConnectionIO, PreparedStatement] =
-      bracket(create)(prepared, FC.embed(_, FPS.close))
+      bracket(create)(FC.embed(_, FPS.close)).flatMap(prepared)
 
     def results(ps: PreparedStatement): Stream[ConnectionIO, A] =
-      bracket(FC.embed(ps, exec))(unrolled, FC.embed(_, FRS.close))
+      bracket(FC.embed(ps, exec))(FC.embed(_, FRS.close)).flatMap(unrolled)
 
     preparedStatement.flatMap(results)
 

--- a/modules/core/src/main/scala/doobie/hi/preparedstatement.scala
+++ b/modules/core/src/main/scala/doobie/hi/preparedstatement.scala
@@ -47,7 +47,7 @@ object preparedstatement {
 
   /** @group Execution */
   def stream[A: Read](chunkSize: Int): Stream[PreparedStatementIO, A] =
-    bracket(FPS.executeQuery)(unrolled[A](_, chunkSize), FPS.embed(_, FRS.close))
+    bracket(FPS.executeQuery)(FPS.embed(_, FRS.close)).flatMap(unrolled[A](_, chunkSize))
 
   /**
    * Non-strict unit for capturing effects.
@@ -96,7 +96,7 @@ object preparedstatement {
 
  /** @group Execution */
   def executeUpdateWithGeneratedKeys[A: Read](chunkSize: Int): Stream[PreparedStatementIO, A] =
-    bracket(FPS.executeUpdate *> FPS.getGeneratedKeys)(unrolled[A](_, chunkSize), FPS.embed(_, FRS.close))
+    bracket(FPS.executeUpdate *> FPS.getGeneratedKeys)(FPS.embed(_, FRS.close)).flatMap(unrolled[A](_, chunkSize))
   /**
    * Compute the column `JdbcMeta` list for this `PreparedStatement`.
    * @group Metadata

--- a/modules/example/src/main/scala/example/GenericStream.scala
+++ b/modules/example/src/main/scala/example/GenericStream.scala
@@ -59,10 +59,10 @@ object GenericStream {
       repeatEvalChunks(FC.embed(rs, getNextChunkGeneric(chunkSize)))
 
     val preparedStatement: Stream[ConnectionIO, PreparedStatement] =
-      bracket(create)(prepared, FC.embed(_, FPS.close))
+      bracket(create)(FC.embed(_, FPS.close)).flatMap(prepared)
 
     def results(ps: PreparedStatement): Stream[ConnectionIO, Row] =
-      bracket(FC.embed(ps, exec))(unrolled, FC.embed(_, FRS.close))
+      bracket(FC.embed(ps, exec))(FC.embed(_, FRS.close)).flatMap(unrolled)
 
     preparedStatement.flatMap(results)
 

--- a/modules/example/src/main/scala/example/StreamingCopy.scala
+++ b/modules/example/src/main/scala/example/StreamingCopy.scala
@@ -66,7 +66,7 @@ object StreamingCopy {
       interpS(sinkXA.strategy.always)
 
     // And we're done!
-    Stream.bracket(open)(mkStream, cleanup)
+    Stream.bracket(open)(cleanup).flatMap(mkStream)
 
   }
 

--- a/modules/free/src/main/scala/doobie/free/clob.scala
+++ b/modules/free/src/main/scala/doobie/free/clob.scala
@@ -5,7 +5,7 @@
 package doobie.free
 
 import cats.~>
-import cats.effect.Async
+import cats.effect.{ Async, ExitCase }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
 
 import java.io.InputStream
@@ -46,6 +46,8 @@ object clob { module =>
       def delay[A](a: () => A): F[A]
       def handleErrorWith[A](fa: ClobIO[A], f: Throwable => ClobIO[A]): F[A]
       def async[A](k: (Either[Throwable, A] => Unit) => Unit): F[A]
+      def asyncF[A](k: (Either[Throwable, A] => Unit) => ClobIO[Unit]): F[A]
+      def bracketCase[A, B](acquire: ClobIO[A])(use: A => ClobIO[B])(release: (A, ExitCase[Throwable]) => ClobIO[Unit]): F[B]
 
       // Clob
       def free: F[Unit]
@@ -79,6 +81,12 @@ object clob { module =>
     }
     final case class Async1[A](k: (Either[Throwable, A] => Unit) => Unit) extends ClobOp[A] {
       def visit[F[_]](v: Visitor[F]) = v.async(k)
+    }
+    final case class AsyncF[A](k: (Either[Throwable, A] => Unit) => ClobIO[Unit]) extends ClobOp[A] {
+      def visit[F[_]](v: Visitor[F]) = v.asyncF(k)
+    }
+    final case class BracketCase[A, B](acquire: ClobIO[A], use: A => ClobIO[B], release: (A, ExitCase[Throwable]) => ClobIO[Unit]) extends ClobOp[B] {
+      def visit[F[_]](v: Visitor[F]) = v.bracketCase(acquire)(use)(release)
     }
 
     // Clob-specific operations.
@@ -134,6 +142,8 @@ object clob { module =>
   def handleErrorWith[A](fa: ClobIO[A], f: Throwable => ClobIO[A]): ClobIO[A] = FF.liftF[ClobOp, A](HandleErrorWith(fa, f))
   def raiseError[A](err: Throwable): ClobIO[A] = delay(throw err)
   def async[A](k: (Either[Throwable, A] => Unit) => Unit): ClobIO[A] = FF.liftF[ClobOp, A](Async1(k))
+  def asyncF[A](k: (Either[Throwable, A] => Unit) => ClobIO[Unit]): ClobIO[A] = FF.liftF[ClobOp, A](AsyncF(k))
+  def bracketCase[A, B](acquire: ClobIO[A])(use: A => ClobIO[B])(release: (A, ExitCase[Throwable]) => ClobIO[Unit]): ClobIO[B] = FF.liftF[ClobOp, B](BracketCase(acquire, use, release))
 
   // Smart constructors for Clob-specific operations.
   val free: ClobIO[Unit] = FF.liftF(Free)
@@ -154,10 +164,12 @@ object clob { module =>
   implicit val AsyncClobIO: Async[ClobIO] =
     new Async[ClobIO] {
       val M = FF.catsFreeMonadForFree[ClobOp]
+      def bracketCase[A, B](acquire: ClobIO[A])(use: A => ClobIO[B])(release: (A, ExitCase[Throwable]) => ClobIO[Unit]): ClobIO[B] = module.bracketCase(acquire)(use)(release)
       def pure[A](x: A): ClobIO[A] = M.pure(x)
       def handleErrorWith[A](fa: ClobIO[A])(f: Throwable => ClobIO[A]): ClobIO[A] = module.handleErrorWith(fa, f)
       def raiseError[A](e: Throwable): ClobIO[A] = module.raiseError(e)
       def async[A](k: (Either[Throwable,A] => Unit) => Unit): ClobIO[A] = module.async(k)
+      def asyncF[A](k: (Either[Throwable,A] => Unit) => ClobIO[Unit]): ClobIO[A] = module.asyncF(k)
       def flatMap[A, B](fa: ClobIO[A])(f: A => ClobIO[B]): ClobIO[B] = M.flatMap(fa)(f)
       def tailRecM[A, B](a: A)(f: A => ClobIO[Either[A, B]]): ClobIO[B] = M.tailRecM(a)(f)
       def suspend[A](thunk: => ClobIO[A]): ClobIO[A] = M.flatten(module.delay(thunk))

--- a/modules/free/src/main/scala/doobie/free/driver.scala
+++ b/modules/free/src/main/scala/doobie/free/driver.scala
@@ -5,7 +5,7 @@
 package doobie.free
 
 import cats.~>
-import cats.effect.Async
+import cats.effect.{ Async, ExitCase }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
 
 import java.lang.String
@@ -46,6 +46,8 @@ object driver { module =>
       def delay[A](a: () => A): F[A]
       def handleErrorWith[A](fa: DriverIO[A], f: Throwable => DriverIO[A]): F[A]
       def async[A](k: (Either[Throwable, A] => Unit) => Unit): F[A]
+      def asyncF[A](k: (Either[Throwable, A] => Unit) => DriverIO[Unit]): F[A]
+      def bracketCase[A, B](acquire: DriverIO[A])(use: A => DriverIO[B])(release: (A, ExitCase[Throwable]) => DriverIO[Unit]): F[B]
 
       // Driver
       def acceptsURL(a: String): F[Boolean]
@@ -73,6 +75,12 @@ object driver { module =>
     }
     final case class Async1[A](k: (Either[Throwable, A] => Unit) => Unit) extends DriverOp[A] {
       def visit[F[_]](v: Visitor[F]) = v.async(k)
+    }
+    final case class AsyncF[A](k: (Either[Throwable, A] => Unit) => DriverIO[Unit]) extends DriverOp[A] {
+      def visit[F[_]](v: Visitor[F]) = v.asyncF(k)
+    }
+    final case class BracketCase[A, B](acquire: DriverIO[A], use: A => DriverIO[B], release: (A, ExitCase[Throwable]) => DriverIO[Unit]) extends DriverOp[B] {
+      def visit[F[_]](v: Visitor[F]) = v.bracketCase(acquire)(use)(release)
     }
 
     // Driver-specific operations.
@@ -110,6 +118,8 @@ object driver { module =>
   def handleErrorWith[A](fa: DriverIO[A], f: Throwable => DriverIO[A]): DriverIO[A] = FF.liftF[DriverOp, A](HandleErrorWith(fa, f))
   def raiseError[A](err: Throwable): DriverIO[A] = delay(throw err)
   def async[A](k: (Either[Throwable, A] => Unit) => Unit): DriverIO[A] = FF.liftF[DriverOp, A](Async1(k))
+  def asyncF[A](k: (Either[Throwable, A] => Unit) => DriverIO[Unit]): DriverIO[A] = FF.liftF[DriverOp, A](AsyncF(k))
+  def bracketCase[A, B](acquire: DriverIO[A])(use: A => DriverIO[B])(release: (A, ExitCase[Throwable]) => DriverIO[Unit]): DriverIO[B] = FF.liftF[DriverOp, B](BracketCase(acquire, use, release))
 
   // Smart constructors for Driver-specific operations.
   def acceptsURL(a: String): DriverIO[Boolean] = FF.liftF(AcceptsURL(a))
@@ -124,10 +134,12 @@ object driver { module =>
   implicit val AsyncDriverIO: Async[DriverIO] =
     new Async[DriverIO] {
       val M = FF.catsFreeMonadForFree[DriverOp]
+      def bracketCase[A, B](acquire: DriverIO[A])(use: A => DriverIO[B])(release: (A, ExitCase[Throwable]) => DriverIO[Unit]): DriverIO[B] = module.bracketCase(acquire)(use)(release)
       def pure[A](x: A): DriverIO[A] = M.pure(x)
       def handleErrorWith[A](fa: DriverIO[A])(f: Throwable => DriverIO[A]): DriverIO[A] = module.handleErrorWith(fa, f)
       def raiseError[A](e: Throwable): DriverIO[A] = module.raiseError(e)
       def async[A](k: (Either[Throwable,A] => Unit) => Unit): DriverIO[A] = module.async(k)
+      def asyncF[A](k: (Either[Throwable,A] => Unit) => DriverIO[Unit]): DriverIO[A] = module.asyncF(k)
       def flatMap[A, B](fa: DriverIO[A])(f: A => DriverIO[B]): DriverIO[B] = M.flatMap(fa)(f)
       def tailRecM[A, B](a: A)(f: A => DriverIO[Either[A, B]]): DriverIO[B] = M.tailRecM(a)(f)
       def suspend[A](thunk: => DriverIO[A]): DriverIO[A] = M.flatten(module.delay(thunk))

--- a/modules/h2/src/main/scala/doobie/h2/H2Transactor.scala
+++ b/modules/h2/src/main/scala/doobie/h2/H2Transactor.scala
@@ -22,6 +22,6 @@ object H2Transactor {
 
   /** Constructs a stream that emits a single `HikariTransactor` with guaranteed cleanup. */
   def stream[M[_]: Async](url: String, user: String, pass: String) : Stream[M, H2Transactor[M]] =
-    Stream.bracket(newH2Transactor(url, user, pass))(Stream.emit(_), _.configure(ds => Async[M].delay(ds.dispose())))
+    Stream.bracket(newH2Transactor(url, user, pass))(_.configure(ds => Async[M].delay(ds.dispose())))
 
 }

--- a/modules/hikari/src/main/scala/doobie/hikari/HikariTransactor.scala
+++ b/modules/hikari/src/main/scala/doobie/hikari/HikariTransactor.scala
@@ -43,6 +43,6 @@ object HikariTransactor {
 
   /** Constructs a stream that emits a single `HikariTransactor` with guaranteed cleanup. */
   def stream[M[_]: Async](driverClassName: String, url: String, user: String, pass: String) : Stream[M, HikariTransactor[M]] =
-    Stream.bracket(newHikariTransactor(driverClassName, url, user, pass))(Stream.emit(_), _.configure(ds => Async[M].delay(ds.close)))
+    Stream.bracket(newHikariTransactor(driverClassName, url, user, pass))(_.configure(ds => Async[M].delay(ds.close)))
 
 }

--- a/modules/postgres/src/main/scala/doobie/postgres/free/copyin.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/free/copyin.scala
@@ -5,7 +5,7 @@
 package doobie.postgres.free
 
 import cats.~>
-import cats.effect.Async
+import cats.effect.{ Async, ExitCase }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
 
 import org.postgresql.copy.{ CopyIn => PGCopyIn }
@@ -41,6 +41,8 @@ object copyin { module =>
       def delay[A](a: () => A): F[A]
       def handleErrorWith[A](fa: CopyInIO[A], f: Throwable => CopyInIO[A]): F[A]
       def async[A](k: (Either[Throwable, A] => Unit) => Unit): F[A]
+      def asyncF[A](k: (Either[Throwable, A] => Unit) => CopyInIO[Unit]): F[A]
+      def bracketCase[A, B](acquire: CopyInIO[A])(use: A => CopyInIO[B])(release: (A, ExitCase[Throwable]) => CopyInIO[Unit]): F[B]
 
       // PGCopyIn
       def cancelCopy: F[Unit]
@@ -70,6 +72,12 @@ object copyin { module =>
     }
     final case class Async1[A](k: (Either[Throwable, A] => Unit) => Unit) extends CopyInOp[A] {
       def visit[F[_]](v: Visitor[F]) = v.async(k)
+    }
+    final case class AsyncF[A](k: (Either[Throwable, A] => Unit) => CopyInIO[Unit]) extends CopyInOp[A] {
+      def visit[F[_]](v: Visitor[F]) = v.asyncF(k)
+    }
+    final case class BracketCase[A, B](acquire: CopyInIO[A], use: A => CopyInIO[B], release: (A, ExitCase[Throwable]) => CopyInIO[Unit]) extends CopyInOp[B] {
+      def visit[F[_]](v: Visitor[F]) = v.bracketCase(acquire)(use)(release)
     }
 
     // PGCopyIn-specific operations.
@@ -113,6 +121,8 @@ object copyin { module =>
   def handleErrorWith[A](fa: CopyInIO[A], f: Throwable => CopyInIO[A]): CopyInIO[A] = FF.liftF[CopyInOp, A](HandleErrorWith(fa, f))
   def raiseError[A](err: Throwable): CopyInIO[A] = delay(throw err)
   def async[A](k: (Either[Throwable, A] => Unit) => Unit): CopyInIO[A] = FF.liftF[CopyInOp, A](Async1(k))
+  def asyncF[A](k: (Either[Throwable, A] => Unit) => CopyInIO[Unit]): CopyInIO[A] = FF.liftF[CopyInOp, A](AsyncF(k))
+  def bracketCase[A, B](acquire: CopyInIO[A])(use: A => CopyInIO[B])(release: (A, ExitCase[Throwable]) => CopyInIO[Unit]): CopyInIO[B] = FF.liftF[CopyInOp, B](BracketCase(acquire, use, release))
 
   // Smart constructors for CopyIn-specific operations.
   val cancelCopy: CopyInIO[Unit] = FF.liftF(CancelCopy)
@@ -129,10 +139,12 @@ object copyin { module =>
   implicit val AsyncCopyInIO: Async[CopyInIO] =
     new Async[CopyInIO] {
       val M = FF.catsFreeMonadForFree[CopyInOp]
+      def bracketCase[A, B](acquire: CopyInIO[A])(use: A => CopyInIO[B])(release: (A, ExitCase[Throwable]) => CopyInIO[Unit]): CopyInIO[B] = module.bracketCase(acquire)(use)(release)
       def pure[A](x: A): CopyInIO[A] = M.pure(x)
       def handleErrorWith[A](fa: CopyInIO[A])(f: Throwable => CopyInIO[A]): CopyInIO[A] = module.handleErrorWith(fa, f)
       def raiseError[A](e: Throwable): CopyInIO[A] = module.raiseError(e)
       def async[A](k: (Either[Throwable,A] => Unit) => Unit): CopyInIO[A] = module.async(k)
+      def asyncF[A](k: (Either[Throwable,A] => Unit) => CopyInIO[Unit]): CopyInIO[A] = module.asyncF(k)
       def flatMap[A, B](fa: CopyInIO[A])(f: A => CopyInIO[B]): CopyInIO[B] = M.flatMap(fa)(f)
       def tailRecM[A, B](a: A)(f: A => CopyInIO[Either[A, B]]): CopyInIO[B] = M.tailRecM(a)(f)
       def suspend[A](thunk: => CopyInIO[A]): CopyInIO[A] = M.flatten(module.delay(thunk))

--- a/modules/postgres/src/main/scala/doobie/postgres/free/pgconnection.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/free/pgconnection.scala
@@ -5,11 +5,12 @@
 package doobie.postgres.free
 
 import cats.~>
-import cats.effect.Async
+import cats.effect.{ Async, ExitCase }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
 
 import java.lang.Class
 import java.lang.String
+import java.sql.{ Array => SqlArray }
 import org.postgresql.PGConnection
 import org.postgresql.PGNotification
 import org.postgresql.copy.{ CopyManager => PGCopyManager }
@@ -50,10 +51,13 @@ object pgconnection { module =>
       def delay[A](a: () => A): F[A]
       def handleErrorWith[A](fa: PGConnectionIO[A], f: Throwable => PGConnectionIO[A]): F[A]
       def async[A](k: (Either[Throwable, A] => Unit) => Unit): F[A]
+      def asyncF[A](k: (Either[Throwable, A] => Unit) => PGConnectionIO[Unit]): F[A]
+      def bracketCase[A, B](acquire: PGConnectionIO[A])(use: A => PGConnectionIO[B])(release: (A, ExitCase[Throwable]) => PGConnectionIO[Unit]): F[B]
 
       // PGConnection
       def addDataType(a: String, b: Class[_ <: org.postgresql.util.PGobject]): F[Unit]
       def addDataType(a: String, b: String): F[Unit]
+      def createArrayOf(a: String, b: AnyRef): F[SqlArray]
       def escapeIdentifier(a: String): F[String]
       def escapeLiteral(a: String): F[String]
       def getAutosave: F[AutoSave]
@@ -89,6 +93,12 @@ object pgconnection { module =>
     final case class Async1[A](k: (Either[Throwable, A] => Unit) => Unit) extends PGConnectionOp[A] {
       def visit[F[_]](v: Visitor[F]) = v.async(k)
     }
+    final case class AsyncF[A](k: (Either[Throwable, A] => Unit) => PGConnectionIO[Unit]) extends PGConnectionOp[A] {
+      def visit[F[_]](v: Visitor[F]) = v.asyncF(k)
+    }
+    final case class BracketCase[A, B](acquire: PGConnectionIO[A], use: A => PGConnectionIO[B], release: (A, ExitCase[Throwable]) => PGConnectionIO[Unit]) extends PGConnectionOp[B] {
+      def visit[F[_]](v: Visitor[F]) = v.bracketCase(acquire)(use)(release)
+    }
 
     // PGConnection-specific operations.
     final case class  AddDataType(a: String, b: Class[_ <: org.postgresql.util.PGobject]) extends PGConnectionOp[Unit] {
@@ -96,6 +106,9 @@ object pgconnection { module =>
     }
     final case class  AddDataType1(a: String, b: String) extends PGConnectionOp[Unit] {
       def visit[F[_]](v: Visitor[F]) = v.addDataType(a, b)
+    }
+    final case class  CreateArrayOf(a: String, b: AnyRef) extends PGConnectionOp[SqlArray] {
+      def visit[F[_]](v: Visitor[F]) = v.createArrayOf(a, b)
     }
     final case class  EscapeIdentifier(a: String) extends PGConnectionOp[String] {
       def visit[F[_]](v: Visitor[F]) = v.escapeIdentifier(a)
@@ -158,10 +171,13 @@ object pgconnection { module =>
   def handleErrorWith[A](fa: PGConnectionIO[A], f: Throwable => PGConnectionIO[A]): PGConnectionIO[A] = FF.liftF[PGConnectionOp, A](HandleErrorWith(fa, f))
   def raiseError[A](err: Throwable): PGConnectionIO[A] = delay(throw err)
   def async[A](k: (Either[Throwable, A] => Unit) => Unit): PGConnectionIO[A] = FF.liftF[PGConnectionOp, A](Async1(k))
+  def asyncF[A](k: (Either[Throwable, A] => Unit) => PGConnectionIO[Unit]): PGConnectionIO[A] = FF.liftF[PGConnectionOp, A](AsyncF(k))
+  def bracketCase[A, B](acquire: PGConnectionIO[A])(use: A => PGConnectionIO[B])(release: (A, ExitCase[Throwable]) => PGConnectionIO[Unit]): PGConnectionIO[B] = FF.liftF[PGConnectionOp, B](BracketCase(acquire, use, release))
 
   // Smart constructors for PGConnection-specific operations.
   def addDataType(a: String, b: Class[_ <: org.postgresql.util.PGobject]): PGConnectionIO[Unit] = FF.liftF(AddDataType(a, b))
   def addDataType(a: String, b: String): PGConnectionIO[Unit] = FF.liftF(AddDataType1(a, b))
+  def createArrayOf(a: String, b: AnyRef): PGConnectionIO[SqlArray] = FF.liftF(CreateArrayOf(a, b))
   def escapeIdentifier(a: String): PGConnectionIO[String] = FF.liftF(EscapeIdentifier(a))
   def escapeLiteral(a: String): PGConnectionIO[String] = FF.liftF(EscapeLiteral(a))
   val getAutosave: PGConnectionIO[AutoSave] = FF.liftF(GetAutosave)
@@ -183,10 +199,12 @@ object pgconnection { module =>
   implicit val AsyncPGConnectionIO: Async[PGConnectionIO] =
     new Async[PGConnectionIO] {
       val M = FF.catsFreeMonadForFree[PGConnectionOp]
+      def bracketCase[A, B](acquire: PGConnectionIO[A])(use: A => PGConnectionIO[B])(release: (A, ExitCase[Throwable]) => PGConnectionIO[Unit]): PGConnectionIO[B] = module.bracketCase(acquire)(use)(release)
       def pure[A](x: A): PGConnectionIO[A] = M.pure(x)
       def handleErrorWith[A](fa: PGConnectionIO[A])(f: Throwable => PGConnectionIO[A]): PGConnectionIO[A] = module.handleErrorWith(fa, f)
       def raiseError[A](e: Throwable): PGConnectionIO[A] = module.raiseError(e)
       def async[A](k: (Either[Throwable,A] => Unit) => Unit): PGConnectionIO[A] = module.async(k)
+      def asyncF[A](k: (Either[Throwable,A] => Unit) => PGConnectionIO[Unit]): PGConnectionIO[A] = module.asyncF(k)
       def flatMap[A, B](fa: PGConnectionIO[A])(f: A => PGConnectionIO[B]): PGConnectionIO[B] = M.flatMap(fa)(f)
       def tailRecM[A, B](a: A)(f: A => PGConnectionIO[Either[A, B]]): PGConnectionIO[B] = M.tailRecM(a)(f)
       def suspend[A](thunk: => PGConnectionIO[A]): PGConnectionIO[A] = M.flatten(module.delay(thunk))

--- a/modules/postgres/src/main/scala/doobie/postgres/hi/lostreaming.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/hi/lostreaming.scala
@@ -14,16 +14,14 @@ import org.postgresql.largeobject.LargeObject
 object lostreaming {
   def createLOFromStream(data: Stream[ConnectionIO, Byte]): ConnectionIO[Long] =
     createLO.flatMap { oid =>
-      Stream.bracket(openLO(oid))(
-        lo => data.to(FS2IO.writeOutputStream(getOutputStream(lo))),
-        closeLO
-      ).compile.drain.as(oid)
+      Stream.bracket(openLO(oid))(closeLO)
+        .flatMap(lo => data.to(FS2IO.writeOutputStream(getOutputStream(lo))))
+        .compile.drain.as(oid)
     }
 
   def createStreamFromLO(oid: Long, chunkSize: Int): Stream[ConnectionIO, Byte] =
-    Stream.bracket(openLO(oid))(
-      lo => FS2IO.readInputStream(getInputStream(lo), chunkSize),
-      closeLO) 
+    Stream.bracket(openLO(oid))(closeLO)
+      .flatMap(lo => FS2IO.readInputStream(getInputStream(lo), chunkSize))
 
   private val createLO: ConnectionIO[Long] =
     PHC.pgGetLargeObjectAPI(PFLOM.createLO)

--- a/modules/postgres/src/test/scala/doobie/postgres/lostreaming.scala
+++ b/modules/postgres/src/test/scala/doobie/postgres/lostreaming.scala
@@ -35,9 +35,9 @@ object lostreamingspec extends Specification with ScalaCheck {
       val data0 = data.covary[ConnectionIO]
 
       val result = Stream.bracket(PHLOS.createLOFromStream(data0))(
-        oid => PHLOS.createStreamFromLO(oid, chunkSize = 1024 * 10),
         oid => PHC.pgGetLargeObjectAPI(PFLOM.unlink(oid))
-      ).compile.toVector.transact(xa).unsafeRunSync()
+      ).flatMap(oid => PHLOS.createStreamFromLO(oid, chunkSize = 1024 * 10))
+       .compile.toVector.transact(xa).unsafeRunSync()
 
       result must_=== data.toVector
     }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.jsuereth"       % "sbt-pgp"         % "1.1.1")
-addSbtPlugin("com.github.gseitz"  % "sbt-release"     % "1.0.8")
+addSbtPlugin("com.github.gseitz"  % "sbt-release"     % "1.0.9")
 addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"    % "2.0")
 addSbtPlugin("com.47deg"          % "sbt-microsites"  % "0.7.13")
 addSbtPlugin("org.scoverage"      % "sbt-scoverage"   % "1.5.1")


### PR DESCRIPTION
This updates to fs2 1.0.0-M1 and thus to cats-effect 1.0.0-RC2 which means the `Async` implementations and uses of `bracket` needed to change. 