### PR TITLE
Revert to use java.sql.Timestamp to serialize java.time.Instant

### DIFF
--- a/modules/core/src/main/scala/doobie/util/meta.scala
+++ b/modules/core/src/main/scala/doobie/util/meta.scala
@@ -260,10 +260,7 @@ trait MetaInstances { this: MetaConstructors =>
 
   /** @group Instances */
   implicit val JavaTimeInstantMeta: Meta[java.time.Instant] =
-    Basic.one[java.time.Instant](
-      Timestamp,
-      List(Char, VarChar, LongVarChar, Date, Time),
-      _.getObject(_, classOf[java.time.Instant]), _.setObject(_, _), _.updateObject(_, _))
+    TimestampMeta.imap(_.toInstant)(java.sql.Timestamp.from)
 
   /** @group Instances */
   implicit val JavaTimeLocalDateMeta: Meta[java.time.LocalDate] =

--- a/modules/postgres/src/test/scala/doobie/postgres/pgtypes.scala
+++ b/modules/postgres/src/test/scala/doobie/postgres/pgtypes.scala
@@ -7,6 +7,7 @@ package doobie.postgres
 import java.math.{BigDecimal => JBigDecimal}
 import java.net.InetAddress
 import java.sql.Timestamp
+import java.time.temporal.ChronoField.NANO_OF_SECOND
 import java.time.{LocalDate, ZoneOffset}
 import java.util.UUID
 
@@ -166,6 +167,7 @@ class pgtypesspec extends Specification with ScalaCheck {
    */
   testInOutWithCustomTransform[java.sql.Timestamp]("timestamp") { ts => ts.setNanos(0); ts }
   testInOutWithCustomTransform[java.time.LocalDateTime]("timestamp")(_.withNano(0))
+  testInOutWithCustomTransform[java.time.Instant]("timestamp")(_.`with`(NANO_OF_SECOND, 0))
 
   /*
       timestamp with time zone


### PR DESCRIPTION
Fixes #1096 #1095 