### PR TITLE
Testcase for 824

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -498,7 +498,10 @@ lazy val hikari = project
   .settings(
     name := "doobie-hikari",
     description := "Hikari support for doobie.",
-    libraryDependencies += "com.zaxxer" % "HikariCP" % hikariVersion
+    libraryDependencies ++= Seq(
+      "com.zaxxer"     % "HikariCP" % hikariVersion,
+      "com.h2database" % "h2"       % h2Version       % "test"
+    )
   )
 
 lazy val specs2 = project

--- a/build.sbt
+++ b/build.sbt
@@ -499,8 +499,9 @@ lazy val hikari = project
     name := "doobie-hikari",
     description := "Hikari support for doobie.",
     libraryDependencies ++= Seq(
-      "com.zaxxer"     % "HikariCP" % hikariVersion,
-      "com.h2database" % "h2"       % h2Version       % "test"
+      "com.zaxxer"     % "HikariCP"   % hikariVersion,
+      "com.h2database" % "h2"         % h2Version      % "test",
+      "org.slf4j"      % "slf4j-nop"  % slf4jVersion   % "test"
     )
   )
 

--- a/modules/hikari/src/test/scala/doobie/hikari/issue/824.scala
+++ b/modules/hikari/src/test/scala/doobie/hikari/issue/824.scala
@@ -1,0 +1,75 @@
+// Copyright (c) 2013-2018 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.hikari.issue
+
+import cats.effect._
+import cats.implicits._
+import doobie._
+import doobie.hikari._
+import doobie.implicits._
+import org.specs2.mutable.Specification
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.util.Random
+
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+object `824` extends Specification {
+
+  implicit def contextShift: ContextShift[IO] =
+    IO.contextShift(ExecutionContext.global)
+
+  implicit def timer: Timer[IO] =
+    IO.timer(ExecutionContext.global)
+
+  val transactor: Resource[IO, HikariTransactor[IO]] =
+    for {
+      ce <- ExecutionContexts.fixedThreadPool[IO](16) // our connect EC
+      te <- ExecutionContexts.cachedThreadPool[IO]    // our transaction EC
+      xa <- HikariTransactor.newHikariTransactor[IO](
+              "org.h2.Driver",                        // driver classname
+              "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1",   // connect URL
+              "sa",                                   // username
+              "",                                     // password
+              ce,                                     // await connection here
+              te                                      // execute JDBC operations here
+            )
+    } yield xa
+
+  val prog: IO[Int] =
+    transactor.use { xa =>
+
+      // Show the state of the pool
+      val report: IO[Unit] =
+        IO {
+          val mx = xa.kernel.getHikariPoolMXBean; import mx._
+          println(s"Idle: $getIdleConnections, Active: $getActiveConnections, Total: $getTotalConnections, Waiting: $getThreadsAwaitingConnection")
+        }
+
+      // Kick off a concurrent transaction, reporting the pool state on exit
+      val random: IO[Fiber[IO, Unit]] =
+        for {
+          d <- IO(Random.nextInt(200) milliseconds)
+          f <- (IO.sleep(d) *> report).to[ConnectionIO].transact(xa).start
+        } yield f
+
+      // Run a bunch of transactions at once, then return the active connection count
+      for {
+        _  <- IO(xa.kernel.setMaximumPoolSize(10)) // max connections
+        _  <- ().pure[ConnectionIO].transact(xa)  // do this once to init the MBean
+        _  <- report
+        fs <- random.replicateA(50)
+        _  <- fs.traverse(_.join)
+        _  <- report
+        a  <- IO(xa.kernel.getHikariPoolMXBean.getActiveConnections)
+      } yield a
+    }
+
+  "HikariTransactor" should {
+    "close connections promptly" in {
+      prog.unsafeRunSync must_== 0
+    }
+  }
+
+}

--- a/modules/hikari/src/test/scala/doobie/hikari/issue/824.scala
+++ b/modules/hikari/src/test/scala/doobie/hikari/issue/824.scala
@@ -40,6 +40,7 @@ object `824` extends Specification {
     } yield xa
 
     // Show the state of the pool
+    @SuppressWarnings(Array("org.wartremover.warts.StringPlusAny"))
     def report(ds: HikariDataSource): IO[Unit] =
       IO {
         val mx = ds.getHikariPoolMXBean; import mx._


### PR DESCRIPTION
@unhappy-boi this testcase for #824 shows correct pool behavior, with connections being returned as transactions complete. Can you demonstrate your problem by modifying this testcase?

```
HikariTransactor should
Idle: 1, Active: 0, Total: 1, Waiting: 0
Idle: 0, Active: 10, Total: 10, Waiting: 16
...
dle: 0, Active: 10, Total: 10, Waiting: 16
Idle: 0, Active: 10, Total: 10, Waiting: 13
Idle: 0, Active: 10, Total: 10, Waiting: 13
Idle: 0, Active: 10, Total: 10, Waiting: 11
Idle: 0, Active: 10, Total: 10, Waiting: 11
Idle: 0, Active: 10, Total: 10, Waiting: 11
Idle: 0, Active: 10, Total: 10, Waiting: 11
Idle: 0, Active: 10, Total: 10, Waiting: 11
Idle: 0, Active: 10, Total: 10, Waiting: 11
Idle: 0, Active: 10, Total: 10, Waiting: 5
Idle: 0, Active: 10, Total: 10, Waiting: 5
Idle: 0, Active: 10, Total: 10, Waiting: 5
Idle: 0, Active: 10, Total: 10, Waiting: 5
Idle: 0, Active: 10, Total: 10, Waiting: 5
Idle: 0, Active: 10, Total: 10, Waiting: 5
Idle: 1, Active: 9, Total: 10, Waiting: 0
Idle: 1, Active: 9, Total: 10, Waiting: 0
Idle: 1, Active: 9, Total: 10, Waiting: 0
Idle: 4, Active: 6, Total: 10, Waiting: 0
Idle: 4, Active: 6, Total: 10, Waiting: 0
Idle: 4, Active: 6, Total: 10, Waiting: 0
Idle: 4, Active: 6, Total: 10, Waiting: 0
Idle: 4, Active: 6, Total: 10, Waiting: 0
Idle: 4, Active: 6, Total: 10, Waiting: 0
Idle: 10, Active: 0, Total: 10, Waiting: 0
  + close connections promptly


Total for specification 824
Finished in 1 second, 737 ms
1 example, 0 failure, 0 error
```