### PR TITLE
Add release-drafter

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,0 +1,7 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: | 
+  ## Changes
+  
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,18 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
I've setup a very barebone template as personally the app is just to keep track of changes since last release. 

Setup steps:

- Create a personal access token and give it the "repo:public_repo access" permission https://github.com/settings/tokens
![image](https://user-images.githubusercontent.com/4957161/93197495-d09c8200-f79f-11ea-85eb-983453eee672.png)
- Add the token to doobie repo settings with the name RELEASE_TOKEN
- Merge the PR :crossed_fingers: 