### PR TITLE
Upgrade cats version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import microsites._
 resolvers in Global += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 
 // Library versions all in one place, for convenience and sanity.
-lazy val catsVersion          = "1.1.0"
+lazy val catsVersion          = "1.3.1"
 lazy val circeVersion         = "0.9.3"
 lazy val fs2CoreVersion       = "0.10.4"
 lazy val h2Version            = "1.4.197"

--- a/modules/core/src/test/scala/doobie/issue/780.scala
+++ b/modules/core/src/test/scala/doobie/issue/780.scala
@@ -15,9 +15,8 @@ object `780` extends Specification {
   "Param" should {
     "exist when meta instances are in scope" in {
       class Foo[A: Meta, B: Meta] {
-        def bar = Param[A :: B :: HNil]
+        Param[A :: B :: HNil]
       }
-
       true
     }
   }


### PR DESCRIPTION
This upgrades cats on series 0.5.x to the latest cats version which has a corresponding stable cats-effect version.

Additionally when making this, I discovered that my solution to #780 only worked _sometimes_.  In partial compiles, it compiled fine.  In full-rebuilds, it would not.  I've switched it to use the solution found in #797, which works consistently.