### PR TITLE
Port fix from #782 in to 6.x

### DIFF
--- a/modules/core/src/main/scala/doobie/util/param.scala
+++ b/modules/core/src/main/scala/doobie/util/param.scala
@@ -6,7 +6,7 @@ package doobie.util
 
 import scala.annotation.implicitNotFound
 
-import shapeless.{ HNil, HList, :: }
+import shapeless.{ HNil, HList, ::, Lazy}
 
 /** Module defining the `Param` typeclass. */
 object param {
@@ -52,9 +52,8 @@ Chapter 12 of the book of doobie for more information.
       new Param[HNil](Write.emptyProduct)
 
     /** Inductively we can cons a new `Param` onto the head of a `Param` of an `HList`. */
-    implicit def ParamHList[H, T <: HList](implicit ph: Param[H], pt: Param[T]): Param[H :: T] =
-      new Param[H :: T](Write.product[H,T](ph.write, pt.write))
-
+    implicit def ParamHList[H, T <: HList](implicit ph: Lazy[Param[H]], pt: Lazy[Param[T]]): Param[H :: T] =
+      new Param[H :: T](Write.product[H,T](ph.value.write, pt.value.write))
   }
 
 }

--- a/modules/core/src/main/scala/doobie/util/put.scala
+++ b/modules/core/src/main/scala/doobie/util/put.scala
@@ -186,11 +186,11 @@ trait PutInstances {
     }
 
   /** @group Instances */
-  implicit def ArrayTypeAsListGet[A: ClassTag: TypeTag](implicit ev: Put[Array[A]]): Put[List[A]] =
+  implicit def ArrayTypeAsListPut[A: ClassTag: TypeTag](implicit ev: Put[Array[A]]): Put[List[A]] =
     ev.tcontramap(_.toArray)
 
   /** @group Instances */
-  implicit def ArrayTypeAsVectorGet[A: ClassTag: TypeTag](implicit ev: Put[Array[A]]): Put[Vector[A]] =
+  implicit def ArrayTypeAsVectorPut[A: ClassTag: TypeTag](implicit ev: Put[Array[A]]): Put[Vector[A]] =
     ev.tcontramap(_.toArray)
 
   /** @group Instances */

--- a/modules/core/src/test/scala/doobie/issue/780.scala
+++ b/modules/core/src/test/scala/doobie/issue/780.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2013-2018 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.issue
+
+import doobie._, doobie.implicits._
+import org.specs2.mutable.Specification
+import scala.Predef._
+import shapeless.{::, HNil}
+
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+object `780` extends Specification {
+
+  "deriving instances" should {
+    "work correctly for Param from class scope" in {
+      class Foo[A: Param, B: Param] {
+        Param[A :: B :: HNil]
+      }
+      true
+    }
+
+    "work correctly for Write from class scope" in {
+      class Foo[A: Write, B: Write] {
+        Write[A :: B :: HNil]
+      }
+      true
+    }
+  }
+
+}


### PR DESCRIPTION
This should resolve #780 in the 6.x series.

Moving priorities around didn't work, so I had to resort to using `shapeless.Lazy`.  It doesn't seem to be causing any new problems.

Also fixed a couple of typos in `put.scala` while I was poking around.


cc: @mcanlas 