### PR TITLE
fixes NullPointer if nested exception has null msg

### DIFF
--- a/modules/core/src/main/scala/doobie/util/pretty.scala
+++ b/modules/core/src/main/scala/doobie/util/pretty.scala
@@ -55,6 +55,7 @@ object pretty {
     val empty = Block(Nil)
     def fromString(s: String) = Block(List(s))
     def fromLines(s: String) = Block(s.linesIterator.toList)
+    def fromErrorMsgLines(e: Throwable) = Block(Option(e.getMessage).toList.flatMap(_.linesIterator.toList))
 
     implicit val BlockMonoid: Monoid[Block] = new Monoid[Block] {
       def empty = Block.empty

--- a/modules/core/src/main/scala/doobie/util/testing.scala
+++ b/modules/core/src/main/scala/doobie/util/testing.scala
@@ -159,7 +159,7 @@ package object testing {
     case Left(e) =>
       List(AnalysisReport.Item(
         "SQL Compiles and TypeChecks",
-        Some(Block.fromLines(e.getMessage))
+        Some(Block.fromErrorMsgLines(e))
       ))
     case Right(a) =>
       AnalysisReport.Item("SQL Compiles and TypeChecks", None) ::


### PR DESCRIPTION
I got an error `SQLFeatureNotSupportedException` in a test, but it got covered by NullPointerException. This commit should fix it.