### PR TITLE
tut: fix psql command

### DIFF
--- a/modules/docs/src/main/tut/docs/01-Introduction.md
+++ b/modules/docs/src/main/tut/docs/01-Introduction.md
@@ -31,7 +31,7 @@ The example code assumes a local [PostgreSQL](http://www.postgresql.org/) server
 
 ```
 $ curl -O https://raw.githubusercontent.com/tpolecat/doobie/series/0.7.x/world.sql
-$ psql -c 'create user postgres createdb'
+$ psql -c 'create user postgres createdb' postgres
 $ psql -c 'create database world;' -U postgres
 $ psql -c '\i world.sql' -d world -U postgres
 $ psql -d world -c "create type myenum as enum ('foo', 'bar')" -U postgres


### PR DESCRIPTION
This commit fix a SQL command that's going to fail for most users.

If not specified the command will use $USER as the db default. Yet in
general the only present db is `postgres`.