### PR TITLE
Removed instructions for partial-unification in docs, as it is now included by default

### DIFF
--- a/modules/docs/src/main/tut/docs/01-Introduction.md
+++ b/modules/docs/src/main/tut/docs/01-Introduction.md
@@ -71,7 +71,7 @@ On the Scala side you just need a console with the proper dependencies. A minima
 ```scala
 scalaVersion := "{{site.scalaVersion}}" // Scala {{site.scalaVersions}}
 
-scalacOptions += "-Ypartial-unification" // 2.11.9+
+scalacOptions += "-Ypartial-unification" // if scalaVersion < 2.13 
 
 lazy val doobieVersion = "{{site.doobieVersion}}"
 
@@ -82,7 +82,7 @@ libraryDependencies ++= Seq(
 )
 ```
 
-The `-Ypartial-unification` compiler flag enables a bug fix that makes working with functional code significantly easier. See the Cats [Getting Started](https://github.com/typelevel/cats#getting-started) for more info on this if it interests you.
+For scalaVersion < 2.13, the `-Ypartial-unification` compiler flag enables a bug fix that makes working with functional code significantly easier. See the Cats [Getting Started](https://github.com/typelevel/cats#getting-started) for more info on this if it interests you. The latest version of scala [enabled this by default](https://github.com/typelevel/cats/issues/2948).
 
 If you are not using PostgreSQL you can omit `doobie-postgres` and will need to add the appropriate JDBC driver as a dependency. Note that there is a `doobie-h2` add-on if you happen to be using [H2](http://www.h2database.com/).
 


### PR DESCRIPTION
Had a minor issue with the build.sbt described in the docs, as `partial-unification` seems to be included by default now 

https://github.com/typelevel/cats/issues/2948