### PR TITLE
convert docs from tut to mdoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -552,8 +552,7 @@ lazy val docs = project
   .settings(crossScalaNo213)
   .settings(noPublishSettings)
   .settings(
-    scalacOptions in Tut --= Seq("-Ywarn-unused:imports", "-Yno-imports", "-Ywarn-unused:params"),
-    scalacOptions in Tut ++= Seq("-Ydelambdafy:inline"), // http://fs2.io/faq.html
+    scalacOptions --= Seq("-Ywarn-unused:imports", "-Yno-imports", "-Ywarn-unused:params"),
 
     libraryDependencies ++= Seq(
       "io.circe"    %% "circe-core"    % circeVersion,
@@ -604,7 +603,9 @@ lazy val docs = project
     micrositeExtraMdFiles := Map(
       file("CHANGELOG.md") -> ExtraMdFileConfig("changelog.md", "page", Map("title" -> "changelog", "section" -> "changelog", "position" -> "4")),
       file("LICENSE")      -> ExtraMdFileConfig("license.md",   "page", Map("title" -> "license",   "section" -> "license",   "position" -> "5"))
-    )
+    ),
+    micrositeCompilingDocsTool := WithMdoc,
+    mdocIn                     := sourceDirectory.value / "main" / "tut"
   )
 
 lazy val refined = project

--- a/modules/core/src/main/scala/doobie/util/Colors.scala
+++ b/modules/core/src/main/scala/doobie/util/Colors.scala
@@ -1,0 +1,84 @@
+// Copyright (c) 2013-2018 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.util
+
+trait Colors {
+  def BLACK     : String
+  def RED       : String
+  def GREEN     : String
+  def YELLOW    : String
+  def BLUE      : String
+  def MAGENTA   : String
+  def CYAN      : String
+  def WHITE     : String
+  def BLACK_B   : String
+  def RED_B     : String
+  def GREEN_B   : String
+  def YELLOW_B  : String
+  def BLUE_B    : String
+  def MAGENTA_B : String
+  def CYAN_B    : String
+  def WHITE_B   : String
+  def RESET     : String
+  def BOLD      : String
+  def UNDERLINED: String
+  def BLINK     : String
+  def REVERSED  : String
+  def INVISIBLE : String
+}
+
+object Colors {
+
+  object Ansi extends Colors {
+    val BLACK      = "\u001b[30m"
+    val RED        = "\u001b[31m"
+    val GREEN      = "\u001b[32m"
+    val YELLOW     = "\u001b[33m"
+    val BLUE       = "\u001b[34m"
+    val MAGENTA    = "\u001b[35m"
+    val CYAN       = "\u001b[36m"
+    val WHITE      = "\u001b[37m"
+    val BLACK_B    = "\u001b[40m"
+    val RED_B      = "\u001b[41m"
+    val GREEN_B    = "\u001b[42m"
+    val YELLOW_B   = "\u001b[43m"
+    val BLUE_B     = "\u001b[44m"
+    val MAGENTA_B  = "\u001b[45m"
+    val CYAN_B     = "\u001b[46m"
+    val WHITE_B    = "\u001b[47m"
+    val RESET      = "\u001b[0m"
+    val BOLD       = "\u001b[1m"
+    val UNDERLINED = "\u001b[4m"
+    val BLINK      = "\u001b[5m"
+    val REVERSED   = "\u001b[7m"
+    val INVISIBLE  = "\u001b[8m"
+  }
+
+  object None extends Colors {
+    val BLACK      = ""
+    val RED        = ""
+    val GREEN      = ""
+    val YELLOW     = ""
+    val BLUE       = ""
+    val MAGENTA    = ""
+    val CYAN       = ""
+    val WHITE      = ""
+    val BLACK_B    = ""
+    val RED_B      = ""
+    val GREEN_B    = ""
+    val YELLOW_B   = ""
+    val BLUE_B     = ""
+    val MAGENTA_B  = ""
+    val CYAN_B     = ""
+    val WHITE_B    = ""
+    val RESET      = ""
+    val BOLD       = ""
+    val UNDERLINED = ""
+    val BLINK      = ""
+    val REVERSED   = ""
+    val INVISIBLE  = ""
+  }
+
+}

--- a/modules/core/src/main/scala/doobie/util/ExecutionContexts.scala
+++ b/modules/core/src/main/scala/doobie/util/ExecutionContexts.scala
@@ -28,4 +28,10 @@ object ExecutionContexts {
     Resource.make(alloc)(free).map(ExecutionContext.fromExecutor)
   }
 
+  /** Execution context that runs everthing synchronously. This can be useful for testing. */
+  object synchronous extends ExecutionContext {
+    def execute(runnable: Runnable): Unit = runnable.run()
+    def reportFailure(cause: Throwable): Unit = cause.printStackTrace()
+  }
+
 }

