### PR TITLE
stacksafe fragment (rebased for 0.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ This file summarizes **notable** changes for each release, but does not describe
 This is a **compatibility-breaking** release intended to satisfy some lingering issues prior to switching to a tagless encoding.
 
 - Added support for Scala 2.13.0-M5, many thanks to **Sam Guymer** for setting this up.
-- Replaced `MonadError`-based `guarantee` with `bracket`, which prevents potential resource when using cancelable IO. Thanks **Sam Guymer** for this update.
+- Replaced `MonadError`-based `guarantee` with `bracket`, which prevents potential resource leakage when using cancelable IO. Thanks **Sam Guymer** for this update.
+- `Fragment` concatenation and derived combinators like `Fragments.in` are now stacksafe, so you can now have gigantic `IN` clauses. This required API changes in `Param`, `Fragment`, `Update[0]` and `Query[0]` but these should not affect most users.
+
 ____
 
 ### <a name="0.6.0"></a>New and Noteworthy for Version 0.6.0

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ resolvers in Global += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/con
 
 // Library versions all in one place, for convenience and sanity.
 lazy val catsVersion          = "1.5.0"
+lazy val catsEffectVersion    = "1.2.0"
 lazy val circeVersion         = "0.11.1"
 def fs2CoreVersion(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
   case Some((2, v)) if v >= 13 => "1.0.3-SNAPSHOT"
@@ -17,7 +18,7 @@ lazy val kindProjectorVersion = "0.9.9"
 lazy val monixVersion         = "3.0.0-RC2"
 lazy val postGisVersion       = "2.3.0"
 lazy val postgresVersion      = "42.2.5"
-lazy val refinedVersion       = "0.9.3"
+lazy val refinedVersion       = "0.9.4"
 lazy val scalaCheckVersion    = "1.14.0"
 def scalatestVersion(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
   case Some((2, v)) if v >= 13 => "3.0.6-SNAP5"
@@ -284,9 +285,10 @@ lazy val free = project
     scalacOptions += "-Yno-predef",
     scalacOptions -= "-Xfatal-warnings", // the only reason this project exists
     libraryDependencies ++= Seq(
-      "co.fs2"         %% "fs2-core"   % fs2CoreVersion(scalaVersion.value),
-      "org.typelevel"  %% "cats-core"  % catsVersion,
-      "org.typelevel"  %% "cats-free"  % catsVersion
+      "co.fs2"         %% "fs2-core"    % fs2CoreVersion(scalaVersion.value),
+      "org.typelevel"  %% "cats-core"   % catsVersion,
+      "org.typelevel"  %% "cats-free"   % catsVersion,
+      "org.typelevel"  %% "cats-effect" % catsEffectVersion,
     ),
     freeGen2Dir     := (scalaSource in Compile).value / "doobie" / "free",
     freeGen2Package := "doobie.free",

--- a/modules/core/src/main/scala/doobie/aliases.scala
+++ b/modules/core/src/main/scala/doobie/aliases.scala
@@ -4,26 +4,28 @@
 
 package doobie
 
+import shapeless.HList
+
 /** Mixin containing aliases for the most commonly used types and modules from doobie-core. */
 trait Aliases extends Types with Modules
 
 /** Mixin containing aliases for the most commonly used types from doobie-core. */
 trait Types {
-  /** @group Type Aliases - Core */ type Meta[A]                    = doobie.util.Meta[A]
-  /** @group Type Aliases - Core */ type Get[A]                     = doobie.util.Get[A]
-  /** @group Type Aliases - Core */ type Put[A]                     = doobie.util.Put[A]
-  /** @group Type Aliases - Core */ type Read[A]                    = doobie.util.Read[A]
-  /** @group Type Aliases - Core */ type Write[A]                   = doobie.util.Write[A]
-  /** @group Type Aliases - Core */ type Query[A,B]                 = doobie.util.query.Query[A,B]
-  /** @group Type Aliases - Core */ type Update[A]                  = doobie.util.update.Update[A]
-  /** @group Type Aliases - Core */ type Query0[A]                  = doobie.util.query.Query0[A]
-  /** @group Type Aliases - Core */ type Update0                    = doobie.util.update.Update0
-  /** @group Type Aliases - Core */ type SqlState                   = doobie.enum.SqlState
-  /** @group Type Aliases - Core */ type Param[A]                   = doobie.util.param.Param[A]
-  /** @group Type Aliases - Core */ type Transactor[M[_]]           = doobie.util.transactor.Transactor[M]
-  /** @group Type Aliases - Core */ type LogHandler                 = doobie.util.log.LogHandler
-  /** @group Type Aliases - Core */ type Fragment                   = doobie.util.fragment.Fragment
-  /** @group Type Aliases - Core */ type KleisliInterpreter[F[_]]   = doobie.free.KleisliInterpreter[F]
+  /** @group Type Aliases - Core */ type Meta[A]                  = doobie.util.Meta[A]
+  /** @group Type Aliases - Core */ type Get[A]                   = doobie.util.Get[A]
+  /** @group Type Aliases - Core */ type Put[A]                   = doobie.util.Put[A]
+  /** @group Type Aliases - Core */ type Read[A]                  = doobie.util.Read[A]
+  /** @group Type Aliases - Core */ type Write[A]                 = doobie.util.Write[A]
+  /** @group Type Aliases - Core */ type Query[A,B]               = doobie.util.query.Query[A,B]
+  /** @group Type Aliases - Core */ type Update[A]                = doobie.util.update.Update[A]
+  /** @group Type Aliases - Core */ type Query0[A]                = doobie.util.query.Query0[A]
+  /** @group Type Aliases - Core */ type Update0                  = doobie.util.update.Update0
+  /** @group Type Aliases - Core */ type SqlState                 = doobie.enum.SqlState
+  /** @group Type Aliases - Core */ type Param[A <: HList]        = doobie.util.param.Param[A]
+  /** @group Type Aliases - Core */ type Transactor[M[_]]         = doobie.util.transactor.Transactor[M]
+  /** @group Type Aliases - Core */ type LogHandler               = doobie.util.log.LogHandler
+  /** @group Type Aliases - Core */ type Fragment                 = doobie.util.fragment.Fragment
+  /** @group Type Aliases - Core */ type KleisliInterpreter[F[_]] = doobie.free.KleisliInterpreter[F]
   /** @group Type Aliases - Core */ type DataSourceTransactor[F[_]] = doobie.util.transactor.Transactor.Aux[F, javax.sql.DataSource]
 }
 

--- a/modules/core/src/main/scala/doobie/syntax/string.scala
+++ b/modules/core/src/main/scala/doobie/syntax/string.scala
@@ -7,7 +7,7 @@ package doobie.syntax
 import doobie.util.param.Param
 import doobie.util.pos.Pos
 import doobie.util.fragment.Fragment
-import shapeless.ProductArgs
+import shapeless.{ HList, ProductArgs }
 
 /**
  * String interpolator for SQL literals. An expression of the form `sql".. $a ... $b ..."` with
@@ -16,9 +16,9 @@ import shapeless.ProductArgs
  */
 final class SqlInterpolator(private val sc: StringContext)(implicit pos: Pos) {
 
-  private def mkFragment[A](a: A, token: Boolean)(implicit ev: Param[A]): Fragment = {
+  private def mkFragment[A <: HList](a: A, token: Boolean)(implicit ev: Param[A]): Fragment = {
     val sql = sc.parts.mkString("", "?", if (token) " " else "")
-    Fragment(sql, a, Some(pos))(ev.write)
+    Fragment(sql, ev.elems(a), Some(pos))
   }
 
   /**
@@ -28,7 +28,7 @@ final class SqlInterpolator(private val sc: StringContext)(implicit pos: Pos) {
    * think about intervening whitespace. If you do not want this behavior, use `fr0`.
    */
   object fr extends ProductArgs {
-    def applyProduct[A: Param](a: A): Fragment = mkFragment(a, true)
+    def applyProduct[A <: HList : Param](a: A): Fragment = mkFragment(a, true)
   }
 
   /** Alternative name for the `fr0` interpolator. */
@@ -39,7 +39,7 @@ final class SqlInterpolator(private val sc: StringContext)(implicit pos: Pos) {
    * attempt is made to be helpful with respect to whitespace.
    */
   object fr0 extends ProductArgs {
-    def applyProduct[A: Param](a: A): Fragment = mkFragment(a, false)
+    def applyProduct[A <: HList : Param](a: A): Fragment = mkFragment(a, false)
   }
 
 }

--- a/modules/core/src/main/scala/doobie/util/ExecutionContexts.scala
+++ b/modules/core/src/main/scala/doobie/util/ExecutionContexts.scala
@@ -5,7 +5,6 @@
 package doobie.util
 
 import cats.effect.{ Resource, Sync }
-import cats.implicits._
 import java.util.concurrent.{ Executors, ExecutorService }
 import scala.concurrent.ExecutionContext
 

--- a/modules/core/src/main/scala/doobie/util/fragment.scala
+++ b/modules/core/src/main/scala/doobie/util/fragment.scala
@@ -9,10 +9,10 @@ import cats.implicits._
 
 import doobie._, doobie.implicits._
 import doobie.util.pos.Pos
-
+import doobie.util.param.Param.Elem
+import doobie.enum.Nullability._
+import java.sql.{ PreparedStatement, ResultSet }
 import scala.Predef.augmentString
-
-import shapeless.HNil
 
 /** Module defining the `Fragment` data type. */
 object fragment {
@@ -23,43 +23,59 @@ object fragment {
    * constructed a `Fragment` is opaque; it has no externally observable properties. Fragments are
    * eventually used to construct a [[Query0]] or [[Update0]].
    */
-  sealed trait Fragment { fa =>
+  final class Fragment(
+    protected val sql: String,
+    protected val elems: List[Elem],
+    protected val pos: Option[Pos]
+  ) {
 
-    protected type A                // type of interpolated argument (existential, HNil for none)
-    protected def a: A              // the interpolated argument itself
-    protected def ca: Write[A]  // proof that we can map the argument to parameters
-    protected def sql: String       // snipped of SQL with `ca.length` placeholders
+    // Unfortunately we need to produce a Write for our list of elems, which is a bit of a grunt
+    // but straightforward nonetheless. And it's stacksafe!
+    private implicit lazy val write: Write[elems.type] = {
+      import Elem._
+
+      val puts: List[(Put[_], NullabilityKnown)] =
+        elems.map {
+          case Arg(_, p) => (p, NoNulls)
+          case Opt(_, p) => (p, Nullable)
+        }
+
+      val toList: elems.type => List[Any] = elems =>
+        elems.map {
+          case Arg(a, _) => a
+          case Opt(a, _) => a
+        }
+
+      val unsafeSet: (PreparedStatement, Int, elems.type) => Unit = (ps, n, elems) =>
+        elems.zipWithIndex.foreach {
+          case (Arg(a, p), i) => p.unsafeSetNonNullable(ps, i + n, a)
+          case (Opt(a, p), i) => p.unsafeSetNullable(ps, i + n, a)
+        }
+
+      val unsafeUpdate: (ResultSet, Int, elems.type) => Unit = (ps, n, elems) =>
+        elems.zipWithIndex.foreach {
+          case (Arg(a, p), i) => p.unsafeUpdateNonNullable(ps, i + n, a)
+          case (Opt(a, p), i) => p.unsafeUpdateNullable(ps, i + n, a)
+        }
+
+      new Write(puts, toList, unsafeSet, unsafeUpdate)
+
+    }
 
     /**
      * Construct a program in ConnectionIO that constructs and prepares a PreparedStatement, with
      * further handling delegated to the provided program.
      */
     def execWith[B](fa: PreparedStatementIO[B]): ConnectionIO[B] =
-      HC.prepareStatement(sql)(ca.set(1, a) *> fa)
-
-    // Stack frame, used by the query checker to guess the source position. This will go away at
-    // some point, possibly in favor of Haoyi's source position doodad.
-    protected def pos: Option[Pos]
+      HC.prepareStatement(sql)(write.set(1, elems) *> fa)
 
     /** Concatenate this fragment with another, yielding a larger fragment. */
     def ++(fb: Fragment): Fragment =
-      new Fragment {
-        type A  = (fa.A, fb.A)
-        val ca  = fa.ca product fb.ca
-        val a   = (fa.a, fb.a)
-        val sql = fa.sql + fb.sql
-        val pos = fa.pos orElse fb.pos
-      }
+      new Fragment(sql + fb.sql, elems ++ fb.elems, pos orElse fb.pos)
 
     @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
     def stripMargin(marginChar: Char): Fragment =
-      new Fragment {
-        type A = fa.A
-        val a = fa.a
-        val sql = fa.sql.stripMargin(marginChar)
-        val pos = fa.pos
-        val ca = fa.ca
-      }
+      new Fragment(sql.stripMargin(marginChar), elems, pos)
 
     @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
     def stripMargin: Fragment = stripMargin('|')
@@ -74,7 +90,7 @@ object fragment {
      * `LogHandler`.
      */
     def queryWithLogHandler[B](h: LogHandler)(implicit cb: Read[B]): Query0[B] =
-      Query[A, B](sql, pos, h)(ca, cb).toQuery0(a)
+      Query[elems.type, B](sql, pos, h).toQuery0(elems)
 
     /** Construct an [[Update0]] from this fragment. */
     @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
@@ -83,36 +99,34 @@ object fragment {
 
     /** Construct an [[Update0]] from this fragment with the given `LogHandler`. */
     def updateWithLogHandler(h: LogHandler): Update0 =
-      Update[A](sql, pos, h)(ca).toUpdate0(a)
+      Update[elems.type](sql, pos, h).toUpdate0(elems)
 
     override def toString =
       s"""Fragment("$sql")"""
 
-    /** Used only for testing; this uses universal equality on the captured argument. */
+    /** Used only for testing; this pulls out the arguments as an untyped list. */
+    private def args: List[Any] =
+      elems.map {
+        case Elem.Arg(a, _) => a
+        case Elem.Opt(a, _) => a
+      }
+
+    /** Used only for testing; this uses universal equality on the captured arguments. */
     @SuppressWarnings(Array("org.wartremover.warts.Equals"))
     private[util] def unsafeEquals(fb: Fragment): Boolean =
-      fa.a == fb.a && fa.sql == fb.sql
+      sql == fb.sql && args == fb.args
 
   }
-
   object Fragment {
 
     /**
      * Construct a statement fragment with the given SQL string, which must contain sufficient `?`
-     * placeholders to accommodate the fields of the given interpolated value. This is normally
+     * placeholders to accommodate the given list of interpolated elements. This is normally
      * accomplished via the string interpolator rather than direct construction.
      */
     @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
-    def apply[A0](sql0: String, a0: A0, pos0: Option[Pos] = None)(
-      implicit ev: Write[A0]
-    ): Fragment =
-      new Fragment {
-        type A  = A0
-        val ca  = ev
-        val a   = a0
-        val sql = sql0
-        val pos = pos0
-      }
+    def apply(sql: String, elems: List[Elem], pos: Option[Pos] = None): Fragment =
+      new Fragment(sql, elems, pos)
 
     /**
      * Construct a statement fragment with no interpolated values and no trailing space; the
@@ -120,7 +134,7 @@ object fragment {
      */
     @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
     def const0(sql: String, pos: Option[Pos] = None): Fragment =
-      Fragment[HNil](sql, HNil, pos)
+      new Fragment(sql, Nil, pos)
 
     /**
      * Construct a statement fragment with no interpolated values and a trailing space; the

--- a/modules/core/src/main/scala/doobie/util/fragment.scala
+++ b/modules/core/src/main/scala/doobie/util/fragment.scala
@@ -5,13 +5,13 @@
 package doobie.util
 
 import cats._
+import cats.data.Chain
 import cats.implicits._
 
 import doobie._, doobie.implicits._
 import doobie.util.pos.Pos
 import doobie.util.param.Param.Elem
 import doobie.enum.Nullability._
-import fs2.Catenable
 import java.sql.{ PreparedStatement, ResultSet }
 import scala.Predef.augmentString
 
@@ -26,7 +26,7 @@ object fragment {
    */
   final class Fragment(
     protected val sql: String,
-    protected val elems: Catenable[Elem],
+    protected val elems: Chain[Elem],
     protected val pos: Option[Pos]
   ) {
 
@@ -50,7 +50,7 @@ object fragment {
       @SuppressWarnings(Array("org.wartremover.warts.Var"))
       val unsafeSet: (PreparedStatement, Int, elems.type) => Unit = { (ps, n, elems) =>
         var index = n
-        elems.foreach { e =>
+        elems.iterator.foreach { e =>
           e match {
             case Arg(a, p) => p.unsafeSetNonNullable(ps, index, a)
             case Opt(a, p) => p.unsafeSetNullable(ps, index, a)
@@ -62,7 +62,7 @@ object fragment {
       @SuppressWarnings(Array("org.wartremover.warts.Var"))
       val unsafeUpdate: (ResultSet, Int, elems.type) => Unit = { (ps, n, elems) =>
         var index = n
-        elems.foreach { e =>
+        elems.iterator.foreach { e =>
           e match {
             case Arg(a, p) => p.unsafeUpdateNonNullable(ps, index, a)
             case Opt(a, p) => p.unsafeUpdateNullable(ps, index, a)
@@ -139,7 +139,7 @@ object fragment {
      */
     @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
     def apply(sql: String, elems: List[Elem], pos: Option[Pos] = None): Fragment =
-      new Fragment(sql, Catenable.fromSeq(elems), pos)
+      new Fragment(sql, Chain.fromSeq(elems), pos)
 
     /**
      * Construct a statement fragment with no interpolated values and no trailing space; the
@@ -147,7 +147,7 @@ object fragment {
      */
     @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
     def const0(sql: String, pos: Option[Pos] = None): Fragment =
-      new Fragment(sql, Catenable.empty, pos)
+      new Fragment(sql, Chain.empty, pos)
 
     /**
      * Construct a statement fragment with no interpolated values and a trailing space; the

--- a/modules/core/src/main/scala/doobie/util/fragments.scala
+++ b/modules/core/src/main/scala/doobie/util/fragments.scala
@@ -13,11 +13,11 @@ import cats.implicits._
 object fragments {
 
   /** Returns `f IN (fs0, fs1, ...)`. */
-  def in[F[_]: Reducible, A: Param](f: Fragment, fs: F[A]): Fragment =
+  def in[F[_]: Reducible, A: Put](f: Fragment, fs: F[A]): Fragment =
     fs.toList.map(a => fr0"$a").foldSmash1(f ++ fr0"IN (", fr",", fr")")
 
   /** Returns `f NOT IN (fs0, fs1, ...)`. */
-  def notIn[F[_]: Reducible, A: Param](f: Fragment, fs: F[A]): Fragment =
+  def notIn[F[_]: Reducible, A: Put](f: Fragment, fs: F[A]): Fragment =
     fs.toList.map(a => fr0"$a").foldSmash1(f ++ fr0"NOT IN (", fr",", fr")")
 
   /** Returns `f1 AND f2 AND ... fn`. */

--- a/modules/core/src/main/scala/doobie/util/query.scala
+++ b/modules/core/src/main/scala/doobie/util/query.scala
@@ -77,9 +77,9 @@ object query {
      */
     def pos: Option[Pos]
 
-    /** Turn this `Query` into a `Fragment`, given an argument. */
-    def toFragment(a: A): Fragment =
-      Fragment(sql, a, pos)
+    // /** Turn this `Query` into a `Fragment`, given an argument. */
+    // def toFragment(a: A): Fragment =
+    //   Fragment(sql, ai(a), pos)
 
     /**
      * Program to construct an analysis of this query's SQL statement and asserted parameter and
@@ -188,7 +188,7 @@ object query {
       new Query0[B] {
         def sql = outer.sql
         def pos = outer.pos
-        def toFragment = outer.toFragment(a)
+        // def toFragment = outer.toFragment(a)
         def analysis = outer.analysis
         def outputAnalysis = outer.outputAnalysis
         def streamWithChunkSize(n: Int) = outer.streamWithChunkSize(a, n)
@@ -263,8 +263,8 @@ object query {
      */
     def pos: Option[Pos]
 
-    /** Turn this `Query0` into a `Fragment`. */
-    def toFragment: Fragment
+    // /** Turn this `Query0` into a `Fragment`. */
+    // def toFragment: Fragment
 
     /**
      * Program to construct an analysis of this query's SQL statement and asserted parameter and

--- a/modules/core/src/main/scala/doobie/util/query.scala
+++ b/modules/core/src/main/scala/doobie/util/query.scala
@@ -77,10 +77,6 @@ object query {
      */
     def pos: Option[Pos]
 
-    // /** Turn this `Query` into a `Fragment`, given an argument. */
-    // def toFragment(a: A): Fragment =
-    //   Fragment(sql, ai(a), pos)
-
     /**
      * Program to construct an analysis of this query's SQL statement and asserted parameter and
      * column types.
@@ -262,9 +258,6 @@ object query {
      * @group Diagnostics
      */
     def pos: Option[Pos]
-
-    // /** Turn this `Query0` into a `Fragment`. */
-    // def toFragment: Fragment
 
     /**
      * Program to construct an analysis of this query's SQL statement and asserted parameter and

--- a/modules/core/src/main/scala/doobie/util/update.scala
+++ b/modules/core/src/main/scala/doobie/util/update.scala
@@ -72,10 +72,6 @@ object update {
      */
     val pos: Option[Pos]
 
-    // /** Turn this `Update` into a `Fragment`, given an argument. */
-    // def toFragment(a: A): Fragment =
-    //   Fragment(sql, ai(a), pos)
-
     /**
      * Program to construct an analysis of this query's SQL statement and asserted parameter types.
      * @group Diagnostics
@@ -159,7 +155,6 @@ object update {
       new Update0 {
         val sql = u.sql
         val pos = u.pos
-        // def toFragment = u.toFragment(a)
         def analysis = u.analysis
         def run = u.run(a)
         def withGeneratedKeysWithChunkSize[K: Read](columns: String*)(chunkSize: Int) =
@@ -214,9 +209,6 @@ object update {
      * @group Diagnostics
      */
     val pos: Option[Pos]
-
-    // /** Turn this `Update`0 into a `Fragment`. */
-    // def toFragment: Fragment
 
     /**
      * Program to construct an analysis of this query's SQL statement and asserted parameter types.

--- a/modules/core/src/main/scala/doobie/util/update.scala
+++ b/modules/core/src/main/scala/doobie/util/update.scala
@@ -72,9 +72,9 @@ object update {
      */
     val pos: Option[Pos]
 
-    /** Turn this `Update` into a `Fragment`, given an argument. */
-    def toFragment(a: A): Fragment =
-      Fragment(sql, a, pos)
+    // /** Turn this `Update` into a `Fragment`, given an argument. */
+    // def toFragment(a: A): Fragment =
+    //   Fragment(sql, ai(a), pos)
 
     /**
      * Program to construct an analysis of this query's SQL statement and asserted parameter types.
@@ -159,7 +159,7 @@ object update {
       new Update0 {
         val sql = u.sql
         val pos = u.pos
-        def toFragment = u.toFragment(a)
+        // def toFragment = u.toFragment(a)
         def analysis = u.analysis
         def run = u.run(a)
         def withGeneratedKeysWithChunkSize[K: Read](columns: String*)(chunkSize: Int) =
@@ -215,8 +215,8 @@ object update {
      */
     val pos: Option[Pos]
 
-    /** Turn this `Update`0 into a `Fragment`. */
-    def toFragment: Fragment
+    // /** Turn this `Update`0 into a `Fragment`. */
+    // def toFragment: Fragment
 
     /**
      * Program to construct an analysis of this query's SQL statement and asserted parameter types.

--- a/modules/core/src/test/scala/doobie/issue/780.scala
+++ b/modules/core/src/test/scala/doobie/issue/780.scala
@@ -14,7 +14,7 @@ object `780` extends Specification {
 
   "deriving instances" should {
     "work correctly for Param from class scope" in {
-      class Foo[A: Param, B: Param] {
+      class Foo[A: Put, B: Put] {
         Param[A :: B :: HNil]
       }
       true

--- a/modules/core/src/test/scala/doobie/util/fragment.scala
+++ b/modules/core/src/test/scala/doobie/util/fragment.scala
@@ -62,16 +62,6 @@ object fragmentspec extends Specification {
       s.query[(Int, String, Boolean)].unique.transact(xa).unsafeRunSync must_== ((a, b, c))
     }
 
-    // "translate to and from Query0" in {
-    //   val f = fr"bar $a $b $c baz"
-    //   f.query[HNil].toFragment unsafeEquals f
-    // }
-
-    // "translate to and from Update0" in {
-    //   val f = fr"bar $a $b $c baz"
-    //   f.update.toFragment unsafeEquals f
-    // }
-
     "Add a trailing space when constructed with .const" in {
       Fragment.const("foo").query[Int].sql must_== "foo "
     }

--- a/modules/core/src/test/scala/doobie/util/fragment.scala
+++ b/modules/core/src/test/scala/doobie/util/fragment.scala
@@ -99,6 +99,26 @@ object fragmentspec extends Specification {
           |""".stripMargin.query[Int].sql must_== "select foo || baz\n  from bar\n "
     }
 
+    // A fragment composed of this many sub-fragments would not be stacksafe without special
+    // handling, which we test below.
+    val STACK_UNSAFE_SIZE = 20000
+
+    "be stacksafe (left-associve)" in {
+      val frag =
+        fr0"SELECT 1 WHERE 1 IN (" ++
+        List.fill(STACK_UNSAFE_SIZE)(1).foldLeft(Fragment.empty)((f, n) => f ++ fr"$n,") ++
+        fr0"1)"
+      frag.query[Int].unique.transact(xa).unsafeRunSync must_== 1
+    }
+
+    "be stacksafe (right-associve)" in {
+      val frag =
+        fr0"SELECT 1 WHERE 1 IN (" ++
+        List.fill(STACK_UNSAFE_SIZE)(1).foldRight(Fragment.empty)((n, f) => f ++ fr"$n,") ++
+        fr0"1)"
+      frag.query[Int].unique.transact(xa).unsafeRunSync must_== 1
+    }
+
   }
 
 }

--- a/modules/core/src/test/scala/doobie/util/fragment.scala
+++ b/modules/core/src/test/scala/doobie/util/fragment.scala
@@ -62,15 +62,15 @@ object fragmentspec extends Specification {
       s.query[(Int, String, Boolean)].unique.transact(xa).unsafeRunSync must_== ((a, b, c))
     }
 
-    "translate to and from Query0" in {
-      val f = fr"bar $a $b $c baz"
-      f.query[HNil].toFragment unsafeEquals f
-    }
+    // "translate to and from Query0" in {
+    //   val f = fr"bar $a $b $c baz"
+    //   f.query[HNil].toFragment unsafeEquals f
+    // }
 
-    "translate to and from Update0" in {
-      val f = fr"bar $a $b $c baz"
-      f.update.toFragment unsafeEquals f
-    }
+    // "translate to and from Update0" in {
+    //   val f = fr"bar $a $b $c baz"
+    //   f.update.toFragment unsafeEquals f
+    // }
 
     "Add a trailing space when constructed with .const" in {
       Fragment.const("foo").query[Int].sql must_== "foo "

--- a/modules/core/src/test/scala/doobie/util/param.scala
+++ b/modules/core/src/test/scala/doobie/util/param.scala
@@ -21,15 +21,15 @@ object paramspec extends Specification {
       true
     }
 
-    // "exist for any Put" in {
-    //   def foo[A: Put] = Param[A]
-    //   true
-    // }
+    "exist for A :: HNil given Put[A]" in {
+      def foo[A: Put] = Param[A :: HNil]
+      true
+    }
 
-    // "exist for any Option of Put" in {
-    //   def foo[A: Put] = Param[Option[A]]
-    //   true
-    // }
+    "exist for Option[A] :: HNil given Put[A]" in {
+      def foo[A: Put] = Param[Option[A] :: HNil]
+      true
+    }
 
     "exist for any HList with Put for head" in {
       def foo[A: Put, B <: HList : Param] = Param[A :: B]

--- a/modules/core/src/test/scala/doobie/util/param.scala
+++ b/modules/core/src/test/scala/doobie/util/param.scala
@@ -21,16 +21,15 @@ object paramspec extends Specification {
       true
     }
 
-    "exist for any Put" in {
-      def foo[A: Put] = Param[A]
-      true
-    }
+    // "exist for any Put" in {
+    //   def foo[A: Put] = Param[A]
+    //   true
+    // }
 
-    "exist for any Option of Put" in {
-      def foo[A: Put] = Param[Option[A]]
-      true
-    }
-
+    // "exist for any Option of Put" in {
+    //   def foo[A: Put] = Param[Option[A]]
+    //   true
+    // }
 
     "exist for any HList with Put for head" in {
       def foo[A: Put, B <: HList : Param] = Param[A :: B]

--- a/modules/h2/src/test/scala/doobie/h2/h2types.scala
+++ b/modules/h2/src/test/scala/doobie/h2/h2types.scala
@@ -24,11 +24,18 @@ object h2typesspec extends Specification {
     "sa", ""
   )
 
-  def inOut[A: Param: Read](col: String, a: A) =
+  def inOut[A: Put: Get](col: String, a: A): ConnectionIO[A] =
     for {
       _  <- Update0(s"CREATE LOCAL TEMPORARY TABLE TEST (value $col)", None).run
       _  <- sql"INSERT INTO TEST VALUES ($a)".update.run
       a0 <- sql"SELECT value FROM TEST".query[A].unique
+    } yield (a0)
+
+  def inOutOpt[A: Put: Get](col: String, a: Option[A]): ConnectionIO[Option[A]] =
+    for {
+      _  <- Update0(s"CREATE LOCAL TEMPORARY TABLE TEST (value $col)", None).run
+      _  <- sql"INSERT INTO TEST VALUES ($a)".update.run
+      a0 <- sql"SELECT value FROM TEST".query[Option[A]].unique
     } yield (a0)
 
   def testInOut[A](col: String, a: A)(implicit m: Get[A], p: Put[A]) =
@@ -37,10 +44,10 @@ object h2typesspec extends Specification {
         inOut(col, a).transact(xa).attempt.unsafeRunSync must_== Right(a)
       }
       s"write+read $col as Option[${m.typeStack}] (Some)" in {
-        inOut[Option[A]](col, Some(a)).transact(xa).attempt.unsafeRunSync must_== Right(Some(a))
+        inOutOpt[A](col, Some(a)).transact(xa).attempt.unsafeRunSync must_== Right(Some(a))
       }
       s"write+read $col as Option[${m.typeStack}] (None)" in {
-        inOut[Option[A]](col, None).transact(xa).attempt.unsafeRunSync must_== Right(None)
+        inOutOpt[A](col, None).transact(xa).attempt.unsafeRunSync must_== Right(None)
       }
     }
 

--- a/modules/hikari/src/main/scala/doobie/hikari/HikariTransactor.scala
+++ b/modules/hikari/src/main/scala/doobie/hikari/HikariTransactor.scala
@@ -6,7 +6,6 @@ package doobie
 package hikari
 
 import cats.effect._
-import cats.implicits._
 import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
 import scala.concurrent.ExecutionContext
 

--- a/modules/postgres-circe/src/test/scala/doobie/postrges/circe/pgjsonspec.scala
+++ b/modules/postgres-circe/src/test/scala/doobie/postrges/circe/pgjsonspec.scala
@@ -29,10 +29,7 @@ object pgjsonspec extends Specification {
       a0 <- Update[A](s"INSERT INTO TEST VALUES (?)", None).withUniqueGeneratedKeys[A]("value")(a)
     } yield a0
 
-  def testInOut[A](col: String, a: A, t: Transactor[IO])(implicit m: Get[A], p: Put[A]) = {
-
-    Param.hcons[A, shapeless.HNil]
-
+  def testInOut[A](col: String, a: A, t: Transactor[IO])(implicit m: Get[A], p: Put[A]) =
     s"Mapping for $col as ${m.typeStack}" >> {
       s"write+read $col as ${m.typeStack}" in {
         inOut(col, a).transact(t).attempt.unsafeRunSync must_== Right(a)
@@ -44,7 +41,6 @@ object pgjsonspec extends Specification {
         inOut[Option[A]](col, None).transact(t).attempt.unsafeRunSync must_== Right(None)
       }
     }
-  }
 
   {
     import doobie.postgres.circe.json.implicits._

--- a/modules/postgres/src/test/scala/doobie/postgres/pgtypes.scala
+++ b/modules/postgres/src/test/scala/doobie/postgres/pgtypes.scala
@@ -30,11 +30,17 @@ object pgtypesspec extends Specification {
     "postgres", ""
   )
 
-  def inOut[A: Param: Write: Read](col: String, a: A) =
+  def inOut[A: Get: Put](col: String, a: A): ConnectionIO[A] =
     for {
       _  <- Update0(s"CREATE TEMPORARY TABLE TEST (value $col)", None).run
       a0 <- Update[A](s"INSERT INTO TEST VALUES (?)", None).withUniqueGeneratedKeys[A]("value")(a)
-    } yield (a0)
+    } yield a0
+
+  def inOutOpt[A: Get: Put](col: String, a: Option[A]): ConnectionIO[Option[A]] =
+    for {
+      _  <- Update0(s"CREATE TEMPORARY TABLE TEST (value $col)", None).run
+      a0 <- Update[Option[A]](s"INSERT INTO TEST VALUES (?)", None).withUniqueGeneratedKeys[Option[A]]("value")(a)
+    } yield a0
 
   def testInOut[A](col: String, a: A)(implicit m: Get[A], p: Put[A]) =
     s"Mapping for $col as ${m.typeStack}" >> {
@@ -42,10 +48,10 @@ object pgtypesspec extends Specification {
         inOut(col, a).transact(xa).attempt.unsafeRunSync must_== Right(a)
       }
       s"write+read $col as Option[${m.typeStack}] (Some)" in {
-        inOut[Option[A]](col, Some(a)).transact(xa).attempt.unsafeRunSync must_== Right(Some(a))
+        inOutOpt[A](col, Some(a)).transact(xa).attempt.unsafeRunSync must_== Right(Some(a))
       }
       s"write+read $col as Option[${m.typeStack}] (None)" in {
-        inOut[Option[A]](col, None).transact(xa).attempt.unsafeRunSync must_== Right(None)
+        inOutOpt[A](col, None).transact(xa).attempt.unsafeRunSync must_== Right(None)
       }
     }
 


### PR DESCRIPTION
This makes `Fragment` composition stacksafe.

- Stack overflows occur when we compose `Fragment`s via combinators like `Fragments.in`. This happens because we rely on semigroupal composition of `Write` which isn't stacksafe.
- If instead `Fragment` maintained (conceptually) `elems: Chain[(A, Put[A]) forSome { type A}]` then we could compose fragments trivially by simple concatenation. We could then construct a stacksafe `Write[elems.type]` when it's time to turn the `Fragment` into a `Query`/`Update`. The singleton type gets buried and the user never sees it.

A consequence of this design is that it's no longer possible to turn a `Query`/`Update` back into a `Fragment`. I think this is probably ok.

