### PR TITLE
sql-interpolation for Update and Query

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ lazy val specs2Version        = "4.9.2"
 lazy val scala212Version      = "2.12.10"
 lazy val scala213Version      = "2.13.1"
 lazy val slf4jVersion         = "1.7.30"
+lazy val monocleVersion       = "2.0.4"
 
 // These are releases to ignore during MiMa checks
 lazy val botchedReleases = Set("0.8.0", "0.8.1")
@@ -205,8 +206,10 @@ lazy val example = project
   .settings(doobieSettings ++ noPublishSettings)
   .dependsOn(core, postgres, specs2, scalatest, hikari, h2)
   .settings(
+    scalacOptions in Compile +=  "-Ymacro-annotations",
     libraryDependencies ++= Seq(
-      "co.fs2" %% "fs2-io"     % fs2Version
+      "co.fs2"                     %% "fs2-io"       % fs2Version,
+      "com.github.julien-truffaut" %% "monocle-macro" % monocleVersion
     )
   )
 

--- a/create.sql
+++ b/create.sql
@@ -1,0 +1,3 @@
+create extension postgis;
+create extension hstore;
+create type myenum as enum ('foo', 'bar', 'invalid');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  # main instance for testing
+  postgres:
+    image: mdillon/postgis:11
+    volumes:
+      - ./world.sql:/docker-entrypoint-initdb.d/world.sql
+      - ./create.sql:/docker-entrypoint-initdb.d/create.sql
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_DB: world
+      POSTGRES_USER: postgres
+      POSTGRES_HOST_AUTH_METHOD: trust

--- a/modules/core/src/main/scala/doobie/aliases.scala
+++ b/modules/core/src/main/scala/doobie/aliases.scala
@@ -21,7 +21,7 @@ trait Types {
   /** @group Type Aliases - Core */ type SqlState                 = doobie.enum.SqlState
   /** @group Type Aliases - Core */ type Transactor[M[_]]         = doobie.util.transactor.Transactor[M]
   /** @group Type Aliases - Core */ type LogHandler               = doobie.util.log.LogHandler
-  /** @group Type Aliases - Core */ type Fragment                 = doobie.util.fragment.Fragment
+  /** @group Type Aliases - Core */ type Fragment[-R]             = doobie.util.fragment.Fragment[R]
   /** @group Type Aliases - Core */ type KleisliInterpreter[F[_]] = doobie.free.KleisliInterpreter[F]
   /** @group Type Aliases - Core */ type DataSourceTransactor[F[_]] = doobie.util.transactor.Transactor.Aux[F, javax.sql.DataSource]
 }

