### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ In 0.5.x we provided some single-element `Stream`s that would emit values and gu
 
 Prior to the 0.6.x series we provided two typeclasses for **bidirectional** type mapping:
 - `Meta` defined nullable mappings between column/parameter values and scala types.
-- `Composite` defined null-safe mappings betwen column/parameter **vectors** and scala types.
+- `Composite` defined null-safe mappings between column/parameter **vectors** and scala types.
 
 Starting with version 0.6.0 type mappings are **unidirectional**:
 - `Meta` has been split into `Get` and `Put` typeclasses, for reads and writes of column/parameter values, respectively.

--- a/modules/docs/src/main/tut/docs/14-Managing-Connections.md
+++ b/modules/docs/src/main/tut/docs/14-Managing-Connections.md
@@ -173,7 +173,7 @@ If the default `Transactor` behavior don't meet your needs you can replace any m
 val testXa = Transactor.after.set(xa, HC.rollback)
 ```
 
-As another exmaple, Hive's JDBC driver doesn't support transaction commit or rollback, you can create your own  `Transactor` to accommodate that, like:
+As another example, Hive's JDBC driver doesn't support transaction commit or rollback, you can create your own  `Transactor` to accommodate that, like:
 
 ```scala
 import doobie.free.connection.unit

--- a/modules/docs/src/main/tut/migration.md
+++ b/modules/docs/src/main/tut/migration.md
@@ -48,7 +48,7 @@ In 0.5.x we provided some single-element `Stream`s that would emit values and gu
 
 Prior to the 0.6.x series we provided two typeclasses for **bidirectional** type mapping:
 - `Meta` defined nullable mappings between column/parameter values and scala types.
-- `Composite` defined null-safe mappings betwen column/parameter **vectors** and scala types.
+- `Composite` defined null-safe mappings between column/parameter **vectors** and scala types.
 
 Starting with version 0.6.0 type mappings are **unidirectional**:
 - `Meta` has been split into `Get` and `Put` typeclasses, for reads and writes of column/parameter values, respectively.


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos.