### PR TITLE
Remove scala-compiler dependency from doobie-refined

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -554,7 +554,6 @@ lazy val refined = project
     description := "Refined support for doobie.",
     libraryDependencies ++= Seq(
       "eu.timepit"            %% "refined"        % refinedVersion,
-      scalaOrganization.value %  "scala-compiler" % scalaVersion.value % Provided,
       "com.h2database"        %  "h2"             % h2Version          % "test"
     )
   )


### PR DESCRIPTION
This dependency was added in https://github.com/tpolecat/doobie/pull/481
which updated refined to 0.7.0. This version required the scala-compiler
dependency as mentioned in the release notes here:
https://github.com/fthomas/refined/blob/master/notes/0.7.0.markdown

refined 0.8.0 dropped this requirement again
(https://github.com/fthomas/refined/blob/master/notes/0.8.0.markdown)
but it wasn't removed from the doobie build as refined was bumped to
0.8.0.