### PR TITLE
Switch to Scala CoC

### DIFF
--- a/modules/docs/src/main/tut/index.md
+++ b/modules/docs/src/main/tut/index.md
@@ -38,7 +38,7 @@ And then …
 find("France").transact(xa).unsafeRunSync
 ```
 
-**doobie** is a [**Typelevel**](http://typelevel.org/) project. This means we embrace pure, typeful, functional programming, and provide a safe and friendly environment for teaching, learning, and contributing as described in the Typelevel [**Code of Conduct**](http://typelevel.org/conduct.html).
+**doobie** is a [**Typelevel**](http://typelevel.org/) project. This means we embrace pure, typeful, functional programming, and provide a safe and friendly environment for teaching, learning, and contributing as described in the Scala [**Code of Conduct**](http://scala-lang.org/conduct.html).
 
 ## Quick Start
 


### PR DESCRIPTION
This switches from the deprecated Typelevel Code of Conduct to the newer Scala Code of Conduct.