### PR TITLE
Fix documentation typo

### DIFF
--- a/modules/docs/src/main/tut/docs/03-Connecting.md
+++ b/modules/docs/src/main/tut/docs/03-Connecting.md
@@ -42,7 +42,7 @@ import scala.concurrent.ExecutionContext
 // is where nonblocking operations will be executed.
 implicit val cs = IO.contextShift(ExecutionContext.global)
 
-// A transactor that gets connections from java.sql.DriverManager and excutes blocking operations
+// A transactor that gets connections from java.sql.DriverManager and executes blocking operations
 // on an unbounded pool of daemon threads. See the chapter on connection handling for more info.
 val xa = Transactor.fromDriverManager[IO](
   "org.postgresql.Driver", // driver classname

--- a/modules/docs/src/main/tut/docs/04-Selecting.md
+++ b/modules/docs/src/main/tut/docs/04-Selecting.md
@@ -25,7 +25,7 @@ import scala.concurrent.ExecutionContext
 // is where nonblocking operations will be executed.
 implicit val cs = IO.contextShift(ExecutionContext.global)
 
-// A transactor that gets connections from java.sql.DriverManager and excutes blocking operations
+// A transactor that gets connections from java.sql.DriverManager and executes blocking operations
 // on an unbounded pool of daemon threads. See the chapter on connection handling for more info.
 val xa = Transactor.fromDriverManager[IO](
   "org.postgresql.Driver", // driver classname

--- a/modules/docs/src/main/tut/docs/05-Parameterized.md
+++ b/modules/docs/src/main/tut/docs/05-Parameterized.md
@@ -25,7 +25,7 @@ import scala.concurrent.ExecutionContext
 // is where nonblocking operations will be executed.
 implicit val cs = IO.contextShift(ExecutionContext.global)
 
-// A transactor that gets connections from java.sql.DriverManager and excutes blocking operations
+// A transactor that gets connections from java.sql.DriverManager and executes blocking operations
 // on an unbounded pool of daemon threads. See the chapter on connection handling for more info.
 val xa = Transactor.fromDriverManager[IO](
   "org.postgresql.Driver", // driver classname

--- a/modules/docs/src/main/tut/docs/06-Checking.md
+++ b/modules/docs/src/main/tut/docs/06-Checking.md
@@ -25,7 +25,7 @@ import scala.concurrent.ExecutionContext
 // is where nonblocking operations will be executed.
 implicit val cs = IO.contextShift(ExecutionContext.global)
 
-// A transactor that gets connections from java.sql.DriverManager and excutes blocking operations
+// A transactor that gets connections from java.sql.DriverManager and executes blocking operations
 // on an unbounded pool of daemon threads. See the chapter on connection handling for more info.
 val xa = Transactor.fromDriverManager[IO](
   "org.postgresql.Driver", // driver classname

--- a/modules/docs/src/main/tut/docs/07-Updating.md
+++ b/modules/docs/src/main/tut/docs/07-Updating.md
@@ -25,7 +25,7 @@ import scala.concurrent.ExecutionContext
 // is where nonblocking operations will be executed.
 implicit val cs = IO.contextShift(ExecutionContext.global)
 
-// A transactor that gets connections from java.sql.DriverManager and excutes blocking operations
+// A transactor that gets connections from java.sql.DriverManager and executes blocking operations
 // on an unbounded pool of daemon threads. See the chapter on connection handling for more info.
 val xa = Transactor.fromDriverManager[IO](
   "org.postgresql.Driver", // driver classname

--- a/modules/docs/src/main/tut/docs/08-Fragments.md
+++ b/modules/docs/src/main/tut/docs/08-Fragments.md
@@ -25,7 +25,7 @@ import scala.concurrent.ExecutionContext
 // is where nonblocking operations will be executed.
 implicit val cs = IO.contextShift(ExecutionContext.global)
 
-// A transactor that gets connections from java.sql.DriverManager and excutes blocking operations
+// A transactor that gets connections from java.sql.DriverManager and executes blocking operations
 // on an unbounded pool of daemon threads. See the chapter on connection handling for more info.
 val xa = Transactor.fromDriverManager[IO](
   "org.postgresql.Driver", // driver classname

--- a/modules/docs/src/main/tut/docs/09-Error-Handling.md
+++ b/modules/docs/src/main/tut/docs/09-Error-Handling.md
@@ -23,7 +23,7 @@ import scala.concurrent.ExecutionContext
 // is where nonblocking operations will be executed.
 implicit val cs = IO.contextShift(ExecutionContext.global)
 
-// A transactor that gets connections from java.sql.DriverManager and excutes blocking operations
+// A transactor that gets connections from java.sql.DriverManager and executes blocking operations
 // on an unbounded pool of daemon threads. See the chapter on connection handling for more info.
 val xa = Transactor.fromDriverManager[IO](
   "org.postgresql.Driver", // driver classname

--- a/modules/docs/src/main/tut/docs/10-Logging.md
+++ b/modules/docs/src/main/tut/docs/10-Logging.md
@@ -25,7 +25,7 @@ import scala.concurrent.ExecutionContext
 // is where nonblocking operations will be executed.
 implicit val cs = IO.contextShift(ExecutionContext.global)
 
-// A transactor that gets connections from java.sql.DriverManager and excutes blocking operations
+// A transactor that gets connections from java.sql.DriverManager and executes blocking operations
 // on an unbounded pool of daemon threads. See the chapter on connection handling for more info.
 val xa = Transactor.fromDriverManager[IO](
   "org.postgresql.Driver", // driver classname

--- a/modules/docs/src/main/tut/docs/11-Arrays.md
+++ b/modules/docs/src/main/tut/docs/11-Arrays.md
@@ -27,7 +27,7 @@ import scala.concurrent.ExecutionContext
 // is where nonblocking operations will be executed.
 implicit val cs = IO.contextShift(ExecutionContext.global)
 
-// A transactor that gets connections from java.sql.DriverManager and excutes blocking operations
+// A transactor that gets connections from java.sql.DriverManager and executes blocking operations
 // on an unbounded pool of daemon threads. See the chapter on connection handling for more info.
 val xa = Transactor.fromDriverManager[IO](
   "org.postgresql.Driver", // driver classname

--- a/modules/docs/src/main/tut/docs/13-Unit-Testing.md
+++ b/modules/docs/src/main/tut/docs/13-Unit-Testing.md
@@ -25,7 +25,7 @@ import scala.concurrent.ExecutionContext
 // is where nonblocking operations will be executed.
 implicit val cs = IO.contextShift(ExecutionContext.global)
 
-// A transactor that gets connections from java.sql.DriverManager and excutes blocking operations
+// A transactor that gets connections from java.sql.DriverManager and executes blocking operations
 // on an unbounded pool of daemon threads. See the chapter on connection handling for more info.
 val xa = Transactor.fromDriverManager[IO](
   "org.postgresql.Driver", // driver classname

--- a/modules/docs/src/main/tut/docs/14-Managing-Connections.md
+++ b/modules/docs/src/main/tut/docs/14-Managing-Connections.md
@@ -64,7 +64,7 @@ import scala.concurrent.ExecutionContext
 // is where nonblocking operations will be executed.
 implicit val cs = IO.contextShift(ExecutionContext.global)
 
-// A transactor that gets connections from java.sql.DriverManager and excutes blocking operations
+// A transactor that gets connections from java.sql.DriverManager and executes blocking operations
 // on an unbounded pool of daemon threads.
 val xa = Transactor.fromDriverManager[IO](
   "org.postgresql.Driver", // driver classname

--- a/modules/docs/src/main/tut/docs/15-Extensions-PostgreSQL.md
+++ b/modules/docs/src/main/tut/docs/15-Extensions-PostgreSQL.md
@@ -31,7 +31,7 @@ import scala.concurrent.ExecutionContext
 // is where nonblocking operations will be executed.
 implicit val cs = IO.contextShift(ExecutionContext.global)
 
-// A transactor that gets connections from java.sql.DriverManager and excutes blocking operations
+// A transactor that gets connections from java.sql.DriverManager and executes blocking operations
 // on an unbounded pool of daemon threads. See the chapter on connection handling for more info.
 val xa = Transactor.fromDriverManager[IO](
   "org.postgresql.Driver", // driver classname

--- a/modules/docs/src/main/tut/docs/17-FAQ.md
+++ b/modules/docs/src/main/tut/docs/17-FAQ.md
@@ -24,7 +24,7 @@ import scala.concurrent.ExecutionContext
 // is where nonblocking operations will be executed.
 implicit val cs = IO.contextShift(ExecutionContext.global)
 
-// A transactor that gets connections from java.sql.DriverManager and excutes blocking operations
+// A transactor that gets connections from java.sql.DriverManager and executes blocking operations
 // on an unbounded pool of daemon threads. See the chapter on connection handling for more info.
 val xa = Transactor.fromDriverManager[IO](
   "org.postgresql.Driver", // driver classname


### PR DESCRIPTION
"excutes" -> "executes"