### PR TITLE
add instance of Text[Char] fixing #826

### DIFF
--- a/modules/postgres/src/main/scala/doobie/postgres/Text.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/Text.scala
@@ -118,6 +118,9 @@ trait TextInstances extends TextInstances0 { this: Text.type =>
       }
     }
 
+  //Char
+  implicit val intInstance:    Text[Char]    = instance((n, sb) => sb.append(n.toString))
+
   // Primitive Numerics
   implicit val intInstance:    Text[Int]    = instance((n, sb) => sb.append(n))
   implicit val shortInstance:  Text[Short]  = instance((n, sb) => sb.append(n))

--- a/modules/postgres/src/main/scala/doobie/postgres/Text.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/Text.scala
@@ -119,7 +119,7 @@ trait TextInstances extends TextInstances0 { this: Text.type =>
     }
 
   //Char
-  implicit val intInstance:    Text[Char]    = instance((n, sb) => sb.append(n.toString))
+  implicit val charInstance:    Text[Char]    = instance((n, sb) => sb.append(n.toString))
 
   // Primitive Numerics
   implicit val intInstance:    Text[Int]    = instance((n, sb) => sb.append(n))


### PR DESCRIPTION
This seemed like the easiest way to stop pathological compilation times while being as close to what I can tell the expected functionality for inserting a Char to be i.e. should not differ from a string