### PR TITLE
Resolve diverging implicit expansion problem (#780)

### DIFF
--- a/modules/core/src/main/scala/doobie/util/param.scala
+++ b/modules/core/src/main/scala/doobie/util/param.scala
@@ -29,7 +29,7 @@ instance for each element in the REPL. See the FAQ in the Book of Doobie for mor
    * Derivations for `Param`, which disallow embedding. Each interpolated query argument corresponds
    * with a type with a `Meta` instance, or an `Option` thereof.
    */
-  object Param {
+  object Param extends LowPriorityParamImplicits {
 
     def apply[A](implicit ev: Param[A]): Param[A] = ev
 
@@ -45,10 +45,17 @@ instance for each element in the REPL. See the FAQ in the Book of Doobie for mor
     implicit val ParamHNil: Param[HNil] =
       new Param[HNil](Composite.emptyProduct)
 
+    implicit def ParamHListFromMeta[H, T <: HList](implicit mh: Meta[H], pt: Param[T]): Param[H :: T] =
+      ParamHList(new Param[H](Composite.fromMeta(mh)), pt)
+
+    implicit def ParamHListFromMetaOption[H, T <: HList](implicit mh: Meta[H], pt: Param[T]): Param[Option[H] :: T] =
+      ParamHList(new Param[Option[H]](Composite.fromMetaOption(mh)), pt)
+  }
+
+  trait LowPriorityParamImplicits {
     /** Inductively we can cons a new `Param` onto the head of a `Param` of an `HList`. */
     implicit def ParamHList[H, T <: HList](implicit ph: Param[H], pt: Param[T]): Param[H :: T] =
       new Param[H :: T](Composite.product[H,T](ph.composite, pt.composite))
-
   }
 
 }

--- a/modules/core/src/main/scala/doobie/util/param.scala
+++ b/modules/core/src/main/scala/doobie/util/param.scala
@@ -44,12 +44,6 @@ instance for each element in the REPL. See the FAQ in the Book of Doobie for mor
     /** There is an empty `Param` for `HNil`. */
     implicit val ParamHNil: Param[HNil] =
       new Param[HNil](Composite.emptyProduct)
-
-    implicit def ParamHListFromMeta[H, T <: HList](implicit mh: Meta[H], pt: Param[T]): Param[H :: T] =
-      ParamHList(fromMeta(mh), pt)
-
-    implicit def ParamHListFromMetaOption[H, T <: HList](implicit mh: Meta[H], pt: Param[T]): Param[Option[H] :: T] =
-      ParamHList(fromMetaOption(mh), pt)
   }
 
   trait LowPriorityParamImplicits {

--- a/modules/core/src/main/scala/doobie/util/param.scala
+++ b/modules/core/src/main/scala/doobie/util/param.scala
@@ -46,10 +46,10 @@ instance for each element in the REPL. See the FAQ in the Book of Doobie for mor
       new Param[HNil](Composite.emptyProduct)
 
     implicit def ParamHListFromMeta[H, T <: HList](implicit mh: Meta[H], pt: Param[T]): Param[H :: T] =
-      ParamHList(new Param[H](Composite.fromMeta(mh)), pt)
+      ParamHList(fromMeta(mh), pt)
 
     implicit def ParamHListFromMetaOption[H, T <: HList](implicit mh: Meta[H], pt: Param[T]): Param[Option[H] :: T] =
-      ParamHList(new Param[Option[H]](Composite.fromMetaOption(mh)), pt)
+      ParamHList(fromMetaOption(mh), pt)
   }
 
   trait LowPriorityParamImplicits {

--- a/modules/core/src/test/scala/doobie/issue/780.scala
+++ b/modules/core/src/test/scala/doobie/issue/780.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2013-2018 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.issue
+
+import doobie._, doobie.implicits._
+import org.specs2.mutable.Specification
+import scala.Predef._
+import shapeless.{::, HNil}
+
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+object `780` extends Specification {
+
+  "Param" should {
+    "exist when meta instances are in scope" in {
+      class Foo[A: Meta, B: Meta] {
+        def bar = Param[A :: B :: HNil]
+      }
+
+      true
+    }
+  }
+
+}

--- a/modules/core/src/test/scala/doobie/util/param.scala
+++ b/modules/core/src/test/scala/doobie/util/param.scala
@@ -42,14 +42,6 @@ object paramspec extends Specification {
       true
     }
 
-    "exist for wider scopes" in { // #780
-      class Foo[A: Meta, B: Meta] {
-        def bar = Param[A :: B :: HNil]
-      }
-
-      true
-    }
-
     "not exist for non-unary products" in {
       illTyped("Param[Z]")
       illTyped("Param[(Int, Int)]")

--- a/modules/core/src/test/scala/doobie/util/param.scala
+++ b/modules/core/src/test/scala/doobie/util/param.scala
@@ -42,6 +42,14 @@ object paramspec extends Specification {
       true
     }
 
+    "exist for wider scopes" in { // #780
+      class Foo[A: Meta, B: Meta] {
+        def bar = Param[A :: B :: HNil]
+      }
+
+      true
+    }
+
     "not exist for non-unary products" in {
       illTyped("Param[Z]")
       illTyped("Param[(Int, Int)]")


### PR DESCRIPTION
As far as I can tell, this solves the issue without introducing any new ambiguous implicit errors. I don't know how scala's implicit resolution works though. This could've broken things. 