### PR TITLE
Add Adopters list to documentation

### DIFF
--- a/modules/docs/src/main/mdoc/index.md
+++ b/modules/docs/src/main/mdoc/index.md
@@ -119,3 +119,24 @@ sbt:docs> makeSite
 sbt:doce> ghpagesPushSite
 ```
 
+
+## Adopters
+
+Here's a (non-exhaustive) list of companies that use doobie in production.
+Don't see yours? [You can add it in a PR!](https://github.com/tpolecat/doobie/edit/master/modules/docs/src/main/mdoc/index.md)
+
+ - [Banno at Jack Henry & Associates](https://banno.com/)
+ - [Crunchbase](https://crunchbase.com)
+ - [Doomoolmori](https://doomoolmori.com)   
+ - [eBay Inc.](https://www.ebay.com)
+ - [HIFI](https://hi.fi)
+ - [ITV](https://www.itv.com/)
+ - [lences.io](https://lenses.io)  
+ - [Medidata](https://www.medidata.com/)
+ - [NOIRLab](https://noirlab.edu)
+ - [RaiffeisenBank Russia](https://raiffeisen.ru)
+ - [ReachFive](www.reachfive.com)
+ - [Rudder](https://rudder.io)
+ - [SoftwareMill](https://softwaremill.com)
+ - [Unit](https://unit.co)
+


### PR DESCRIPTION
The idea is to create the list of Adopters that use `doobie` in production, similar to what [Cats has in README](https://github.com/typelevel/cats/blob/master/README.md#adopters).
The motivation is to promote the library and make people feel more confident.
Thanks everyone!