### PR TITLE
docs - use 4 spaces instead of 2 for sub-lists

### DIFF
--- a/modules/docs/src/main/mdoc/docs/04-Selecting.md
+++ b/modules/docs/src/main/mdoc/docs/04-Selecting.md
@@ -65,10 +65,10 @@ Let's break this down a bit.
 
 - `sql"select name from country".query[String]` defines a `Query0[String]`, which is a one-column query that maps each returned row to a `String`. We will get to more interesting row types soon.
 - `.to[List]` is a convenience method that accumulates rows into a `List`, in this case yielding a `ConnectionIO[List[String]]`. It works with any collection type that has a `CanBuildFrom`. Similar methods are:
-  - `.unique` which returns a single value, raising an exception if there is not exactly one row returned.
-  - `.option` which returns an `Option`, raising an exception if there is more than one row returned.
-  - `.nel` which returns an `NonEmptyList`, raising an exception if there are no rows returned.
-  - See the Scaladoc for `Query0` for more information on these and other methods.
+    - `.unique` which returns a single value, raising an exception if there is not exactly one row returned.
+    - `.option` which returns an `Option`, raising an exception if there is more than one row returned.
+    - `.nel` which returns an `NonEmptyList`, raising an exception if there are no rows returned.
+    - See the Scaladoc for `Query0` for more information on these and other methods.
 - The rest is familar; `transact(xa)` yields a `IO[List[String]]` which we run, giving us a normal Scala `List[String]` that we print out.
 
 ### Internal Streaming

--- a/modules/docs/src/main/mdoc/docs/14-Managing-Connections.md
+++ b/modules/docs/src/main/mdoc/docs/14-Managing-Connections.md
@@ -25,8 +25,8 @@ A `Transactor[M]` consists of the following bits of information:
 Given this information a `Transactor[M]` can provide the following transformations:
 
 - `trans: ConnectionIO ~> M` A natural transformation of a program in `ConnectionIO` to the target monad `M` that uses the given `Strategy` to wrap the given program with additional setup, error-handling and cleanup operations. This yields an independent program in `M`. This is the most common way to run a doobie program.
-  - e.g., `xa.trans.apply(program1)`
-  - you can also use the syntax `program1.transact(xa)`, which runs `xa.trans` under the hood
+    - e.g., `xa.trans.apply(program1)`
+    - you can also use the syntax `program1.transact(xa)`, which runs `xa.trans` under the hood
 - `rawTrans` natural transformation equivalent to `trans` but one that does not use the provided `Strategy` to wrap the given program with additional operations. This can be useful in cases where transactional handling is unsupported or undesired.
 - `rawTransP: Stream[ConnectionIO, ?] ~> Stream[M, ?]` equivalent to `rawTrans` but expressed using `Stream`.
 - `transP: Stream[ConnectionIO, ?] ~> Stream[M, ?]` equivalent to `trans` but expressed using `Stream`.


### PR DESCRIPTION
As reported in https://github.com/tpolecat/doobie/issues/1288, sub-lists are not being shown as expected in Doobie documentation. This is because when using paradox, [4 spaces or a tab of indentation are needed for sub-lists to be rendered as expected](https://github.com/lightbend/paradox/issues/452#issuecomment-711138155), but Doobie docs are using 2 spaces indentation for sub-lists.

This PR fixes that. I've build the docs locally and confirmed that the sub-lists now are shown as expected.