### PR TITLE
update circe, fs2; remove 2.11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ dist: xenial
 stages:
   - name: test
 
-scala_version_211: &scala_version_211 "2.11.12"
 scala_version_212: &scala_version_212 "2.12.9"
 scala_version_213: &scala_version_213 "2.13.0"
 
@@ -33,15 +32,9 @@ jobs:
       script:
         - sbt ++$TRAVIS_SCALA_VERSION test
         - sbt ++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues
-      scala: *scala_version_211
-      jdk: *java_8
-    - <<: *tests
+        - sbt ++$TRAVIS_SCALA_VERSION -J-XX:+UseG1GC docs/tutQuick
       scala: *scala_version_212
       jdk: *java_8
-      script:
-        - sbt ++$TRAVIS_SCALA_VERSION test
-        - sbt ++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues
-        - sbt ++$TRAVIS_SCALA_VERSION -J-XX:+UseG1GC docs/tutQuick
     - <<: *tests
       scala: *scala_version_213
       jdk: *java_8

--- a/build.sbt
+++ b/build.sbt
@@ -5,22 +5,21 @@ import microsites._
 // Library versions all in one place, for convenience and sanity.
 lazy val catsVersion          = "2.0.0"
 lazy val catsEffectVersion    = "2.0.0"
-lazy val circeVersion         = "0.12.0-M3"
-lazy val fs2Version           = "1.1.0-M1"
+lazy val circeVersion         = "0.12.1"
+lazy val fs2Version           = "2.0.0"
 lazy val h2Version            = "1.4.199"
 lazy val hikariVersion        = "3.3.1"
 lazy val kindProjectorVersion = "0.10.3"
 lazy val monixVersion         = "3.0.0"
 lazy val quillVersion         = "3.4.4"
 lazy val postGisVersion       = "2.3.0"
-lazy val postgresVersion      = "42.2.6"
+lazy val postgresVersion      = "42.2.6"  // 42.2.7 has a bug in `inet` type, skip that release
 lazy val refinedVersion       = "0.9.9"
 lazy val scalaCheckVersion    = "1.14.0"
 lazy val scalatestVersion     = "3.0.8"
 lazy val shapelessVersion     = "2.3.3"
 lazy val sourcecodeVersion    = "0.1.7"
 lazy val specs2Version        = "4.7.0"
-lazy val scala211Version      = "2.11.12"
 lazy val scala212Version      = "2.12.9"
 lazy val scala213Version      = "2.13.0"
 lazy val slf4jVersion         = "1.7.28"
@@ -255,10 +254,10 @@ lazy val modules: List[ProjectReference] = List(
 
 
 lazy val crossScalaAll = Seq(
-  crossScalaVersions := Seq(scala211Version, scala212Version, scala213Version)
+  crossScalaVersions := Seq(scala212Version, scala213Version)
 )
 lazy val crossScalaNo213 = Seq(
-  crossScalaVersions := Seq(scala211Version, scala212Version)
+  crossScalaVersions := Seq(scala212Version)
 )
 
 lazy val doobieSettings = buildSettings ++ commonSettings

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,2 +1,2 @@
 // TODO: how to share with main build?
-libraryDependencies += "org.postgresql" % "postgresql" % "42.2.6"
+libraryDependencies += "org.postgresql" % "postgresql" % "42.2.6" // 42.2.7 has a bug in `inet` type, skip that release


### PR DESCRIPTION
Like it says on the tin. Circe isn't available for 2.11 anymore so I'm dropping support here as well.

Note that Postgres JDBC driver 42.2.7 is out but I'm skipping it because the newly-added mapping from `inet` ⟷ `InetAddress` is buggy and the existing mapping via `PGObject` no longer works. There's a fix planned for 42.2.8 so I'll wait for that and try again.