### PR TITLE
Fix Typechecking Queries example's output

### DIFF
--- a/modules/docs/src/main/tut/docs/06-Checking.md
+++ b/modules/docs/src/main/tut/docs/06-Checking.md
@@ -93,7 +93,7 @@ If we fix all of these problems and try again, we get a clean bill of health.
 ```scala mdoc:silent
 case class Country2(code: String, name: String, pop: Int, gnp: Option[BigDecimal])
 
-def biggerThan(minPop: Int) =
+def biggerThan2(minPop: Int) =
   sql"""
     select code, name, population, gnp
     from country
@@ -102,7 +102,7 @@ def biggerThan(minPop: Int) =
 ```
 
 ```scala mdoc
-biggerThan(0).check.unsafeRunSync
+biggerThan2(0).check.unsafeRunSync
 ```
 
 **doobie** supports `check` for queries and updates in three ways: programmatically, via YOLO mode in the REPL, and via the `doobie-specs2` and `doobie-scalatest` packages, which allow checking to become part of your unit test suite. We will investigate this in the chapter on testing.


### PR DESCRIPTION
Fix for #1147 
It seemed that the first `.check` called the second `biggerThan`, so I just changed the second function's name (naming followed the pattern used for ` Country` and `Country2`)