### PR TITLE
Fix typo in "Using Your Own Target Monad"

### DIFF
--- a/modules/docs/src/main/tut/docs/03-Connecting.md
+++ b/modules/docs/src/main/tut/docs/03-Connecting.md
@@ -164,5 +164,5 @@ val mxa = Transactor.fromDriverManager[Task](
   "org.postgresql.Driver", "jdbc:postgresql:world", "postgres", ""
 )
 
-sql"select 42".query[Int].unique.transact(xa)
+sql"select 42".query[Int].unique.transact(mxa)
 ```


### PR DESCRIPTION
After showing how to create a Monix `Task` `Transactor` the docs should show how to use that transactor rather than the `IO` one introduced earlier.