### PR TITLE
Keep PostgreSQL versions in sync

### DIFF
--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,2 +1,3 @@
 // Required for the freegen definition for postgres in ../build.sbt
-libraryDependencies += "org.postgresql" % "postgresql" % "42.2.17"
+val postgresVersion = "42.2.18"
+libraryDependencies += "org.postgresql" % "postgresql" % postgresVersion


### PR DESCRIPTION
This uses a `val` for the PostgreSQL version in `project/build.sbt` similar to how the version is [defined in the root `build.sbt`](https://github.com/tpolecat/doobie/blob/37416d8012f50cee28914c095a88b870437a25e8/build.sbt#L15) so that Scala Steward will update both versions at the same time. Recent updates only bumped the version in `build.sbt` (https://github.com/tpolecat/doobie/pull/1290) or in `project/build.sbt` (https://github.com/tpolecat/doobie/pull/1284).