--- a/modules/core/src/main/scala/doobie/util/testing.scala
+++ b/modules/core/src/main/scala/doobie/util/testing.scala
@@ -27,6 +27,7 @@ package testing {
     // Effect type, required instances
     implicit def M: Effect[M]
     def transactor: Transactor[M]
+    def colors: Colors = Colors.Ansi
   }
 
   /** Common data for all query-like types. */
@@ -176,23 +177,24 @@ package object testing {
     */
   def formatReport(
     args: AnalysisArgs,
-    report: AnalysisReport
+    report: AnalysisReport,
+    colors: Colors
   ): Block = {
     val sql = args.cleanedSql
       .wrap(68)
       // SQL should use the default color
-      .padLeft(Console.RESET.toString)
-    val items = report.items.foldMap(formatItem)
+      .padLeft(colors.RESET.toString)
+    val items = report.items.foldMap(formatItem(colors))
     Block.fromString(args.header)
       .above(sql)
       .above(items)
   }
 
-  private val formatItem: AnalysisReport.Item => Block = {
+  private def formatItem(colors: Colors): AnalysisReport.Item => Block = {
     case AnalysisReport.Item(desc, None) =>
-      Block.fromString(s"${Console.GREEN}✓${Console.RESET} $desc")
+      Block.fromString(s"${colors.GREEN}✓${colors.RESET} $desc")
     case AnalysisReport.Item(desc, Some(err)) =>
-      Block.fromString(s"${Console.RED}✕${Console.RESET} $desc")
+      Block.fromString(s"${colors.RED}✕${colors.RESET} $desc")
         // No color for error details - ScalaTest paints each line of failure
         // red by default.
         .above(err.wrap(66).padLeft("  "))

--- a/modules/docs/src/main/resources/microsite/css/tweak.css
+++ b/modules/docs/src/main/resources/microsite/css/tweak.css
@@ -8,3 +8,6 @@
 pre .hljs {
   padding: 15px;
 }
+.hljs-comment {
+  color: #aca;
+}

--- a/modules/docs/src/main/tut/docs/01-Introduction.md
+++ b/modules/docs/src/main/tut/docs/01-Introduction.md
@@ -90,27 +90,27 @@ If you are not using PostgreSQL you can omit `doobie-postgres` and will need to 
 
 Each page begins with some imports, like this.
 
-```tut:silent
+```scala mdoc:silent
 import cats._, cats.data._, cats.implicits._
 import doobie._
 ```
 
 After that there is text interspersed with code examples. Sometimes definitions will stand alone.
 
-```tut:silent
+```scala mdoc:silent
 case class Person(name: String, age: Int)
 val nel = NonEmptyList.of(Person("Bob", 12), Person("Alice", 14))
 ```
-And sometimes they will appear as a REPL interaction.
 
-```tut
+And sometimes they will appear with output.
+
+```scala mdoc
 nel.head
 nel.tail
 ```
-
 Sometimes we demonstrate that something doesn't compile. In such cases it will be clear from the context that this is expected, and not a problem with the documentation.
 
-```tut:nofail
+```scala mdoc:fail
 woozle(nel) // doesn't compile
 ```
 

--- a/modules/docs/src/main/tut/docs/16-Extensions-H2.md
+++ b/modules/docs/src/main/tut/docs/16-Extensions-H2.md
@@ -37,7 +37,7 @@ See the previous chapter on **SQL Arrays** for usage examples.
 
 **doobie** provides a `Transactor` that wraps the connection pool provided by H2. Because the transactor has internal state, constructing one is a side-effect that must be captured (here by `IO`).
 
-```tut:silent:reset
+```scala mdoc:silent:reset
 import cats.effect._
 import cats.implicits._
 import doobie._

--- a/modules/docs/src/main/tut/docs/17-FAQ.md
+++ b/modules/docs/src/main/tut/docs/17-FAQ.md
@@ -8,7 +8,7 @@ title: Frequently-Asked Questions
 
 In this chapter we address some frequently-asked questions, in no particular order. First a bit of set-up.
 
-```tut:silent
+```scala mdoc:silent
 import cats._
 import cats.data._
 import cats.effect.IO
@@ -16,26 +16,28 @@ import cats.effect.implicits._
 import cats.implicits._
 import doobie._
 import doobie.implicits._
+import doobie.util.ExecutionContexts
 import java.awt.geom.Point2D
 import java.util.UUID
 import shapeless._
-import scala.concurrent.ExecutionContext
 
 // We need a ContextShift[IO] before we can construct a Transactor[IO]. The passed ExecutionContext
-// is where nonblocking operations will be executed.
-implicit val cs = IO.contextShift(ExecutionContext.global)
+// is where nonblocking operations will be executed. For testing here we're using a synchronous EC.
+implicit val cs = IO.contextShift(ExecutionContexts.synchronous)
 
 // A transactor that gets connections from java.sql.DriverManager and executes blocking operations
-// on an unbounded pool of daemon threads. See the chapter on connection handling for more info.
+// on an our synchronous EC. See the chapter on connection handling for more info.
 val xa = Transactor.fromDriverManager[IO](
-  "org.postgresql.Driver", // driver classname
-  "jdbc:postgresql:world", // connect URL (driver-specific)
-  "postgres",              // user
-  ""                       // password
+  "org.postgresql.Driver",     // driver classname
+  "jdbc:postgresql:world",     // connect URL (driver-specific)
+  "postgres",                  // user
+  "",                          // password
+  ExecutionContexts.synchronous // just for testing
 )
+```
 
-val y = xa.yolo
-import y._
+```scala mdoc:invisible
+implicit val mdocColors: doobie.util.Colors = doobie.util.Colors.None
 ```
 
 ### How do I do an `IN` clause?
@@ -46,10 +48,14 @@ This used to be very irritating, but as of 0.4.0 there is a good solution. See t
 
 Interpolated parameters are replaced with `?` placeholders, so if you need to ascribe an SQL type you can use vendor-specific syntax in conjunction with the interpolated value. For example, in PostgreSQL you use `:: type`:
 
-```tut
-val s = "foo"
-sql"select $s".query[String].check.unsafeRunSync
-sql"select $s :: char".query[String].check.unsafeRunSync
+```scala mdoc
+{
+  val y = xa.yolo
+  import y._
+  val s = "foo"
+  sql"select $s".query[String].check.unsafeRunSync
+  sql"select $s :: char".query[String].check.unsafeRunSync
+}
 ```
 
 ### How do I do several things in the same transaction?
@@ -60,7 +66,7 @@ You can use a `for` comprehension to compose any number of `ConnectionIO` progra
 
 `Transactor.transact` takes a `ConnectionIO` and constructs an `IO` or similar that will run it in a single transaction, but it is also possible to include transaction boundaries *within* a `ConnectionIO`, and to disable transaction handling altogether. Some kinds of DDL statements may require this for some databases. You can define a combinator to do this for you.
 
-```tut:silent
+```scala mdoc:silent
 /**
  * Take a program `p` and return an equivalent one that first commits
  * any ongoing transaction, runs `p` without transaction handling, then
@@ -77,7 +83,7 @@ Note that you need both of these operations if you are using a `Transactor` beca
 
 As of **doobie** 0.4.0 this is done via [statement fragments](08-Fragments.html). Here we choose the sort order dynamically.
 
-```tut:silent
+```scala mdoc:silent
 case class Code(country: String)
 case class City(code: Code, name: String, population: Int)
 
@@ -94,24 +100,32 @@ def cities(code: Code, asc: Boolean): Query0[City] = {
 
 We can check the resulting `Query0` as expected.
 
-```tut:plain
-cities(Code("USA"), true).check.unsafeRunSync
+```scala mdoc
+{
+  val y = xa.yolo
+  import y._
+  cities(Code("USA"), true).check.unsafeRunSync
+}
 ```
 
 And it works!
 
-```tut
-cities(Code("USA"), true).stream.take(5).quick.unsafeRunSync
-cities(Code("USA"), false).stream.take(5).quick.unsafeRunSync
+```scala mdoc
+{
+  val y = xa.yolo
+  import y._
+  cities(Code("USA"), true).stream.take(5).quick.unsafeRunSync
+  cities(Code("USA"), false).stream.take(5).quick.unsafeRunSync
+}
 ```
 
 ### How do I handle outer joins?
 
 With an outer join you end up with set of nullable columns, which you typically want to map to a single `Option` of some composite type, which doobie can do for you. If all columns are null you will get back `None`.
 
-```tut:silent
+```scala mdoc:silent
 case class Country(name: String, code: String)
-case class City(name: String, district: String)
+case class City2(name: String, district: String)
 
 val join =
   sql"""
@@ -120,13 +134,17 @@ val join =
     from country c
     left outer join city k
     on c.capital = k.id
-  """.query[(Country, Option[City])]
+  """.query[(Country, Option[City2])]
 ```
 
 Some examples, filtered for size.
 
-```tut
-join.stream.filter(_._1.name.startsWith("United")).quick.unsafeRunSync
+```scala mdoc
+{
+  val y = xa.yolo
+  import y._
+  join.stream.filter(_._1.name.startsWith("United")).quick.unsafeRunSync
+}
 ```
 
 ### How do I log the SQL produced for my query after interpolation?
@@ -137,7 +155,7 @@ As of **doobie** 0.4 there is a reasonable solution to the logging/instrumentati
 
 There are a lot of ways to handle `SQLXML` so there is no pre-defined strategy, but here is one that maps `scala.xml.Elem` to `SQLXML` via streaming.
 
-```tut:silent
+```scala mdoc:silent
 import doobie.enum.JdbcType.Other
 import java.sql.SQLXML
 import scala.xml.{ XML, Elem }
@@ -166,7 +184,7 @@ By default streams constructed with the `sql` interpolator are fetched `Query.De
 
 Domains with check constraints will type check as DISTINCT. For Doobie later than 0.4.4, in order to get the type checks to pass, you can define a `Meta` of with target type Distinct and `xmap` that instances. For example,
 
-```tut:silent
+```scala mdoc:silent
 import cats.data.NonEmptyList
 import doobie._
 import doobie.enum.JdbcType

--- a/modules/docs/src/main/tut/index.md
+++ b/modules/docs/src/main/tut/index.md
@@ -14,7 +14,7 @@ layout: home
 
 **doobie** is a pure functional JDBC layer for Scala and [**Cats**](http://typelevel.org/cats/). It is not an ORM, nor is it a relational algebra; it simply provides a functional way to construct programs (and higher-level libraries) that use JDBC. For common use cases **doobie** provides a minimal but expressive high-level API:
 
-```tut:silent
+```scala mdoc:silent
 import doobie._
 import doobie.implicits._
 import cats.effect.IO
@@ -34,7 +34,7 @@ def find(n: String): ConnectionIO[Option[Country]] =
 
 And then …
 
-```tut
+```scala mdoc
 find("France").transact(xa).unsafeRunSync
 ```
 
@@ -98,3 +98,10 @@ Listed newest first. If you have given a presentation or have written a blog pos
 ## Testing
 
 If you want to build and run the tests for yourself, you'll need a local postgresql database. Tests are run as the default **postgres** user, which should have no password for access in the local environment. You can see the `before_script` section of the [.travis.yml](./.travis.yml) file for an up-to-date list of steps for preparing the test database.
+
+<!-- This stuff isn't in the Home layout anymore so I pasted it here. -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
+<script src="{{site.url}}{{site.baseurl}}/highlight/highlight.pack.js"></script>
+<script>hljs.configure({languages:['scala','java','bash']}); hljs.initHighlighting();</script>
+<script src="{{ site.baseurl }}/js/main.js"></script>

--- a/modules/docs/src/main/tut/infographic.md
+++ b/modules/docs/src/main/tut/infographic.md
@@ -11,5 +11,5 @@ This is an embedded SVG image. Click it to visit the [repository](https://github
 
 
 <a href="https://github.com/tpolecat/doobie-infographic"><img
-  style="width: 100%; margin: 20px" src="https://cdn.rawgit.com/tpolecat/doobie-infographic/master/doobie.svg"
+  style="width: 100%; margin: 20px" src="https://cdn.rawgit.com/tpolecat/doobie-infographic/v0.6.0/doobie.svg"
 /></a>

--- a/modules/scalatest/src/main/scala/doobie/scalatest/AnalysisMatchers.scala
+++ b/modules/scalatest/src/main/scala/doobie/scalatest/AnalysisMatchers.scala
@@ -42,7 +42,7 @@ trait AnalysisMatchers[F[_]] extends CheckerBase[F] {
       Vector(
         // Avoid formatting if the check performed as expected
         LazyArg(()) { _ =>
-          formatReport(args, report).padLeft("  ").toString
+          formatReport(args, report, colors).padLeft("  ").toString
         }
       )
     )

--- a/modules/scalatest/src/main/scala/doobie/scalatest/Checker.scala
+++ b/modules/scalatest/src/main/scala/doobie/scalatest/Checker.scala
@@ -54,7 +54,7 @@ trait Checker[M[_]] extends CheckerBase[M] { self: Assertions =>
     val report = analyzeIO(args, transactor).unsafeRunSync
     if (!report.succeeded) {
       fail(
-        formatReport(args, report)
+        formatReport(args, report, colors)
           .padLeft("  ")
           .toString
       )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("com.jsuereth"       % "sbt-pgp"         % "1.1.2")
 addSbtPlugin("com.github.gseitz"  % "sbt-release"     % "1.0.11")
 addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"    % "2.0")
-addSbtPlugin("com.47deg"          % "sbt-microsites"  % "0.7.27")
+addSbtPlugin("com.47deg"          % "sbt-microsites"  % "0.9.1")
 addSbtPlugin("org.scoverage"      % "sbt-scoverage"   % "1.5.1")
 addSbtPlugin("org.wartremover"    % "sbt-wartremover" % "2.4.1")
 addSbtPlugin("com.timushev.sbt"   % "sbt-updates"     % "0.4.0")


### PR DESCRIPTION
This converts the docs from tut to mdoc and also parameterizes stuff on colorization and changes execution to be single-threaded so output shows up in time to be captured by mdoc.