--- a/modules/core/src/main/scala/doobie/syntax/put.scala
+++ b/modules/core/src/main/scala/doobie/syntax/put.scala
@@ -10,17 +10,17 @@ import doobie.util.fragment.Elem.{Arg, Opt}
 import doobie.util.pos.Pos
 
 final class PutOps[A : Put](a: A) {
-  def fr(implicit pos: Pos): Fragment = mkFragment("? ", pos)
-  def fr0(implicit pos: Pos): Fragment = mkFragment("?", pos)
+  def fr(implicit pos: Pos): Fragment[Any] = mkFragment("? ", pos)
+  def fr0(implicit pos: Pos): Fragment[Any] = mkFragment("?", pos)
 
-  private def mkFragment(sql: String, pos: Pos) = Fragment(sql, List(Arg(a, Put[A])), Some(pos))
+  private def mkFragment(sql: String, pos: Pos):Fragment[Any] = Fragment(sql, List(Arg(a, Put[A])), Some(pos))
 }
 
 final class OptionPutOps[A : Put](oa: Option[A]) {
-  def fr(implicit pos: Pos): Fragment = mkFragment("? ", pos)
-  def fr0(implicit pos: Pos): Fragment = mkFragment("?", pos)
+  def fr(implicit pos: Pos): Fragment[Any] = mkFragment("? ", pos)
+  def fr0(implicit pos: Pos): Fragment[Any] = mkFragment("?", pos)
 
-  private def mkFragment(sql: String, pos: Pos) = Fragment(sql, List(Opt(oa, Put[A])), Some(pos))
+  private def mkFragment(sql: String, pos: Pos):Fragment[Any] = Fragment(sql, List(Opt(oa, Put[A])), Some(pos))
 }
 
 trait ToPutOps {

--- a/modules/core/src/main/scala/doobie/util/fragment.scala
+++ b/modules/core/src/main/scala/doobie/util/fragment.scala
@@ -7,9 +7,8 @@ package doobie.util
 import cats._
 import cats.data.Chain
 import cats.implicits._
-
-import doobie._, doobie.implicits._
-import doobie.util.pos.Pos
+import doobie._
+import doobie.implicits._
 import doobie.enum.Nullability._
 import doobie.util.pos.Pos
 import java.sql.{ PreparedStatement, ResultSet }
@@ -24,95 +23,22 @@ object fragment {
    * constructed a `Fragment` is opaque; it has no externally observable properties. Fragments are
    * eventually used to construct a [[Query0]] or [[Update0]].
    */
-  final class Fragment(
+  final class Fragment[-R](
     protected val sql: String,
-    protected val elems: Chain[Elem],
+    protected val elems: Chain[Elem[R]],
     protected val pos: Option[Pos]
   ) {
 
-    // Unfortunately we need to produce a Write for our list of elems, which is a bit of a grunt
-    // but straightforward nonetheless. And it's stacksafe!
-    private implicit lazy val write: Write[elems.type] = {
-      import Elem._
-
-      val puts: List[(Put[_], NullabilityKnown)] =
-        elems.map {
-          case Arg(_, p) => (p, NoNulls)
-          case Opt(_, p) => (p, Nullable)
-        } .toList
-
-      val toList: elems.type => List[Any] = elems =>
-        elems.map {
-          case Arg(a, _) => a
-          case Opt(a, _) => a
-        } .toList
-
-      @SuppressWarnings(Array("org.wartremover.warts.Var"))
-      val unsafeSet: (PreparedStatement, Int, elems.type) => Unit = { (ps, n, elems) =>
-        var index = n
-        elems.iterator.foreach { e =>
-          e match {
-            case Arg(a, p) => p.unsafeSetNonNullable(ps, index, a)
-            case Opt(a, p) => p.unsafeSetNullable(ps, index, a)
-          }
-          index += 1
-        }
-      }
-
-      @SuppressWarnings(Array("org.wartremover.warts.Var"))
-      val unsafeUpdate: (ResultSet, Int, elems.type) => Unit = { (ps, n, elems) =>
-        var index = n
-        elems.iterator.foreach { e =>
-          e match {
-            case Arg(a, p) => p.unsafeUpdateNonNullable(ps, index, a)
-            case Opt(a, p) => p.unsafeUpdateNullable(ps, index, a)
-          }
-          index += 1
-        }
-      }
-
-      new Write(puts, toList, unsafeSet, unsafeUpdate)
-
-    }
-
-    /**
-     * Construct a program in ConnectionIO that constructs and prepares a PreparedStatement, with
-     * further handling delegated to the provided program.
-     */
-    def execWith[B](fa: PreparedStatementIO[B]): ConnectionIO[B] =
-      HC.prepareStatement(sql)(write.set(1, elems) *> fa)
-
     /** Concatenate this fragment with another, yielding a larger fragment. */
-    def ++(fb: Fragment): Fragment =
+    def ++[R2 <: R](fb: Fragment[R2]): Fragment[R2] =
       new Fragment(sql + fb.sql, elems ++ fb.elems, pos orElse fb.pos)
 
     @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
-    def stripMargin(marginChar: Char): Fragment =
+    def stripMargin(marginChar: Char): Fragment[R] =
       new Fragment(sql.stripMargin(marginChar), elems, pos)
 
     @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
-    def stripMargin: Fragment = stripMargin('|')
-
-    /** Construct a [[Query0]] from this fragment, with asserted row type `B`. */
-    @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
-    def query[B: Read](implicit h: LogHandler = LogHandler.nop): Query0[B] =
-      queryWithLogHandler(h)
-
-    /**
-     * Construct a [[Query0]] from this fragment, with asserted row type `B` and the given
-     * `LogHandler`.
-     */
-    def queryWithLogHandler[B](h: LogHandler)(implicit cb: Read[B]): Query0[B] =
-      Query[elems.type, B](sql, pos, h).toQuery0(elems)
-
-    /** Construct an [[Update0]] from this fragment. */
-    @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
-    def update(implicit h: LogHandler = LogHandler.nop): Update0 =
-      updateWithLogHandler(h)
-
-    /** Construct an [[Update0]] from this fragment with the given `LogHandler`. */
-    def updateWithLogHandler(h: LogHandler): Update0 =
-      Update[elems.type](sql, pos, h).toUpdate0(elems)
+    def stripMargin: Fragment[R] = stripMargin('|')
 
     override def toString =
       s"""Fragment("$sql")"""
@@ -120,17 +46,140 @@ object fragment {
     /** Used only for testing; this pulls out the arguments as an untyped list. */
     private def args: List[Any] =
       elems.toList.map {
-        case Elem.Arg(a, _) => a
-        case Elem.Opt(a, _) => a
-      }
+        case Elem.Arg(a, _)      => a
+        case Elem.Opt(a, _)      => a
+        case Elem.FunArg(fun, _) => fun
+        case Elem.FunOpt(fun, _) => fun
+          }
 
     /** Used only for testing; this uses universal equality on the captured arguments. */
     @SuppressWarnings(Array("org.wartremover.warts.Equals"))
-    private[util] def unsafeEquals(fb: Fragment): Boolean =
+    private[util] def unsafeEquals[R2 <: R](fb: Fragment[R2]): Boolean =
       sql == fb.sql && args == fb.args
 
   }
+
   object Fragment {
+
+    implicit class Fragment0Syntax(private val fragment: Fragment[Any])
+        extends AnyVal {
+      private implicit def write: Write[Any] = Fragment.write(fragment.elems)
+
+      /**
+       * Construct a program in ConnectionIO that constructs and prepares a PreparedStatement, with
+       * further handling delegated to the provided program.
+       */
+      def execWith[B](fa: PreparedStatementIO[B]): ConnectionIO[B] =
+        HC.prepareStatement(fragment.sql)(write.set(1, ()) *> fa)
+
+      /** Construct a [[Query0]] from this fragment, with asserted row type `B`. */
+      @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
+      def query[B: Read](implicit h: LogHandler = LogHandler.nop): Query0[B] =
+        queryWithLogHandler(h)
+
+      /**
+        * Construct a [[Query0]] from this fragment, with asserted row type `B` and the given
+        * `LogHandler`.
+        */
+      def queryWithLogHandler[B](h: LogHandler)(implicit cb: Read[B]): Query0[B] =
+        Query[Any, B](fragment.sql, fragment.pos, h).toQuery0(())
+
+      /** Construct an [[Update0]] from this fragment. */
+      @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
+      def update(implicit h: LogHandler = LogHandler.nop): Update0 =
+        updateWithLogHandler(h)
+
+      /** Construct an [[Update0]] from this fragment with the given `LogHandler`. */
+      def updateWithLogHandler(h: LogHandler): Update0 =
+        Update[Any](fragment.sql, fragment.pos, h).toUpdate0(())
+
+    }
+
+    implicit class FragmentSyntax[R](private val fragment: Fragment[R]) extends AnyVal {
+      private implicit def write: Write[R] = Fragment.write(fragment.elems)
+
+      /**
+        * Construct a program in ConnectionIO that constructs and prepares a PreparedStatement, with
+        * further handling delegated to the provided program.
+        */
+      def execWith[B](fa: PreparedStatementIO[B], r: R): ConnectionIO[B] =
+        HC.prepareStatement(fragment.sql)(write.set(1, r) *> fa)
+
+      /** Construct a [[Query0]] from this fragment, with asserted row type `B`. */
+      @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
+      def query[B: Read](implicit h: LogHandler = LogHandler.nop): Query[R, B] =
+        queryWithLogHandler(h)
+
+    /**
+     * Construct a [[Query0]] from this fragment, with asserted row type `B` and the given
+     * `LogHandler`.
+     */
+      def queryWithLogHandler[B](h: LogHandler)(implicit cb: Read[B]): Query[R, B] =
+        Query[R, B](fragment.sql, fragment.pos, h)
+
+      /** Construct an [[Update0]] from this fragment. */
+      @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
+      def update(implicit h: LogHandler = LogHandler.nop): Update[R] =
+        updateWithLogHandler(h)
+
+      /** Construct an [[Update0]] from this fragment with the given `LogHandler`. */
+      def updateWithLogHandler(h: LogHandler): Update[R] =
+        Update[R](fragment.sql, fragment.pos, h)
+
+    }
+
+    // Unfortunately we need to produce a Write for our list of elems, which is a bit of a grunt
+    // but straightforward nonetheless. And it's stacksafe!
+    private[Fragment] def write[R](elems: Chain[Elem[R]]): Write[R] = {
+      import Elem._
+
+      val puts: List[(Put[_], NullabilityKnown)] =
+        elems.map {
+          case Arg(_, p)    => (p, NoNulls)
+          case Opt(_, p)    => (p, Nullable)
+          case FunArg(_, p) => (p, NoNulls)
+          case FunOpt(_, p) => (p, Nullable)
+        }.toList
+
+      val toList: R => List[Any] = r =>
+        elems.map {
+          case Arg(a, _)      => a
+          case Opt(a, _)      => a
+          case FunArg(get, _) => get(r)
+          case FunOpt(get, _) => get(r)
+        }.toList
+
+      @SuppressWarnings(Array("org.wartremover.warts.Var"))
+      val unsafeSet: (PreparedStatement, Int, R) => Unit = { (ps, n, r) =>
+        var index = n
+        elems.iterator.foreach { e =>
+          e match {
+            case Arg(a, p)      => p.unsafeSetNonNullable(ps, index, a)
+            case Opt(a, p)      => p.unsafeSetNullable(ps, index, a)
+            case FunArg(get, p) => p.unsafeSetNonNullable(ps, index, get(r))
+            case FunOpt(get, p) => p.unsafeSetNullable(ps, index, get(r))
+          }
+          index += 1
+        }
+      }
+
+      @SuppressWarnings(Array("org.wartremover.warts.Var"))
+      val unsafeUpdate: (ResultSet, Int, R) => Unit = { (ps, n, r) =>
+        var index = n
+        elems.iterator.foreach { e =>
+          e match {
+            case Arg(a, p)      => p.unsafeUpdateNonNullable(ps, index, a)
+            case Opt(a, p)      => p.unsafeUpdateNullable(ps, index, a)
+            case FunArg(get, p) => p.unsafeUpdateNonNullable(ps, index, get(r))
+            case FunOpt(get, p) => p.unsafeUpdateNullable(ps, index, get(r))
+          }
+          index += 1
+        }
+      }
+
+      new Write(puts, toList, unsafeSet, unsafeUpdate)
+
+  }
 
     /**
      * Construct a statement fragment with the given SQL string, which must contain sufficient `?`
@@ -138,7 +187,9 @@ object fragment {
      * accomplished via the string interpolator rather than direct construction.
      */
     @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
-    def apply(sql: String, elems: List[Elem], pos: Option[Pos] = None): Fragment =
+    def apply[R](sql: String,
+                 elems: List[Elem[R]],
+                 pos: Option[Pos] = None): Fragment[R] =
       new Fragment(sql, Chain.fromSeq(elems), pos)
 
     /**
@@ -146,7 +197,7 @@ object fragment {
      * passed SQL string must not contain `?` placeholders.
      */
     @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
-    def const0(sql: String, pos: Option[Pos] = None): Fragment =
+    def const0(sql: String, pos: Option[Pos] = None): Fragment[Any] =
       new Fragment(sql, Chain.empty, pos)
 
     /**
@@ -154,26 +205,27 @@ object fragment {
      * passed SQL string must not contain `?` placeholders.
      */
      @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
-     def const(sql: String, pos: Option[Pos] = None): Fragment =
+    def const(sql: String, pos: Option[Pos] = None): Fragment[Any] =
       const0(sql + " ", pos)
 
     /** The empty fragment. Adding this to another fragment has no effect. */
-    val empty: Fragment =
+    val empty: Fragment[Any] =
       const0("")
 
     /** Statement fragments form a monoid. */
-    implicit val FragmentMonoid: Monoid[Fragment] =
-      new Monoid[Fragment] {
-        val empty = Fragment.empty
-        def combine(a: Fragment, b: Fragment) = a ++ b
+    implicit def FragmentMonoid[R]: Monoid[Fragment[R]] =
+      new Monoid[Fragment[R]] {
+        val empty: Fragment[R] = Fragment.empty
+        def combine(a: Fragment[R], b: Fragment[R]) = a ++ b
       }
 
   }
 
-  sealed trait Elem
+  sealed trait Elem[-R]
   object Elem {
-    final case class Arg[A](a: A, p: Put[A]) extends Elem
-    final case class Opt[A](a: Option[A], p: Put[A]) extends Elem
+    final case class Arg[A](a: A, p: Put[A]) extends Elem[Any]
+    final case class Opt[A](a: Option[A], p: Put[A]) extends Elem[Any]
+    final case class FunArg[R, A](fun: R => A, p: Put[A]) extends Elem[R]
+    final case class FunOpt[R, A](fun: R => Option[A], p: Put[A]) extends Elem[R]
   }
-
 }

--- a/modules/core/src/main/scala/doobie/util/fragments.scala
+++ b/modules/core/src/main/scala/doobie/util/fragments.scala
@@ -13,58 +13,58 @@ import cats.implicits._
 object fragments {
 
   /** Returns `f IN (fs0, fs1, ...)`. */
-  def in[F[_]: Reducible, A: util.Put](f: Fragment, fs: F[A]): Fragment =
-    fs.toList.map(a => fr0"$a").foldSmash1(f ++ fr0"IN (", fr",", fr")")
+  def in[F[_]: Reducible, R, A: util.Put](f: Fragment[R], fs: F[A]): Fragment[R] =
+    fs.toList.map[Fragment[R]](a => fr0"$a").foldSmash1(f ++ fr0"IN (", fr",", fr")")
 
   /** Returns `f NOT IN (fs0, fs1, ...)`. */
-  def notIn[F[_]: Reducible, A: util.Put](f: Fragment, fs: F[A]): Fragment =
-    fs.toList.map(a => fr0"$a").foldSmash1(f ++ fr0"NOT IN (", fr",", fr")")
+  def notIn[F[_]: Reducible, R, A: util.Put](f: Fragment[R], fs: F[A]): Fragment[R] =
+    fs.toList.map[Fragment[R]](a => fr0"$a").foldSmash1(f ++ fr0"NOT IN (", fr",", fr")")
 
   /** Returns `(f1) AND (f2) AND ... (fn)`. */
-  def and(fs: Fragment*): Fragment =
-    fs.toList.map(parentheses).intercalate(fr"AND")
+  def and[R](fs: Fragment[R]*): Fragment[R] =
+    fs.toList.map(parentheses[R]).intercalate(fr"AND")
 
   /** Returns `(f1) AND (f2) AND ... (fn)` for all defined fragments. */
-  def andOpt(fs: Option[Fragment]*): Fragment =
+  def andOpt[R](fs: Option[Fragment[R]]*): Fragment[R] =
     and(fs.toList.unite: _*)
 
   /** Returns `(f1) OR (f2) OR ... (fn)`. */
-  def or(fs: Fragment*): Fragment =
-    fs.toList.map(parentheses).intercalate(fr"OR")
+  def or[R](fs: Fragment[R]*): Fragment[R] =
+    fs.toList.map(parentheses[R]).intercalate(fr"OR")
 
   /** Returns `(f1) OR (f2) OR ... (fn)` for all defined fragments. */
-  def orOpt(fs: Option[Fragment]*): Fragment =
+  def orOpt[R](fs: Option[Fragment[R]]*): Fragment[R] =
     or(fs.toList.unite: _*)
 
   /** Returns `WHERE (f1) AND (f2) AND ... (fn)` or the empty fragment if `fs` is empty. */
-  def whereAnd(fs: Fragment*): Fragment =
+  def whereAnd[R](fs: Fragment[R]*): Fragment[R] =
     if (fs.isEmpty) Fragment.empty else fr"WHERE" ++ and(fs: _*)
 
   /** Returns `WHERE (f1) AND (f2) AND ... (fn)` for defined `f`, if any, otherwise the empty fragment. */
-  def whereAndOpt(fs: Option[Fragment]*): Fragment =
+  def whereAndOpt[R](fs: Option[Fragment[R]]*): Fragment[R] =
     whereAnd(fs.toList.unite: _*)
 
   /** Returns `WHERE (f1) OR (f2) OR ... (fn)` or the empty fragment if `fs` is empty. */
-  def whereOr(fs: Fragment*): Fragment =
+  def whereOr[R](fs: Fragment[R]*): Fragment[R] =
     if (fs.isEmpty) Fragment.empty else fr"WHERE" ++ or(fs: _*)
 
   /** Returns `WHERE (f1) OR (f2) OR ... (fn)` for defined `f`, if any, otherwise the empty fragment. */
-  def whereOrOpt(fs: Option[Fragment]*): Fragment =
+  def whereOrOpt[R](fs: Option[Fragment[R]]*): Fragment[R] =
     whereOr(fs.toList.unite: _*)
 
   /** Returns `SET f1, f2, ... fn` or the empty fragment if `fs` is empty. */
-  def set(fs: Fragment*): Fragment =
+  def set[R](fs: Fragment[R]*): Fragment[R] =
     if (fs.isEmpty) Fragment.empty else fr"SET" ++ fs.toList.intercalate(fr",")
 
   /** Returns `SET f1, f2, ... fn` for defined `f`, if any, otherwise the empty fragment. */
-  def setOpt(fs: Option[Fragment]*): Fragment =
+  def setOpt[R](fs: Option[Fragment[R]]*): Fragment[R] =
     set(fs.toList.unite: _*)
 
   /** Returns `(f)`. */
-  def parentheses(f: Fragment): Fragment = fr0"(" ++ f ++ fr")"
+  def parentheses[R](f: Fragment[R]): Fragment[R] = fr0"(" ++ f ++ fr")"
 
   /** Returns `?,?,...,?` for the values in `a`. */
-  def values[A](a: A)(implicit w: util.Write[A]): Fragment =
+  def values[A](a: A)(implicit w: util.Write[A]): Fragment[Any] =
     w.toFragment(a)
 
 }

--- a/modules/core/src/main/scala/doobie/util/query.scala
+++ b/modules/core/src/main/scala/doobie/util/query.scala
@@ -80,7 +80,7 @@ object query {
     def pos: Option[Pos]
 
     /** Convert this Query to a `Fragment`. */
-    def toFragment(a: A): Fragment =
+    def toFragment(a: A): Fragment[Any] =
       write.toFragment(a, sql)
 
     /**
@@ -295,7 +295,7 @@ object query {
     def analysis: ConnectionIO[Analysis]
 
     /** Convert this Query0 to a `Fragment`. */
-    def toFragment: Fragment
+    def toFragment: Fragment[Any]
 
     /**
      * Program to construct an inspection of the query. Calls `f` with the SQL

--- a/modules/core/src/main/scala/doobie/util/update.scala
+++ b/modules/core/src/main/scala/doobie/util/update.scala
@@ -73,7 +73,7 @@ object update {
     val pos: Option[Pos]
 
     /** Convert this Update to a `Fragment`. */
-    def toFragment(a: A): Fragment =
+    def toFragment(a: A): Fragment[Any] =
       write.toFragment(a, sql)
 
     /**
@@ -169,7 +169,7 @@ object update {
       new Update0 {
         val sql = u.sql
         val pos = u.pos
-        def toFragment: Fragment = u.toFragment(a)
+        def toFragment: Fragment[Any] = u.toFragment(a)
         def analysis = u.analysis
         def run = u.run(a)
         def withGeneratedKeysWithChunkSize[K: Read](columns: String*)(chunkSize: Int) =
@@ -227,7 +227,7 @@ object update {
     val pos: Option[Pos]
 
     /** Convert this Update0 to a `Fragment`. */
-    def toFragment: Fragment
+    def toFragment: Fragment[Any]
 
       /**
      * Program to construct an analysis of this query's SQL statement and asserted parameter types.

--- a/modules/core/src/main/scala/doobie/util/write.scala
+++ b/modules/core/src/main/scala/doobie/util/write.scala
@@ -48,9 +48,9 @@ final class Write[A](
    * Given a value of type `A` and an appropriately parameterized SQL string we can construct a
    * `Fragment`. If `sql` is unspecified a comma-separated list of `length` placeholders will be used.
    */
-  def toFragment(a: A, sql: String = List.fill(length)("?").mkString(",")): Fragment = {
-    val elems: List[Elem] = (puts zip toList(a)).map {
-      case ((p: Put[a], NoNulls), a) => Elem.Arg(a.asInstanceOf[a], p)
+  def toFragment(a: A, sql: String = List.fill(length)("?").mkString(",")): Fragment[Any] = {
+    val elems: List[Elem[Any]] = (puts zip toList(a)).map {
+      case ((p: Put[a], NoNulls), a)  => Elem.Arg(a.asInstanceOf[a], p)
       case ((p: Put[a], Nullable), a) => Elem.Opt(a.asInstanceOf[Option[a]], p)
     }
     Fragment(sql, elems, None)

--- a/modules/docs/src/main/mdoc/docs/08-Fragments.md
+++ b/modules/docs/src/main/mdoc/docs/08-Fragments.md
@@ -111,7 +111,7 @@ def select(name: Option[String], pop: Option[Int], codes: List[String], limit: L
   val f3 = codes.toNel.map(cs => in(fr"code", cs))
 
   // Our final query
-  val q: Fragment =
+  val q: Fragment[Any] =
     fr"SELECT name, code, population FROM country" ++
     whereAndOpt(f1, f2, f3)                         ++
     fr"LIMIT $limit"

--- a/modules/example/src/main/scala/example/FirstExampleLens.scala
+++ b/modules/example/src/main/scala/example/FirstExampleLens.scala
@@ -1,0 +1,161 @@
+// Copyright (c) 2013-2018 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+// relies on streaming, so no cats for now
+package example
+
+import cats.Show
+import cats.implicits._
+import cats.effect.{ExitCode, IO, IOApp}
+import fs2.Stream
+import doobie._
+import doobie.implicits._
+import doobie.util.lens.{@>, Lens}
+
+// Example of using Lenses to allow sql-interpolated updateMany
+object FirstExampleLens extends IOApp {
+
+  // Our data model
+  object Supplier {
+    val id:     Supplier @> Int    = Lens(_.id, (a, b) => a.copy(id = b))
+    val name:   Supplier @> String = Lens(_.name, (a, b) => a.copy(name = b))
+    val street: Supplier @> String = Lens(_.street, (a, b) => a.copy(street = b))
+    val city:   Supplier @> String = Lens(_.city, (a, b) => a.copy(city = b))
+    val state:  Supplier @> String = Lens(_.state, (a, b) => a.copy(state = b))
+    val zip:    Supplier @> String = Lens(_.zip, (a, b) => a.copy(zip = b))
+  }
+  final case class Supplier(id: Int, name: String, street: String, city: String, state: String, zip: String)
+
+  final case class Coffee(name: String, supId: Int, price: Double, sales: Int, total: Int)
+  object Coffee {
+    implicit val show: Show[Coffee] = Show.fromToString
+    val name:  Coffee @> String = Lens(_.name, (a, b) => a.copy(name = b))
+    val supId: Coffee @> Int    = Lens(_.supId, (a, b) => a.copy(supId = b))
+    val price: Coffee @> Double = Lens(_.price, (a, b) => a.copy(price = b))
+    val sales: Coffee @> Int    = Lens(_.sales, (a, b) => a.copy(sales = b))
+    val total: Coffee @> Int    = Lens(_.total, (a, b) => a.copy(total = b))
+  }
+
+  // Some suppliers
+  val suppliers = List(
+    Supplier(101, "Acme, Inc.",      "99 Market Street", "Groundsville", "CA", "95199"),
+    Supplier( 49, "Superior Coffee", "1 Party Place",    "Mendocino",    "CA", "95460"),
+    Supplier(150, "The High Ground", "100 Coffee Lane",  "Meadows",      "CA", "93966")
+  )
+
+  // Some coffees
+  val coffees = List(
+    Coffee("Colombian",         101, 7.99, 0, 0),
+    Coffee("French_Roast",       49, 8.99, 0, 0),
+    Coffee("Espresso",          150, 9.99, 0, 0),
+    Coffee("Colombian_Decaf",   101, 8.99, 0, 0),
+    Coffee("French_Roast_Decaf", 49, 9.99, 0, 0)
+  )
+
+  // Our example database action
+  def examples: ConnectionIO[String] =
+    for {
+
+      // Create and populate
+      _  <- DAO.create
+      ns <- DAO.insertSuppliers(suppliers)
+      nc <- DAO.insertCoffees(coffees)
+      _  <- putStrLn(show"Inserted $ns suppliers and $nc coffees.")
+
+      // Select and stream the coffees to stdout
+      _ <- DAO.allCoffees.evalMap(c => putStrLn(show"$c")).compile.drain
+
+      // Get the names and supplier names for all coffees costing less than $9.00,
+      // again streamed directly to stdout
+      _ <- DAO.coffeesLessThan(9.0).evalMap(p => putStrLn(show"$p")).compile.drain
+
+      // Same thing, but read into a list this time
+      l <- DAO.coffeesLessThan(9.0).compile.toList
+      _ <- putStrLn(l.toString)
+
+      // Read into a vector this time, with some stream processing
+      v <- DAO.coffeesLessThan(9.0).take(2).map(p => p._1 + "*" + p._2).compile.toVector
+      _ <- putStrLn(v.toString)
+
+    } yield "All done!"
+
+  // Entry point for SafeApp
+  def run(args: List[String]): IO[ExitCode] = {
+    val db = Transactor.fromDriverManager[IO](
+      "org.h2.Driver", "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", "sa", ""
+    )
+    for {
+      a <- examples.transact(db).attempt
+      _ <- IO(println(a))
+    } yield ExitCode.Success
+  }
+
+  /** DAO module provides ConnectionIO constructors for end users. */
+  object DAO {
+
+    def coffeesLessThan(price: Double): Stream[ConnectionIO, (String, String)] =
+      Queries.coffeesLessThan(price).stream
+
+    def insertSuppliers(ss: List[Supplier]): ConnectionIO[Int] =
+      Queries.insertSupplier.updateMany(ss) // bulk insert (!)
+
+    def insertCoffees(cs: List[Coffee]): ConnectionIO[Int] =
+      Queries.insertCoffee.updateMany(cs)
+
+    def allCoffees: Stream[ConnectionIO, Coffee] =
+      Queries.allCoffees.stream
+
+    def create: ConnectionIO[Unit] =
+      Queries.create.run.void
+
+  }
+
+  /** Queries module contains "raw" Query/Update values. */
+  object Queries {
+
+    def coffeesLessThan(price: Double): Query0[(String, String)] =
+      sql"""
+        SELECT cof_name, sup_name
+        FROM coffees JOIN suppliers ON coffees.sup_id = suppliers.sup_id
+        WHERE price < $price
+      """.query[(String, String)]
+
+    val insertSupplier: Update[Supplier] =
+      sql"INSERT INTO suppliers VALUES (${Supplier.id}, ${Supplier.name}, ${Supplier.street}, ${Supplier.city}, ${Supplier.state}, ${Supplier.zip})".update
+
+    val insertCoffee: Update[Coffee] =
+      sql"INSERT INTO coffees VALUES (${Coffee.name}, ${Coffee.supId}, ${Coffee.price}, ${Coffee.sales}, ${Coffee.total})".update
+
+    def allCoffees[A]: Query0[Coffee] =
+      sql"SELECT cof_name, sup_id, price, sales, total FROM coffees".query[Coffee]
+
+    def create: Update0 =
+      sql"""
+        CREATE TABLE suppliers (
+          sup_id   INT     NOT NULL PRIMARY KEY,
+          sup_name VARCHAR NOT NULL,
+          street   VARCHAR NOT NULL,
+          city     VARCHAR NOT NULL,
+          state    VARCHAR NOT NULL,
+          zip      VARCHAR NOT NULL
+        );
+        CREATE TABLE coffees (
+          cof_name VARCHAR NOT NULL,
+          sup_id   INT     NOT NULL,
+          price    DOUBLE  NOT NULL,
+          sales    INT     NOT NULL,
+          total    INT     NOT NULL
+        );
+        ALTER TABLE coffees
+        ADD CONSTRAINT coffees_suppliers_fk FOREIGN KEY (sup_id) REFERENCES suppliers(sup_id);
+      """.update
+
+  }
+
+  // Lifted println
+  def putStrLn(s: => String): ConnectionIO[Unit] =
+    FC.delay(println(s))
+
+}
+

--- a/modules/example/src/main/scala/example/FirstExampleMonocle.scala
+++ b/modules/example/src/main/scala/example/FirstExampleMonocle.scala
@@ -1,0 +1,157 @@
+// Copyright (c) 2013-2018 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package example
+
+import cats.Show
+import cats.implicits._
+import cats.effect.{ExitCode, IO, IOApp}
+import fs2.Stream
+import doobie._
+import doobie.implicits._
+import doobie.syntax.SqlInterpolator.SingleFragment
+import doobie.util.fragment.Elem
+import monocle.Lens
+import monocle.macros.Lenses
+
+// Example of using monocle-lenses in sql-interpolated updateMany
+object FirstExampleMonocle extends IOApp {
+
+  // monocle Lens-support
+  implicit def LensArg[R, A](lens:Lens[R, A])(implicit put:Put[A]):SingleFragment[R] =
+    SingleFragment.fromElem(Elem.FunArg(lens.get, put))
+  implicit def LensOpt[R, A](lens:Lens[R, Option[A]])(implicit put:Put[A]):SingleFragment[R] =
+    SingleFragment.fromElem(Elem.FunOpt(lens.get, put))
+
+  // Our data model
+  @Lenses
+  final case class Supplier(id: Int, name: String, street: String, city: String, state: String, zip: String)
+  @Lenses
+  final case class Coffee(name: String, supId: Int, price: Double, sales: Int, total: Int)
+  object Coffee {
+    implicit val show: Show[Coffee] = Show.fromToString
+  }
+
+  // Some suppliers
+  val suppliers = List(
+    Supplier(101, "Acme, Inc.",      "99 Market Street", "Groundsville", "CA", "95199"),
+    Supplier( 49, "Superior Coffee", "1 Party Place",    "Mendocino",    "CA", "95460"),
+    Supplier(150, "The High Ground", "100 Coffee Lane",  "Meadows",      "CA", "93966")
+  )
+
+  // Some coffees
+  val coffees = List(
+    Coffee("Colombian",         101, 7.99, 0, 0),
+    Coffee("French_Roast",       49, 8.99, 0, 0),
+    Coffee("Espresso",          150, 9.99, 0, 0),
+    Coffee("Colombian_Decaf",   101, 8.99, 0, 0),
+    Coffee("French_Roast_Decaf", 49, 9.99, 0, 0)
+  )
+
+  // Our example database action
+  def examples: ConnectionIO[String] =
+    for {
+
+      // Create and populate
+      _  <- DAO.create
+      ns <- DAO.insertSuppliers(suppliers)
+      nc <- DAO.insertCoffees(coffees)
+      _  <- putStrLn(show"Inserted $ns suppliers and $nc coffees.")
+
+      // Select and stream the coffees to stdout
+      _ <- DAO.allCoffees.evalMap(c => putStrLn(show"$c")).compile.drain
+
+      // Get the names and supplier names for all coffees costing less than $9.00,
+      // again streamed directly to stdout
+      _ <- DAO.coffeesLessThan(9.0).evalMap(p => putStrLn(show"$p")).compile.drain
+
+      // Same thing, but read into a list this time
+      l <- DAO.coffeesLessThan(9.0).compile.toList
+      _ <- putStrLn(l.toString)
+
+      // Read into a vector this time, with some stream processing
+      v <- DAO.coffeesLessThan(9.0).take(2).map(p => p._1 + "*" + p._2).compile.toVector
+      _ <- putStrLn(v.toString)
+
+    } yield "All done!"
+
+  // Entry point for SafeApp
+  def run(args: List[String]): IO[ExitCode] = {
+    val db = Transactor.fromDriverManager[IO](
+      "org.h2.Driver", "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", "sa", ""
+    )
+    for {
+      a <- examples.transact(db).attempt
+      _ <- IO(println(a))
+    } yield ExitCode.Success
+  }
+
+  /** DAO module provides ConnectionIO constructors for end users. */
+  object DAO {
+
+    def coffeesLessThan(price: Double): Stream[ConnectionIO, (String, String)] =
+      Queries.coffeesLessThan(price).stream
+
+    def insertSuppliers(ss: List[Supplier]): ConnectionIO[Int] =
+      Queries.insertSupplier.updateMany(ss) // bulk insert (!)
+
+    def insertCoffees(cs: List[Coffee]): ConnectionIO[Int] =
+      Queries.insertCoffee.updateMany(cs)
+
+    def allCoffees: Stream[ConnectionIO, Coffee] =
+      Queries.allCoffees.stream
+
+    def create: ConnectionIO[Unit] =
+      Queries.create.run.void
+
+  }
+
+  /** Queries module contains "raw" Query/Update values. */
+  object Queries {
+
+    def coffeesLessThan(price: Double): Query0[(String, String)] =
+      sql"""
+        SELECT cof_name, sup_name
+        FROM coffees JOIN suppliers ON coffees.sup_id = suppliers.sup_id
+        WHERE price < $price
+      """.query[(String, String)]
+
+    val insertSupplier: Update[Supplier] =
+      sql"INSERT INTO suppliers VALUES (${Supplier.id}, ${Supplier.name}, ${Supplier.street}, ${Supplier.city}, ${Supplier.state}, ${Supplier.zip})".update
+
+    val insertCoffee: Update[Coffee] =
+      sql"INSERT INTO coffees VALUES (${Coffee.name}, ${Coffee.supId}, ${Coffee.price}, ${Coffee.sales}, ${Coffee.total})".update
+
+    def allCoffees[A]: Query0[Coffee] =
+      sql"SELECT cof_name, sup_id, price, sales, total FROM coffees".query[Coffee]
+
+    def create: Update0 =
+      sql"""
+        CREATE TABLE suppliers (
+          sup_id   INT     NOT NULL PRIMARY KEY,
+          sup_name VARCHAR NOT NULL,
+          street   VARCHAR NOT NULL,
+          city     VARCHAR NOT NULL,
+          state    VARCHAR NOT NULL,
+          zip      VARCHAR NOT NULL
+        );
+        CREATE TABLE coffees (
+          cof_name VARCHAR NOT NULL,
+          sup_id   INT     NOT NULL,
+          price    DOUBLE  NOT NULL,
+          sales    INT     NOT NULL,
+          total    INT     NOT NULL
+        );
+        ALTER TABLE coffees
+        ADD CONSTRAINT coffees_suppliers_fk FOREIGN KEY (sup_id) REFERENCES suppliers(sup_id);
+      """.update
+
+  }
+
+  // Lifted println
+  def putStrLn(s: => String): ConnectionIO[Unit] =
+    FC.delay(println(s))
+
+}
+

--- a/modules/example/src/main/scala/example/FragmentExample.scala
+++ b/modules/example/src/main/scala/example/FragmentExample.scala
@@ -25,7 +25,7 @@ object FragmentExample extends IOApp {
     val f3 = codes.toNel.map(cs => in(fr"code", cs))
 
     // Our final query
-    val q: Fragment =
+    val q: Fragment[Any] =
       fr"SELECT name, code, population FROM country" ++
       whereAndOpt(f1, f2, f3)                        ++
       fr"LIMIT $limit"

--- a/modules/postgres/src/main/scala/doobie/postgres/syntax/FragmentSyntax.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/syntax/FragmentSyntax.scala
@@ -16,7 +16,7 @@ import fs2.text._
 import java.io.StringReader
 import java.io.InputStream
 
-class FragmentOps(f: Fragment) {
+class FragmentOps[R](f: Fragment[R]) {
 
   /**
    * Given a fragment of the form `COPY table (col, ...) FROM STDIN` construct a
@@ -64,7 +64,7 @@ class FragmentOps(f: Fragment) {
 }
 
 trait ToFragmentOps {
-  implicit def toFragmentOps(f: Fragment): FragmentOps =
+  implicit def toFragmentOps[R](f: Fragment[R]): FragmentOps[R] =
     new FragmentOps(f)
 }
 

--- a/modules/postgres/src/test/scala/doobie/postgres/text.scala
+++ b/modules/postgres/src/test/scala/doobie/postgres/text.scala
@@ -48,7 +48,7 @@ class textspec extends Specification with ScalaCheck {
           | ) ON COMMIT DELETE ROWS
           |""".stripMargin.update.run.void
 
-  val insert: Fragment =
+  val insert: Fragment[Any] =
     sql"""| COPY test (a, b, c, d, e, f, g, h, i, j, k)
           | FROM STDIN
           |""".stripMargin


### PR DESCRIPTION
why:
sql interpolation is limited to binding concrete values only, typically as a way of producing Update0 and Query0 instances.
Having to switch to Update or Query with plain strings and explicit `?` to use updateMany is confusing
for beginners, and a bit annoying for everyone else. This change adds support for also building
Update and Query instances through sql-interpolation.

how:
`Fragment.Elem` gets two more cases `FunArg` and `FunOpt` for functions.
`Fragment.Elem`, `Fragment` and `SingleFragment` all gets a contravariant type parameter for keeping track of the input type to these functions.

To provide fairly good source compatibility with existing code, all methods on
Fragment touching the contravariant type is moved to two new implicit syntax-classes
Fragment0Syntax for Fragment[Any] providing the same api as today, yielding the same Update0 and Query0 instances,
and FragmentSyntax yielding Update and Query instances.

notes:
FirstExampleLens demonstrates interpolated Update using doobie lenses.
FirsExampleMonocle demonstrates how to add monocle support to reduce boilerplate
I also added docker-compose file in a separate commit to easily set up a working environment to run the tests.

warning:
this probably needs a lot more testing, but I wanted to see if there was any interest in this change before I pour more hours into this.