### PR TITLE
Add withOptionalGeneratedKeys to Update and Update0

### DIFF
--- a/modules/core/src/main/scala/doobie/hi/preparedstatement.scala
+++ b/modules/core/src/main/scala/doobie/hi/preparedstatement.scala
@@ -94,6 +94,10 @@ object preparedstatement {
   def executeUpdateWithUniqueGeneratedKeys[A: Read]: PreparedStatementIO[A] =
     executeUpdate.flatMap(_ => getUniqueGeneratedKeys[A])
 
+  /** @group Execution */
+  def executeUpdateWithOptionallyGeneratedKeys[A: Read]: PreparedStatementIO[Option[A]] =
+    executeUpdate.flatMap(_ => getOptionallyGeneratedKeys[A])
+
  /** @group Execution */
   def executeUpdateWithGeneratedKeys[A: Read](chunkSize: Int): Stream[PreparedStatementIO, A] =
     bracket(FPS.executeUpdate *> FPS.getGeneratedKeys)(FPS.embed(_, FRS.close)).flatMap(unrolled[A](_, chunkSize))
@@ -141,6 +145,10 @@ object preparedstatement {
   /** @group Results */
   def getUniqueGeneratedKeys[A: Read]: PreparedStatementIO[A] =
     getGeneratedKeys(resultset.getUnique[A])
+
+  /** @group Results */
+  def getOptionallyGeneratedKeys[A: Read]: PreparedStatementIO[Option[A]] =
+    getGeneratedKeys(resultset.getOption[A])
 
   /**
    * Compute the parameter `JdbcMeta` list for this `PreparedStatement`.

--- a/modules/core/src/main/scala/doobie/util/update.scala
+++ b/modules/core/src/main/scala/doobie/util/update.scala
@@ -150,6 +150,16 @@ object update {
       HC.prepareStatementS(sql, columns.toList)(HPS.set(a) *> HPS.executeUpdateWithUniqueGeneratedKeys)
 
     /**
+     * Construct a program that performs the update, yielding an optional set of generated keys of
+     * readable type `K`, identified by the specified columns. Note that not all drivers support
+     * generated keys, and some support only a single key column.
+     *
+     * @group Execution
+     */
+    def withOptionalGeneratedKeys[K: Read](columns: String*)(a: A): ConnectionIO[Option[K]] =
+      HC.prepareStatementS(sql, columns.toList)(HPS.set(a) *> HPS.executeUpdateWithOptionallyGeneratedKeys)
+
+    /**
      * Update is a contravariant functor.
      * @group Transformations
      */
@@ -177,6 +187,8 @@ object update {
         def withUniqueGeneratedKeys[K: Read](columns: String*) =
           u.withUniqueGeneratedKeys(columns: _*)(a)
         def inspect[R](f: (String, PreparedStatementIO[Unit]) => ConnectionIO[R]) = u.inspect(a)(f)
+        def withOptionalGeneratedKeys[K: Read](columns: String*): doobie.ConnectionIO[Option[K]] =
+          u.withOptionalGeneratedKeys(columns: _*)(a)
       }
 
   }
@@ -274,6 +286,14 @@ object update {
      * @group Execution
      */
     def withUniqueGeneratedKeys[K: Read](columns: String*): ConnectionIO[K]
+
+    /**
+     * Construct a program that performs the update, yielding an optional set of generated keys of
+     * readable type `K`, identified by the specified columns. Note that not all drivers support
+     * generated keys, and some support only a single key column.
+     * @group Execution
+     */
+    def withOptionalGeneratedKeys[K: Read](columns: String*): ConnectionIO[Option[K]]
 
   }
 


### PR DESCRIPTION
Some databases (like postgres) does not always return a row when upserting.

- [ ] Needs a test.