### PR TITLE
circe 0.13.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import microsites._
 // Library versions all in one place, for convenience and sanity.
 lazy val catsVersion          = "2.1.1"
 lazy val catsEffectVersion    = "2.1.1"
-lazy val circeVersion         = "0.12.1"
+lazy val circeVersion         = "0.13.0"
 lazy val collCompatVersion    = "2.1.4"
 lazy val fs2Version           = "2.2.2"
 lazy val h2Version            = "1.4.200"


### PR DESCRIPTION
I presume we don't want to upgrade to a (breaking) new version of Circe in the `0.8.x` series, so I've open this PR targeting `master` branch