### PR TITLE
update setup-scala GH action to v10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 13
-        uses: olafurpg/setup-scala@v2
+        uses: olafurpg/setup-scala@v10
         with:
           java-version: 13
       - name: Cache SBT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: olafurpg/setup-scala@v2
+      - uses: olafurpg/setup-scala@v10
       - name: Cache SBT
         uses: coursier/cache-action@v3
-      - uses: olafurpg/setup-gpg@v2
+      - uses: olafurpg/setup-gpg@v3
       - name: Publish
         run: csbt version "git status" ci-release "git status"
         env:


### PR DESCRIPTION
Fixes
```
 Error: Unable to process command '::add-path::/home/runner/bin' successfully.
  Error: The `add-path` command is disabled.
```