### PR TITLE
Revert magnolia

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,6 @@ lazy val fs2Version           = "2.5.0"
 lazy val h2Version            = "1.4.200"
 lazy val hikariVersion        = "3.4.5"
 lazy val kindProjectorVersion = "0.11.2"
-lazy val magnoliaVersion      = "0.17.0"
 lazy val monixVersion         = "3.3.0"
 lazy val quillVersion         = "3.6.1"
 lazy val postGisVersion       = "2.5.0"
@@ -17,6 +16,7 @@ lazy val postgresVersion      = "42.2.19"
 lazy val refinedVersion       = "0.9.19"
 lazy val scalaCheckVersion    = "1.15.1"
 lazy val scalatestVersion     = "3.2.6"
+lazy val shapelessVersion     = "2.3.3"
 lazy val silencerVersion      = "1.7.1"
 lazy val specs2Version        = "4.10.6"
 lazy val scala212Version      = "2.12.12"
@@ -218,7 +218,7 @@ lazy val core = project
     name := "doobie-core",
     description := "Pure functional JDBC layer for Scala.",
     libraryDependencies ++= Seq(
-      "com.propensive" %% "magnolia"  % magnoliaVersion,
+      "com.chuusai"    %% "shapeless" % shapelessVersion,
     ).filterNot(_ => isDotty.value) ++ Seq(
       "org.tpolecat"   %% "typename"  % "0.1.3",
       "com.h2database" %  "h2"        % h2Version % "test",
@@ -435,6 +435,7 @@ lazy val docs = project
       "scaladoc.doobie.base_url" -> s"https://static.javadoc.io/org.tpolecat/doobie-core_2.12/${version.value}",
       "catsVersion"              -> catsVersion,
       "fs2Version"               -> fs2Version,
+      "shapelessVersion"         -> shapelessVersion,
       "h2Version"                -> h2Version,
       "postgresVersion"          -> postgresVersion,
       "quillVersion"             -> quillVersion,

--- a/modules/core/src/main/scala-2/util/GetPlatform.scala
+++ b/modules/core/src/main/scala-2/util/GetPlatform.scala
@@ -4,4 +4,22 @@
 
 package doobie.util
 
-trait GetPlatform
+import scala.reflect.runtime.universe.TypeTag
+import shapeless._
+import shapeless.ops.hlist.IsHCons
+
+trait GetPlatform {
+  import doobie.util.compat.=:=
+
+  /** @group Instances */
+  implicit def unaryProductGet[A: TypeTag, L <: HList, H, T <: HList](
+     implicit G: Generic.Aux[A, L],
+              C: IsHCons.Aux[L, H, T],
+              H: Lazy[Get[H]],
+              E: (H :: HNil) =:= L
+  ): Get[A] = {
+    void(C) // C drives inference but is not used directly
+    H.value.tmap[A](h => G.from(h :: HNil))
+  }
+
+}

--- a/modules/core/src/main/scala-2/util/PutPlatform.scala
+++ b/modules/core/src/main/scala-2/util/PutPlatform.scala
@@ -4,4 +4,22 @@
 
 package doobie.util
 
-trait PutPlatform
+import scala.reflect.runtime.universe.TypeTag
+import shapeless._
+import shapeless.ops.hlist.IsHCons
+
+trait PutPlatform {
+  import doobie.util.compat.=:=
+
+  /** @group Instances */
+  implicit def unaryProductPut[A: TypeTag, L <: HList, H, T <: HList](
+     implicit G: Generic.Aux[A, L],
+              C: IsHCons.Aux[L, H, T],
+              H: Lazy[Put[H]],
+              E: (H :: HNil) =:= L
+  ): Put[A] = {
+    void(E) // E is a necessary constraint but isn't used directly
+    H.value.contramap[A](a => G.to(a).head)
+  }
+
+}

--- a/modules/core/src/main/scala-2/util/ReadPlatform.scala
+++ b/modules/core/src/main/scala-2/util/ReadPlatform.scala
@@ -4,26 +4,46 @@
 
 package doobie.util
 
-import magnolia.{CaseClass, Magnolia}
-import java.sql.ResultSet
+import shapeless.{ HList, HNil, ::, Generic, Lazy}
+import shapeless.labelled.{ field, FieldType }
 
-trait ReadPlatform  { this: Read.type =>
-  type Typeclass[T] = Read[T]
+trait ReadPlatform extends LowerPriorityRead { this: Read.type =>
 
-  def combine[T](ctx: CaseClass[Read, T]): Read[T] = {
-    val gets   = ctx.parameters.toList.flatMap(_.typeclass.gets)
-    val offset = ctx.parameters.scanLeft(0)(_ + _.typeclass.gets.length)
-
-    def unsafeGet(rs: ResultSet, index: Int): T =
-      ctx.construct(p => p.typeclass.unsafeGet(rs, index + offset(p.index)))
-
-    def unsafeGetOption(rs: ResultSet, index: Int): Option[T] =
-      ctx.constructMonadic(p => p.typeclass.unsafeGetOption(rs, index + offset(p.index)))
-
-    new Read(gets, unsafeGet, unsafeGetOption)
-  }
-
-  implicit def generic[A]: Read[A] = macro Magnolia.gen[A]
+  implicit def recordRead[K <: Symbol, H, T <: HList](
+    implicit H: Lazy[Read[H]],
+              T: Lazy[Read[T]]
+  ): Read[FieldType[K, H] :: T] =
+    new Read[FieldType[K, H] :: T](
+      H.value.gets ++ T.value.gets,
+      (rs, n) => field[K](H.value.unsafeGet(rs, n)) :: T.value.unsafeGet(rs, n + H.value.length),
+      (rs, n) =>
+        for {
+          h <- H.value.unsafeGetOption(rs, n)
+          t <- T.value.unsafeGetOption(rs, n + H.value.length)
+        } yield field[K](h) :: t
+    )
 }
 
+trait LowerPriorityRead { this: Read.type =>
 
+  implicit def product[H, T <: HList](implicit H: Lazy[Read[H]], T: Lazy[Read[T]]): Read[H :: T] =
+    new Read[H :: T](
+      H.value.gets ++ T.value.gets,
+      (rs, n) => H.value.unsafeGet(rs, n) :: T.value.unsafeGet(rs, n + H.value.length),
+      (rs, n) =>
+        for {
+          h <- H.value.unsafeGetOption(rs, n)
+          t <- T.value.unsafeGetOption(rs, n + H.value.length)
+        } yield h :: t
+    )
+
+  implicit val emptyProduct: Read[HNil] =
+    new Read[HNil](Nil, (_, _) => HNil, (_, _) => Option(HNil))
+
+  implicit def generic[F, G](implicit gen: Generic.Aux[F, G], G: Lazy[Read[G]]): Read[F] =
+    new Read[F](
+      G.value.gets,
+      (rs, n) => gen.from(G.value.unsafeGet(rs, n)),
+      (rs, n) => G.value.unsafeGetOption(rs, n).map(gen.from),
+    )
+}

--- a/modules/core/src/main/scala-2/util/ReadPlatform.scala
+++ b/modules/core/src/main/scala-2/util/ReadPlatform.scala
@@ -15,35 +15,26 @@ trait ReadPlatform extends LowerPriorityRead { this: Read.type =>
   ): Read[FieldType[K, H] :: T] =
     new Read[FieldType[K, H] :: T](
       H.value.gets ++ T.value.gets,
-      (rs, n) => field[K](H.value.unsafeGet(rs, n)) :: T.value.unsafeGet(rs, n + H.value.length),
-      (rs, n) =>
-        for {
-          h <- H.value.unsafeGetOption(rs, n)
-          t <- T.value.unsafeGetOption(rs, n + H.value.length)
-        } yield field[K](h) :: t
+      (rs, n) => field[K](H.value.unsafeGet(rs, n)) :: T.value.unsafeGet(rs, n + H.value.length)
     )
+
 }
 
 trait LowerPriorityRead { this: Read.type =>
 
-  implicit def product[H, T <: HList](implicit H: Lazy[Read[H]], T: Lazy[Read[T]]): Read[H :: T] =
+  implicit def product[H, T <: HList](
+    implicit H: Lazy[Read[H]],
+              T: Lazy[Read[T]]
+  ): Read[H :: T] =
     new Read[H :: T](
       H.value.gets ++ T.value.gets,
-      (rs, n) => H.value.unsafeGet(rs, n) :: T.value.unsafeGet(rs, n + H.value.length),
-      (rs, n) =>
-        for {
-          h <- H.value.unsafeGetOption(rs, n)
-          t <- T.value.unsafeGetOption(rs, n + H.value.length)
-        } yield h :: t
+      (rs, n) => H.value.unsafeGet(rs, n) :: T.value.unsafeGet(rs, n + H.value.length)
     )
 
-  implicit val emptyProduct: Read[HNil] =
-    new Read[HNil](Nil, (_, _) => HNil, (_, _) => Option(HNil))
+  implicit def emptyProduct: Read[HNil] =
+    new Read[HNil](Nil, (_, _) => HNil)
 
   implicit def generic[F, G](implicit gen: Generic.Aux[F, G], G: Lazy[Read[G]]): Read[F] =
-    new Read[F](
-      G.value.gets,
-      (rs, n) => gen.from(G.value.unsafeGet(rs, n)),
-      (rs, n) => G.value.unsafeGetOption(rs, n).map(gen.from),
-    )
+    new Read[F](G.value.gets, (rs, n) => gen.from(G.value.unsafeGet(rs, n)))
+
 }

--- a/modules/core/src/main/scala-2/util/ReadPlatform.scala
+++ b/modules/core/src/main/scala-2/util/ReadPlatform.scala
@@ -4,7 +4,7 @@
 
 package doobie.util
 
-import shapeless.{ HList, HNil, ::, Generic, Lazy}
+import shapeless.{ HList, HNil, ::, Generic, Lazy, <:!< }
 import shapeless.labelled.{ field, FieldType }
 
 trait ReadPlatform extends LowerPriorityRead { this: Read.type =>
@@ -20,7 +20,7 @@ trait ReadPlatform extends LowerPriorityRead { this: Read.type =>
 
 }
 
-trait LowerPriorityRead { this: Read.type =>
+trait LowerPriorityRead extends EvenLower { this: Read.type =>
 
   implicit def product[H, T <: HList](
     implicit H: Lazy[Read[H]],
@@ -38,3 +38,42 @@ trait LowerPriorityRead { this: Read.type =>
     new Read[F](G.value.gets, (rs, n) => gen.from(G.value.unsafeGet(rs, n)))
 
 }
+
+trait EvenLower {
+
+  implicit val ohnil: Read[Option[HNil]] =
+    new Read[Option[HNil]](Nil, (_, _) => Some(HNil))
+
+  implicit def ohcons1[H, T <: HList](
+    implicit H: Lazy[Read[Option[H]]],
+              T: Lazy[Read[Option[T]]],
+              N: H <:!< Option[α] forSome { type α }
+  ): Read[Option[H :: T]] = {
+    void(N)
+    new Read[Option[H :: T]](
+      H.value.gets ++ T.value.gets,
+      (rs, n) =>
+        for {
+          h <- H.value.unsafeGet(rs, n)
+          t <- T.value.unsafeGet(rs, n + H.value.length)
+        } yield h :: t
+    )
+  }
+
+  implicit def ohcons2[H, T <: HList](
+    implicit H: Lazy[Read[Option[H]]],
+              T: Lazy[Read[Option[T]]]
+  ): Read[Option[Option[H] :: T]] =
+    new Read[Option[Option[H] :: T]](
+      H.value.gets ++ T.value.gets,
+      (rs, n) => T.value.unsafeGet(rs, n + H.value.length).map(H.value.unsafeGet(rs, n) :: _)
+    )
+
+  implicit def ogeneric[A, Repr <: HList](
+    implicit G: Generic.Aux[A, Repr],
+              B: Lazy[Read[Option[Repr]]]
+  ): Read[Option[A]] =
+    new Read[Option[A]](B.value.gets, B.value.unsafeGet(_, _).map(G.from))
+
+}
+

--- a/modules/core/src/main/scala-2/util/WritePlatform.scala
+++ b/modules/core/src/main/scala-2/util/WritePlatform.scala
@@ -36,7 +36,7 @@ trait LowerPriorityWrite {
       { case (rs, n, h :: t) => H.value.unsafeUpdate(rs, n, h); T.value.unsafeUpdate(rs, n + H.value.length, t) }
     )
 
-  implicit val emptyProduct: Write[HNil] =
+  implicit def emptyProduct: Write[HNil] =
     new Write[HNil](Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
 
   implicit def generic[B, A](implicit gen: Generic.Aux[B, A], A: Lazy[Write[A]]): Write[B] =

--- a/modules/core/src/main/scala-2/util/WritePlatform.scala
+++ b/modules/core/src/main/scala-2/util/WritePlatform.scala
@@ -5,70 +5,47 @@
 package doobie.util
 
 import shapeless.{ HList, HNil, ::, Generic, Lazy}
-import shapeless.labelled.FieldType
+import shapeless.labelled.{ FieldType }
 
 trait WritePlatform extends LowerPriorityWrite {
 
-  implicit def recordWrite[K <: Symbol, H, T <: HList](implicit H: Lazy[Write[H]], T: Lazy[Write[T]]): Write[FieldType[K, H] :: T] = {
+  implicit def recordWrite[K <: Symbol, H, T <: HList](
+    implicit H: Lazy[Write[H]],
+              T: Lazy[Write[T]]
+  ): Write[FieldType[K, H] :: T] = {
     new Write(
-      puts = H.value.puts ++ T.value.puts,
-      toList = { case h :: t => H.value.toList(h) ++ T.value.toList(t)},
-      unsafeSet = { case (ps, n, h :: t) =>
-        H.value.unsafeSet(ps, n, h)
-        T.value.unsafeSet(ps, n + H.value.length, t)
-      },
-      unsafeUpdate = { case (rs, n, h :: t) =>
-        H.value.unsafeUpdate(rs, n, h)
-        T.value.unsafeUpdate(rs, n + H.value.length, t)
-      },
-      unsafeSetOption = { case (ps, n, oht) =>
-        H.value.unsafeSetOption(ps, n, oht.map(_.head))
-        T.value.unsafeSetOption(ps, n + H.value.length, oht.map(_.tail))
-      },
-      unsafeUpdateOption = { case (rs, n, oht) =>
-        H.value.unsafeUpdateOption(rs, n, oht.map(_.head))
-        T.value.unsafeUpdateOption(rs, n + H.value.length, oht.map(_.tail))
-      },
+      H.value.puts ++ T.value.puts,
+      { case h :: t => H.value.toList(h) ++ T.value.toList(t) },
+      { case (ps, n, h :: t) => H.value.unsafeSet(ps, n, h); T.value.unsafeSet(ps, n + H.value.length, t) },
+      { case (rs, n, h :: t) => H.value.unsafeUpdate(rs, n, h); T.value.unsafeUpdate(rs, n + H.value.length, t) }
     )
   }
 
 }
 
 trait LowerPriorityWrite {
-  implicit def product[H, T <: HList](implicit H: Lazy[Write[H]], T: Lazy[Write[T]]): Write[H :: T] =
+
+  implicit def product[H, T <: HList](
+    implicit H: Lazy[Write[H]],
+              T: Lazy[Write[T]]
+  ): Write[H :: T] =
     new Write(
-      puts = H.value.puts ++ T.value.puts,
-      toList = { case h :: t => H.value.toList(h) ++ T.value.toList(t) },
-      unsafeSet = { case (ps, n, h :: t) =>
-        H.value.unsafeSet(ps, n, h)
-        T.value.unsafeSet(ps, n + H.value.length, t)
-      },
-      unsafeUpdate = { case (rs, n, h :: t) =>
-        H.value.unsafeUpdate(rs, n, h)
-        T.value.unsafeUpdate(rs, n + H.value.length, t)
-      },
-      unsafeSetOption = { case (ps, n, oht) =>
-        H.value.unsafeSetOption(ps, n, oht.map(_.head))
-        T.value.unsafeSetOption(ps, n + H.value.length, oht.map(_.tail))
-      },
-      unsafeUpdateOption = { case (rs, n, oht) =>
-        H.value.unsafeUpdateOption(rs, n, oht.map(_.head))
-        T.value.unsafeUpdateOption(rs, n + H.value.length, oht.map(_.tail))
-      },
+      H.value.puts ++ T.value.puts,
+      { case h :: t => H.value.toList(h) ++ T.value.toList(t) },
+      { case (ps, n, h :: t) => H.value.unsafeSet(ps, n, h); T.value.unsafeSet(ps, n + H.value.length, t) },
+      { case (rs, n, h :: t) => H.value.unsafeUpdate(rs, n, h); T.value.unsafeUpdate(rs, n + H.value.length, t) }
     )
 
   implicit val emptyProduct: Write[HNil] =
-    new Write[HNil](
-      puts = Nil,
-      toList = _ => Nil,
-      unsafeSet = (_, _, _) => (),
-      unsafeUpdate = (_, _, _) => (),
-      unsafeSetOption = (_, _, _) => (),
-      unsafeUpdateOption = (_, _, _) => (),
+    new Write[HNil](Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
+
+  implicit def generic[B, A](implicit gen: Generic.Aux[B, A], A: Lazy[Write[A]]): Write[B] =
+    new Write[B](
+      A.value.puts,
+      b => A.value.toList(gen.to(b)),
+      (ps, n, b) => A.value.unsafeSet(ps, n, gen.to(b)),
+      (rs, n, b) => A.value.unsafeUpdate(rs, n, gen.to(b))
     )
 
-  implicit def generic[B, A](implicit gen: Generic.Aux[B, A], A: Lazy[Write[A]]): Write[B] = {
-    A.value.contramap(gen.to)
-  }
 }
 

--- a/modules/core/src/main/scala-2/util/WritePlatform.scala
+++ b/modules/core/src/main/scala-2/util/WritePlatform.scala
@@ -4,31 +4,71 @@
 
 package doobie.util
 
-import magnolia._
-import java.sql.{PreparedStatement, ResultSet}
+import shapeless.{ HList, HNil, ::, Generic, Lazy}
+import shapeless.labelled.FieldType
 
-trait WritePlatform {
-  type Typeclass[A] = Write[A]
+trait WritePlatform extends LowerPriorityWrite {
 
-  def combine[A](ctx: ReadOnlyCaseClass[Write, A]): Write[A] = {
-    val puts         = ctx.parameters.toList.flatMap(_.typeclass.puts)
-    val offset       = ctx.parameters.scanLeft(0)(_ + _.typeclass.puts.length)
-    def toList(a: A) = ctx.parameters.toList.flatMap(param => param.typeclass.toList(param.dereference(a)))
-
-    def unsafeSet(ps: PreparedStatement, n: Int, a: A) =
-      ctx.parameters.foreach(param => param.typeclass.unsafeSet(ps, n + offset(param.index), param.dereference(a)))
-
-    def unsafeUpdate(rs: ResultSet, n: Int, a: A) =
-      ctx.parameters.foreach(param => param.typeclass.unsafeUpdate(rs, n + offset(param.index), param.dereference(a)))
-
-    def unsafeSetOption(ps: PreparedStatement, n: Int, oa: Option[A]) =
-      ctx.parameters.foreach(param => param.typeclass.unsafeSetOption(ps, n + offset(param.index), oa.map(param.dereference)))
-
-    def unsafeUpdateOption(rs: ResultSet, n: Int, oa: Option[A]) =
-      ctx.parameters.foreach(param => param.typeclass.unsafeUpdateOption(rs, n + offset(param.index), oa.map(param.dereference)))
-
-    new Write(puts, toList, unsafeSet, unsafeUpdate, unsafeSetOption, unsafeUpdateOption)
+  implicit def recordWrite[K <: Symbol, H, T <: HList](implicit H: Lazy[Write[H]], T: Lazy[Write[T]]): Write[FieldType[K, H] :: T] = {
+    new Write(
+      puts = H.value.puts ++ T.value.puts,
+      toList = { case h :: t => H.value.toList(h) ++ T.value.toList(t)},
+      unsafeSet = { case (ps, n, h :: t) =>
+        H.value.unsafeSet(ps, n, h)
+        T.value.unsafeSet(ps, n + H.value.length, t)
+      },
+      unsafeUpdate = { case (rs, n, h :: t) =>
+        H.value.unsafeUpdate(rs, n, h)
+        T.value.unsafeUpdate(rs, n + H.value.length, t)
+      },
+      unsafeSetOption = { case (ps, n, oht) =>
+        H.value.unsafeSetOption(ps, n, oht.map(_.head))
+        T.value.unsafeSetOption(ps, n + H.value.length, oht.map(_.tail))
+      },
+      unsafeUpdateOption = { case (rs, n, oht) =>
+        H.value.unsafeUpdateOption(rs, n, oht.map(_.head))
+        T.value.unsafeUpdateOption(rs, n + H.value.length, oht.map(_.tail))
+      },
+    )
   }
 
-  implicit def generic[A]: Write[A] = macro Magnolia.gen[A]
 }
+
+trait LowerPriorityWrite {
+  implicit def product[H, T <: HList](implicit H: Lazy[Write[H]], T: Lazy[Write[T]]): Write[H :: T] =
+    new Write(
+      puts = H.value.puts ++ T.value.puts,
+      toList = { case h :: t => H.value.toList(h) ++ T.value.toList(t) },
+      unsafeSet = { case (ps, n, h :: t) =>
+        H.value.unsafeSet(ps, n, h)
+        T.value.unsafeSet(ps, n + H.value.length, t)
+      },
+      unsafeUpdate = { case (rs, n, h :: t) =>
+        H.value.unsafeUpdate(rs, n, h)
+        T.value.unsafeUpdate(rs, n + H.value.length, t)
+      },
+      unsafeSetOption = { case (ps, n, oht) =>
+        H.value.unsafeSetOption(ps, n, oht.map(_.head))
+        T.value.unsafeSetOption(ps, n + H.value.length, oht.map(_.tail))
+      },
+      unsafeUpdateOption = { case (rs, n, oht) =>
+        H.value.unsafeUpdateOption(rs, n, oht.map(_.head))
+        T.value.unsafeUpdateOption(rs, n + H.value.length, oht.map(_.tail))
+      },
+    )
+
+  implicit val emptyProduct: Write[HNil] =
+    new Write[HNil](
+      puts = Nil,
+      toList = _ => Nil,
+      unsafeSet = (_, _, _) => (),
+      unsafeUpdate = (_, _, _) => (),
+      unsafeSetOption = (_, _, _) => (),
+      unsafeUpdateOption = (_, _, _) => (),
+    )
+
+  implicit def generic[B, A](implicit gen: Generic.Aux[B, A], A: Lazy[Write[A]]): Write[B] = {
+    A.value.contramap(gen.to)
+  }
+}
+

--- a/modules/core/src/main/scala-3.0.0-M2/util/ReadPlatform.scala
+++ b/modules/core/src/main/scala-3.0.0-M2/util/ReadPlatform.scala
@@ -10,18 +10,13 @@ trait ReadPlatform:
 
   // Trivial Read for EmptyTuple
   given Read[EmptyTuple] =
-    new Read[EmptyTuple](Nil, (_, _) => EmptyTuple, (_, _) => Some(EmptyTuple))
+    new Read[EmptyTuple](Nil, (_, _) => EmptyTuple)
 
   // Read for head and tail.
   given [H, T <: Tuple](using H: => Read[H], T: => Read[T]) as Read[H *: T] =
     new Read[H *: T](
       H.gets ++ T.gets,
-      (rs, n) => H.unsafeGet(rs, n) *: T.unsafeGet(rs, n + H.length),
-      (rs, n) =>
-        for {
-        h <- H.unsafeGetOption(rs, n)
-        t <- T.unsafeGetOption(rs, n + H.length)
-        } yield h *: t
+      (rs, n) => H.unsafeGet(rs, n) *: T.unsafeGet(rs, n + H.length)
     )
 
   // Generic Read for products.

--- a/modules/core/src/main/scala-3.0.0-M2/util/ReadPlatform.scala
+++ b/modules/core/src/main/scala-3.0.0-M2/util/ReadPlatform.scala
@@ -27,3 +27,38 @@ trait ReadPlatform:
   ) as Read[P] =
     w.map(a => m.fromProduct(i(a)))
 
+  given roe as Read[Option[EmptyTuple]] =
+    new Read[Option[EmptyTuple]](Nil, (_, _) => Some(EmptyTuple))
+
+  given rou as Read[Option[Unit]] =
+    new Read[Option[Unit]](Nil, (_, _) => Some(()))
+
+  given cons1[H, T <: Tuple](
+    using H: => Read[Option[H]],
+          T: => Read[Option[T]],
+  ) as Read[Option[H *: T]] =
+    new Read[Option[H *: T]](
+      H.gets ++ T.gets,
+      (rs, n) =>
+        for {
+          h <- H.unsafeGet(rs, n)
+          t <- T.unsafeGet(rs, n + H.length)
+        } yield h *: t
+    )
+
+  given cons2[H, T <: Tuple](
+    using H: => Read[Option[H]],
+          T: => Read[Option[T]]
+  ) as Read[Option[Option[H] *: T]] =
+    new Read[Option[Option[H] *: T]](
+      H.gets ++ T.gets,
+      (rs, n) => T.unsafeGet(rs, n + H.length).map(H.unsafeGet(rs, n) *: _)
+    )
+
+  // Generic Read for option of products.
+  given [P <: Product, A](
+    using m: Mirror.ProductOf[P],
+          i: A =:= m.MirroredElemTypes,
+          w: Read[Option[A]]
+  ) as Read[Option[P]] =
+    w.map(a => a.map(a => m.fromProduct(i(a))))

--- a/modules/core/src/main/scala-3.0.0-M2/util/WritePlatform.scala
+++ b/modules/core/src/main/scala-3.0.0-M2/util/WritePlatform.scala
@@ -32,3 +32,48 @@ trait WritePlatform:
   // Trivial write for option of empty tuple.
   given woe as Write[Option[EmptyTuple]] =
     new Write[Option[EmptyTuple]](Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
+
+  // Trivial write for option of Unit.
+  given wou as Write[Option[Unit]] =
+    new Write[Option[Unit]](Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
+
+  // Write[Option[H]], Write[Option[T]] implies Write[Option[H *: T]]
+  given cons1[H, T <: Tuple](
+    using H: => Write[Option[H]],
+          T: => Write[Option[T]],
+          // N: H <:!< Option[_],
+  ) as Write[Option[H *: T]] =
+
+    def split[A](i: Option[H *: T])(f: (Option[H], Option[T]) => A): A =
+      i.fold(f(None, None)) { case h *: t => f(Some(h), Some(t)) }
+
+    new Write(
+      H.puts ++ T.puts,
+      split(_) { (h, t) => H.toList(h) ++ T.toList(t) },
+      (ps, n, i) => split(i) { (h, t) => H.unsafeSet(ps, n, h); T.unsafeSet(ps, n + H.length, t) },
+      (rs, n, i) => split(i) { (h, t) => H.unsafeUpdate(rs, n, h); T.unsafeUpdate(rs, n + H.length, t) }
+    )
+
+  // Write[Option[H]], Write[Option[T]] implies Write[Option[Option[H] *: T]]
+  given cons2[H, T <: Tuple](
+    using H: => Write[Option[H]],
+          T: => Write[Option[T]]
+  ) as Write[Option[Option[H] *: T]] =
+
+    def split[A](i: Option[Option[H] *: T])(f: (Option[H], Option[T]) => A): A =
+      i.fold(f(None, None)) { case oh *: t => f(oh, Some(t)) }
+
+    new Write(
+      H.puts ++ T.puts,
+      split(_) { (h, t) => H.toList(h) ++ T.toList(t) },
+      (ps, n, i) => split(i) { (h, t) => H.unsafeSet(ps, n, h); T.unsafeSet(ps, n + H.length, t) },
+      (rs, n, i) => split(i) { (h, t) => H.unsafeUpdate(rs, n, h); T.unsafeUpdate(rs, n + H.length, t) }
+    )
+
+  // Generic write for options of products.
+  given [P <: Product, A](
+    using m: Mirror.ProductOf[P],
+          i: m.MirroredElemTypes =:= A,
+          w: Write[Option[A]]
+  ) as Write[Option[P]] =
+    w.contramap(op => op.map(p => i(Tuple.fromProductTyped(p))))

--- a/modules/core/src/main/scala-3.0.0-M2/util/WritePlatform.scala
+++ b/modules/core/src/main/scala-3.0.0-M2/util/WritePlatform.scala
@@ -10,36 +10,15 @@ trait WritePlatform:
 
   // Trivial write for empty tuple.
   given Write[EmptyTuple] =
-    new Write(
-      puts = Nil,
-      toList = _ => Nil,
-      unsafeSet = (_, _, _) => (),
-      unsafeUpdate = (_, _, _) => (),
-      unsafeSetOption = (_, _, _) => (),
-      unsafeUpdateOption = (_, _, _) => (),
-    )
+    new Write(Nil, _ => Nil, (_, _, _) => (),(_, _, _) => ())
 
   // Inductive write for writable head and tail.
   given [H, T <: Tuple](using H: => Write[H], T: => Write[T]) as Write[H *: T] =
     new Write(
-      puts = H.puts ++ T.puts,
-      toList = { case h *: t => H.toList(h) ++ T.toList(t) },
-      unsafeSet = { case (ps, n, h *: t) =>
-        H.unsafeSet(ps, n, h)
-        T.unsafeSet(ps, n + H.length, t)
-      },
-      unsafeUpdate = { case (rs, n, h *: t) =>
-        H.unsafeUpdate(rs, n, h);
-        T.unsafeUpdate(rs, n + H.length, t)
-      },
-      unsafeSetOption = { case (ps, n, oht) =>
-        H.unsafeSetOption(ps, n, oht.map(_.head))
-        T.unsafeSetOption(ps, n + H.length, oht.map(_.tail))
-      },
-      unsafeUpdateOption = { case (rs, n, oht) =>
-        H.unsafeUpdateOption(rs, n, oht.map(_.head))
-        T.unsafeUpdateOption(rs, n + H.length, oht.map(_.tail))
-      },
+      H.puts ++ T.puts,
+      { case h *: t => H.toList(h) ++ T.toList(t) },
+      { case (ps, n, h *: t) => H.unsafeSet(ps, n, h); T.unsafeSet(ps, n + H.length, t) },
+      { case (rs, n, h *: t) => H.unsafeUpdate(rs, n, h); T.unsafeUpdate(rs, n + H.length, t) }
     )
 
   // Generic write for products.
@@ -49,3 +28,7 @@ trait WritePlatform:
           w: Write[A]
   ) as Write[P] =
     w.contramap(p => i(Tuple.fromProductTyped(p)))
+
+  // Trivial write for option of empty tuple.
+  given woe as Write[Option[EmptyTuple]] =
+    new Write[Option[EmptyTuple]](Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())

--- a/modules/core/src/main/scala-3.0.0-M3/util/ReadPlatform.scala
+++ b/modules/core/src/main/scala-3.0.0-M3/util/ReadPlatform.scala
@@ -10,18 +10,13 @@ trait ReadPlatform:
 
   // Trivial Read for EmptyTuple
   given Read[EmptyTuple] =
-    new Read[EmptyTuple](Nil, (_, _) => EmptyTuple, (_, _) => Some(EmptyTuple))
+    new Read[EmptyTuple](Nil, (_, _) => EmptyTuple)
 
   // Read for head and tail.
   given [H, T <: Tuple](using H: => Read[H], T: => Read[T]): Read[H *: T] =
     new Read[H *: T](
       H.gets ++ T.gets,
-      (rs, n) => H.unsafeGet(rs, n) *: T.unsafeGet(rs, n + H.length),
-      (rs, n) =>
-        for {
-          h <- H.unsafeGetOption(rs, n)
-          t <- T.unsafeGetOption(rs, n + H.length)
-        } yield h *: t
+      (rs, n) => H.unsafeGet(rs, n) *: T.unsafeGet(rs, n + H.length)
     )
 
   // Generic Read for products.

--- a/modules/core/src/main/scala-3.0.0-M3/util/ReadPlatform.scala
+++ b/modules/core/src/main/scala-3.0.0-M3/util/ReadPlatform.scala
@@ -27,3 +27,38 @@ trait ReadPlatform:
   ): Read[P] =
     w.map(a => m.fromProduct(i(a)))
 
+  given roe: Read[Option[EmptyTuple]] =
+    new Read[Option[EmptyTuple]](Nil, (_, _) => Some(EmptyTuple))
+
+  given rou: Read[Option[Unit]] =
+    new Read[Option[Unit]](Nil, (_, _) => Some(()))
+
+  given cons1[H, T <: Tuple](
+    using H: => Read[Option[H]],
+          T: => Read[Option[T]],
+  ): Read[Option[H *: T]] =
+    new Read[Option[H *: T]](
+      H.gets ++ T.gets,
+      (rs, n) =>
+        for {
+          h <- H.unsafeGet(rs, n)
+          t <- T.unsafeGet(rs, n + H.length)
+        } yield h *: t
+    )
+
+  given cons2[H, T <: Tuple](
+    using H: => Read[Option[H]],
+          T: => Read[Option[T]]
+  ): Read[Option[Option[H] *: T]] =
+    new Read[Option[Option[H] *: T]](
+      H.gets ++ T.gets,
+      (rs, n) => T.unsafeGet(rs, n + H.length).map(H.unsafeGet(rs, n) *: _)
+    )
+
+  // Generic Read for option of products.
+  given [P <: Product, A](
+    using m: Mirror.ProductOf[P],
+          i: A =:= m.MirroredElemTypes,
+          w: Read[Option[A]]
+  ): Read[Option[P]] =
+    w.map(a => a.map(a => m.fromProduct(i(a))))

--- a/modules/core/src/main/scala-3.0.0-M3/util/WritePlatform.scala
+++ b/modules/core/src/main/scala-3.0.0-M3/util/WritePlatform.scala
@@ -10,36 +10,15 @@ trait WritePlatform:
 
   // Trivial write for empty tuple.
   given Write[EmptyTuple] =
-    new Write(
-      puts = Nil,
-      toList = _ => Nil,
-      unsafeSet = (_, _, _) => (),
-      unsafeUpdate = (_, _, _) => (),
-      unsafeSetOption = (_, _, _) => (),
-      unsafeUpdateOption = (_, _, _) => (),
-    )
+    new Write(Nil, _ => Nil, (_, _, _) => (),(_, _, _) => ())
 
   // Inductive write for writable head and tail.
   given [H, T <: Tuple](using H: => Write[H], T: => Write[T]): Write[H *: T] =
     new Write(
-      puts = H.puts ++ T.puts,
-      toList = { case h *: t => H.toList(h) ++ T.toList(t) },
-      unsafeSet = { case (ps, n, h *: t) =>
-        H.unsafeSet(ps, n, h)
-        T.unsafeSet(ps, n + H.length, t)
-      },
-      unsafeUpdate = { case (rs, n, h *: t) =>
-        H.unsafeUpdate(rs, n, h);
-        T.unsafeUpdate(rs, n + H.length, t)
-      },
-      unsafeSetOption = { case (ps, n, oht) =>
-        H.unsafeSetOption(ps, n, oht.map(_.head))
-        T.unsafeSetOption(ps, n + H.length, oht.map(_.tail))
-      },
-      unsafeUpdateOption = { case (rs, n, oht) =>
-        H.unsafeUpdateOption(rs, n, oht.map(_.head))
-        T.unsafeUpdateOption(rs, n + H.length, oht.map(_.tail))
-      },
+      H.puts ++ T.puts,
+      { case h *: t => H.toList(h) ++ T.toList(t) },
+      { case (ps, n, h *: t) => H.unsafeSet(ps, n, h); T.unsafeSet(ps, n + H.length, t) },
+      { case (rs, n, h *: t) => H.unsafeUpdate(rs, n, h); T.unsafeUpdate(rs, n + H.length, t) }
     )
 
   // Generic write for products.

--- a/modules/core/src/main/scala-3.0.0-M3/util/WritePlatform.scala
+++ b/modules/core/src/main/scala-3.0.0-M3/util/WritePlatform.scala
@@ -28,3 +28,52 @@ trait WritePlatform:
           w: Write[A]
   ): Write[P] =
     w.contramap(p => i(Tuple.fromProductTyped(p)))
+
+  // Trivial write for option of empty tuple.
+  given woe: Write[Option[EmptyTuple]] =
+    new Write[Option[EmptyTuple]](Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
+
+  // Trivial write for option of Unit.
+  given wou: Write[Option[Unit]] =
+    new Write[Option[Unit]](Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
+
+  // Write[Option[H]], Write[Option[T]] implies Write[Option[H *: T]]
+  given cons1[H, T <: Tuple](
+    using H: => Write[Option[H]],
+          T: => Write[Option[T]],
+          // N: H <:!< Option[_],
+  ): Write[Option[H *: T]] =
+
+    def split[A](i: Option[H *: T])(f: (Option[H], Option[T]) => A): A =
+      i.fold(f(None, None)) { case h *: t => f(Some(h), Some(t)) }
+
+    new Write(
+      H.puts ++ T.puts,
+      split(_) { (h, t) => H.toList(h) ++ T.toList(t) },
+      (ps, n, i) => split(i) { (h, t) => H.unsafeSet(ps, n, h); T.unsafeSet(ps, n + H.length, t) },
+      (rs, n, i) => split(i) { (h, t) => H.unsafeUpdate(rs, n, h); T.unsafeUpdate(rs, n + H.length, t) }
+    )
+
+  // Write[Option[H]], Write[Option[T]] implies Write[Option[Option[H] *: T]]
+  given cons2[H, T <: Tuple](
+    using H: => Write[Option[H]],
+          T: => Write[Option[T]]
+  ): Write[Option[Option[H] *: T]] =
+
+    def split[A](i: Option[Option[H] *: T])(f: (Option[H], Option[T]) => A): A =
+      i.fold(f(None, None)) { case oh *: t => f(oh, Some(t)) }
+
+    new Write(
+      H.puts ++ T.puts,
+      split(_) { (h, t) => H.toList(h) ++ T.toList(t) },
+      (ps, n, i) => split(i) { (h, t) => H.unsafeSet(ps, n, h); T.unsafeSet(ps, n + H.length, t) },
+      (rs, n, i) => split(i) { (h, t) => H.unsafeUpdate(rs, n, h); T.unsafeUpdate(rs, n + H.length, t) }
+    )
+
+  // Generic write for options of products.
+  given [P <: Product, A](
+    using m: Mirror.ProductOf[P],
+          i: m.MirroredElemTypes =:= A,
+          w: Write[Option[A]]
+  ): Write[Option[P]] =
+    w.contramap(op => op.map(p => i(Tuple.fromProductTyped(p))))

--- a/modules/core/src/main/scala/doobie/util/fragment.scala
+++ b/modules/core/src/main/scala/doobie/util/fragment.scala
@@ -70,14 +70,8 @@ object fragment {
         }
       }
 
-      new Write(
-        puts,
-        toList,
-        unsafeSet,
-        unsafeUpdate,
-        unsafeSetOption = (ps, i, of) => of.foreach(f => unsafeSet(ps, i, f)),
-        unsafeUpdateOption = (rs, i, of) => of.foreach(f => unsafeUpdate(rs, i, f)),
-      )
+      new Write(puts, toList, unsafeSet, unsafeUpdate)
+
     }
 
     /**

--- a/modules/core/src/main/scala/doobie/util/read.scala
+++ b/modules/core/src/main/scala/doobie/util/read.scala
@@ -56,7 +56,7 @@ final class Read[A](
 
 }
 
-object Read extends ReadPlatform with ReadLowerPriorityImplicits {
+object Read extends ReadPlatform {
 
   def apply[A](implicit ev: Read[A]): ev.type = ev
 
@@ -76,9 +76,4 @@ object Read extends ReadPlatform with ReadLowerPriorityImplicits {
   implicit def fromGetOption[A](implicit ev: Get[A]): Read[Option[A]] =
     new Read(List((ev, Nullable)), ev.unsafeGetNullable)
 
-}
-
-sealed trait ReadLowerPriorityImplicits {
-  implicit def opt[A](implicit A: Read[A]): Read[Option[A]] =
-    new Read[Option[A]](A.gets.map{case (g, _) => (g, Nullable)}, unsafeGet = (ps, i) => Option(A.unsafeGet(ps, i)))
 }

--- a/modules/core/src/main/scala/doobie/util/write.scala
+++ b/modules/core/src/main/scala/doobie/util/write.scala
@@ -56,7 +56,7 @@ final class Write[A](
 
 }
 
-object Write extends WritePlatform with WriteLowerPriorityImplicits {
+object Write extends WritePlatform {
 
   def apply[A](implicit A: Write[A]): Write[A] = A
 
@@ -85,16 +85,4 @@ object Write extends WritePlatform with WriteLowerPriorityImplicits {
       (rs, n, a) => P.unsafeUpdateNullable(rs, n, a)
     )
 
-}
-
-sealed trait WriteLowerPriorityImplicits {
-  implicit val ohnil: Write[Option[Unit]] =
-    new Write[Option[Unit]](Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
-
-  implicit def opt[A](implicit A: Write[A]): Write[Option[A]] = new Write[Option[A]](
-    A.puts.map {case (p, _) => (p, Nullable)},
-    oa => oa.map(A.toList).getOrElse(A.puts.map(_ => null)),
-    (ps, i, oa) => oa.foreach(a => A.unsafeSet(ps, i, a)),
-    (ps, i, oa) => oa.foreach(a => A.unsafeUpdate(ps, i, a))
-  )
 }

--- a/modules/core/src/test/scala-2/doobie/util/GetSuitePlatform.scala
+++ b/modules/core/src/test/scala-2/doobie/util/GetSuitePlatform.scala
@@ -4,5 +4,17 @@
 
 package doobie.util
 
-trait GetSuitePlatform { self: GetSuite =>
+object GetSuitePlatform {
+  final case class Y(x: String) extends AnyVal
+  final case class P(x: Int) extends AnyVal
+}
+
+trait GetSuitePlatform { self: munit.FunSuite =>
+  import GetSuitePlatform._
+
+  test("Get should be derived for unary products (AnyVal)") {
+    Get[Y]
+    Get[P]
+  }
+
 }

--- a/modules/core/src/test/scala-2/doobie/util/LogSuitePlatform.scala
+++ b/modules/core/src/test/scala-2/doobie/util/LogSuitePlatform.scala
@@ -5,12 +5,13 @@
 package doobie.util
 
 import doobie.util.log.{ Success, ProcessingFailure }
+import shapeless._
 
 trait LogSuitePlatform { self: LogSuite =>
 
   test("[Query] n-arg success") {
     val Sql = "select 1 where ? = ?"
-    val Arg = (1, 1)
+    val Arg = 1 :: 1 :: HNil
     eventForUniqueQuery(Sql, Arg) match {
       case Success(Sql, List(1, 1), _, _) => ()
       case a => fail(s"no match: $a")
@@ -19,7 +20,7 @@ trait LogSuitePlatform { self: LogSuite =>
 
   test("[Query] n-arg processing failure") {
     val Sql = "select 1 where ? = ?"
-    val Arg = (1, 2)
+    val Arg = 1 :: 2 :: HNil
     eventForUniqueQuery(Sql, Arg) match {
       case ProcessingFailure(Sql, List(1, 2), _, _, _) => ()
       case a => fail(s"no match: $a")
@@ -28,7 +29,7 @@ trait LogSuitePlatform { self: LogSuite =>
 
   test("[Update] n-arg success") {
     val Sql = "update foo set bar = ?"
-    val Arg = 42
+    val Arg = 42 :: HNil
     eventForUniqueUpdate(Sql, Arg) match {
       case Success(Sql, List(42), _, _) => ()
       case a => fail(s"no match: $a")

--- a/modules/core/src/test/scala-2/doobie/util/PutSuitePlatform.scala
+++ b/modules/core/src/test/scala-2/doobie/util/PutSuitePlatform.scala
@@ -4,6 +4,17 @@
 
 package doobie.util
 
-trait PutSuitePlatform { self: PutSuite =>
+object PutSuitePlatform {
+  final case class Y(x: String) extends AnyVal
+  final case class P(x: Int) extends AnyVal
+}
+
+trait PutSuitePlatform { self: munit.FunSuite =>
+  import PutSuitePlatform._
+
+  test("Put should be derived for unary products (AnyVal)") {
+    Put[Y]
+    Put[P]
+  }
 
 }

--- a/modules/core/src/test/scala-2/doobie/util/ReadSuitePlatform.scala
+++ b/modules/core/src/test/scala-2/doobie/util/ReadSuitePlatform.scala
@@ -5,20 +5,30 @@
 package doobie
 package util
 
+import shapeless._
+import shapeless.record._
+
 trait ReadSuitePlatform { self: munit.FunSuite =>
 
-  case class Woozle(a: (String, Int), b: (Int, String), c: Boolean)
+  test("Read should exist for shapeless record types") {
+    type DL = (Double, Long) // used below
+    type A  = Record.`'foo -> Int, 'bar -> String, 'baz -> DL, 'quz -> Woozle`.T
+    util.Read[A]
+    util.Read[(A, A)]
+  }
+
+  case class Woozle(a: (String, Int), b: Int :: String :: HNil, c: Boolean)
 
   test("Read should exist for some fancy types") {
     util.Read[Woozle]
     util.Read[(Woozle, String)]
-    util.Read[(Int, (Woozle, Woozle, String))]
+    util.Read[(Int, Woozle :: Woozle :: String :: HNil)]
   }
 
   test("Read should exist for option of some fancy types") {
     util.Read[Option[Woozle]]
     util.Read[Option[(Woozle, String)]]
-    util.Read[Option[(Int, (Woozle, Woozle, String))]]
+    util.Read[Option[(Int, Woozle :: Woozle :: String :: HNil)]]
   }
 
 }

--- a/modules/core/src/test/scala-2/doobie/util/WriteSuitePlatform.scala
+++ b/modules/core/src/test/scala-2/doobie/util/WriteSuitePlatform.scala
@@ -5,20 +5,29 @@
 package doobie
 package util
 
+import shapeless._, shapeless.record._
+
 trait WriteSuitePlatform { self: munit.FunSuite =>
 
-  case class Woozle(a: (String, Int), b: (Int, String), c: Boolean)
+  test("Write should exist for shapeless record types") {
+    type DL = (Double, Long)
+    type A  = Record.`'foo -> Int, 'bar -> String, 'baz -> DL, 'quz -> Woozle`.T
+    util.Write[A]
+    util.Write[(A, A)]
+  }
+
+  case class Woozle(a: (String, Int), b: Int :: String :: HNil, c: Boolean)
 
   test("Write should exist for some fancy types") {
     util.Write[Woozle]
     util.Write[(Woozle, String)]
-    util.Write[(Int, (Woozle, Woozle, String))]
+    util.Write[(Int, Woozle :: Woozle :: String :: HNil)]
   }
 
   test("Write should exist for option of some fancy types") {
     util.Write[Option[Woozle]]
     util.Write[Option[(Woozle, String)]]
-    util.Write[Option[(Int, (Woozle, Woozle, String))]]
+    util.Write[Option[(Int, Woozle :: Woozle :: String :: HNil)]]
   }
 
 }

--- a/modules/core/src/test/scala-3/doobie/util/GetSuitePlatform.scala
+++ b/modules/core/src/test/scala-3/doobie/util/GetSuitePlatform.scala
@@ -2,16 +2,12 @@
 // This software is licensed under the MIT License (MIT).
 // For more information see LICENSE or https://opensource.org/licenses/MIT
 
-package doobie.util
+package doobie
+package util
 
-import doobie.Get
+trait GetSuitePlatform { self: munit.FunSuite =>
 
-trait GetSuitePlatform { self: GetSuite =>
-  case class X(x: Int)
-  case class Q(x: String)
-
-  test("Get should be derived for unary products") {
-    Get[X]
-    Get[Q]
+  test("Get should be derived for unary products (AnyVal)".ignore) {
   }
+
 }

--- a/modules/core/src/test/scala-3/doobie/util/PutSuitePlatform.scala
+++ b/modules/core/src/test/scala-3/doobie/util/PutSuitePlatform.scala
@@ -2,16 +2,12 @@
 // This software is licensed under the MIT License (MIT).
 // For more information see LICENSE or https://opensource.org/licenses/MIT
 
-package doobie.util
+package doobie
+package util
 
-import doobie.Put
+trait PutSuitePlatform { self: munit.FunSuite =>
 
-trait PutSuitePlatform { self: PutSuite =>
-  case class X(x: Int)
-  case class Q(x: String)
-
-  test("Put should be derived for unary products") {
-    Put[X]
-    Put[Q]
+  test("Put should be derived for unary products (AnyVal)".ignore) {
   }
+
 }

--- a/modules/core/src/test/scala/doobie/issue/780.scala
+++ b/modules/core/src/test/scala/doobie/issue/780.scala
@@ -13,4 +13,5 @@ class `780` extends munit.FunSuite {
       Write[(A, B)]
     }
   }
+
 }

--- a/modules/core/src/test/scala/doobie/util/GetSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/GetSuite.scala
@@ -13,6 +13,9 @@ import scala.concurrent.ExecutionContext
 
 class GetSuite extends munit.FunSuite with GetSuitePlatform {
 
+  case class X(x: Int)
+  case class Q(x: String)
+
   case class Z(i: Int, s: String)
   object S
 
@@ -21,11 +24,17 @@ class GetSuite extends munit.FunSuite with GetSuitePlatform {
     Get[String]
   }
 
+  test("Get should be derived for unary products") {
+    Get[X]
+    Get[Q]
+  }
+
   test("Get should not be derived for non-unary products") {
     compileErrors("Get[Z]")
     compileErrors("Get[(Int, Int)]")
     compileErrors("Get[S.type]")
   }
+
 }
 
 final case class Foo(s: String)

--- a/modules/core/src/test/scala/doobie/util/PutSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/PutSuite.scala
@@ -9,6 +9,8 @@ import doobie._
 import scala.concurrent.ExecutionContext
 
 class PutSuite extends munit.FunSuite with PutSuitePlatform {
+  case class X(x: Int)
+  case class Q(x: String)
 
   case class Z(i: Int, s: String)
   object S
@@ -31,6 +33,11 @@ class PutSuite extends munit.FunSuite with PutSuitePlatform {
   test("Put should exist for primitive types") {
     Put[Int]
     Put[String]
+  }
+
+  test("Put should be derived for unary products") {
+    Put[X]
+    Put[Q]
   }
 
   test("Put should not be derived for non-unary products") {

--- a/modules/core/src/test/scala/doobie/util/ReadSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/ReadSuite.scala
@@ -75,23 +75,4 @@ class ReadSuite extends munit.FunSuite with ReadSuitePlatform {
     assertEquals(o, List((1, 2, 3, 4, 5)))
   }
 
-  test("Read optionals") {
-    import doobie.implicits._
-    case class A(os: Option[String], oos: Option[Option[String]])
-
-    val o = sql"SELECT null, null, null, 'a'".query[(Option[Byte], Option[Int], Option[A])].unique.transact(xa).unsafeRunSync()
-
-    assertEquals(o, (None, None, Some(A(None, Some(Some("a"))))))
-  }
-
-  test("Read optionals2") {
-    import doobie.implicits._
-
-    case class A(os: String, oos: Option[Option[String]])
-
-    val o = sql"SELECT null, null".query[Option[A]].unique.transact(xa).unsafeRunSync()
-
-    assertEquals(o, None)
-  }
-
 }

--- a/modules/docs/src/main/mdoc/docs/04-Selecting.md
+++ b/modules/docs/src/main/mdoc/docs/04-Selecting.md
@@ -129,7 +129,35 @@ sql"select code, name, population, gnp from country"
   .quick
   .unsafeRunSync()
 ```
-**doobie** supports row mappings for atomic column types, as well as options, tuples, and case classes thereof. So let's try mapping rows to a case class.
+**doobie** supports row mappings for atomic column types, as well as options, tuples, `HList`s, shapeless records, and case classes thereof. So let's try the same query with an `HList`:
+
+```scala mdoc
+import shapeless._
+
+sql"select code, name, population, gnp from country"
+  .query[String :: String :: Int :: Option[Double] :: HNil]
+  .stream
+  .take(5)
+  .quick
+  .unsafeRunSync()
+```
+
+And with a shapeless record:
+
+```scala mdoc
+import shapeless.record.Record
+
+type Rec = Record.`'code -> String, 'name -> String, 'pop -> Int, 'gnp -> Option[Double]`.T
+
+sql"select code, name, population, gnp from country"
+  .query[Rec]
+  .stream
+  .take(5)
+  .quick
+  .unsafeRunSync()
+```
+
+And again, mapping rows to a case class.
 
 ```scala mdoc:silent
 case class Country(code: String, name: String, pop: Int, gnp: Option[Double])
@@ -144,7 +172,7 @@ sql"select code, name, population, gnp from country"
   .unsafeRunSync()
 ```
 
-You can also nest case classes, and/or tuples arbitrarily as long as the eventual members are of supported columns types. For instance, here we map the same set of columns to a tuple of two case classes:
+You can also nest case classes, `HList`s, shapeless records, and/or tuples arbitrarily as long as the eventual members are of supported columns types. For instance, here we map the same set of columns to a tuple of two case classes:
 
 ```scala mdoc:silent
 case class Code(code: String)

--- a/modules/docs/src/main/mdoc/docs/18-FAQ.md
+++ b/modules/docs/src/main/mdoc/docs/18-FAQ.md
@@ -13,6 +13,7 @@ import doobie.implicits._
 import doobie.util.ExecutionContexts
 import java.awt.geom.Point2D
 import java.util.UUID
+import shapeless._
 
 // We need a ContextShift[IO] before we can construct a Transactor[IO]. The passed ExecutionContext
 // is where nonblocking operations will be executed. For testing here we're using a synchronous EC.
@@ -78,9 +79,6 @@ As of **doobie** 0.4.0 this is done via [statement fragments](08-Fragments.html)
 
 ```scala mdoc:silent
 case class Code(country: String)
-object Code {
-  implicit val puts: Put[Code] = Put[String].contramap(_.country)
-}
 case class City(code: Code, name: String, population: Int)
 
 def cities(code: Code, asc: Boolean): Query0[City] = {

--- a/modules/example/src/main/scala-2/example/Orm.scala
+++ b/modules/example/src/main/scala-2/example/Orm.scala
@@ -1,0 +1,137 @@
+// Copyright (c) 2013-2020 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package example
+
+import cats.Show
+import cats.effect.{ IO, IOApp, ExitCode }
+import cats.syntax.all._
+import doobie._, doobie.implicits._
+import fs2.Stream
+import shapeless._
+import shapeless.ops.record._
+import shapeless.ops.hlist._
+
+/**
+ * A super-simple ORM for super-simple data types. We assume auto-generated keys, represented
+ * externally, and columns map 1:1 with fields and have the same names.
+ */
+object Orm extends IOApp {
+
+  // to silence unused warnings
+  def void[A](a: A): Unit = (a, ())._2
+
+  trait Dao[A] {
+    type Key
+    def insert(a: A): ConnectionIO[Key]
+    def find(k: Key): ConnectionIO[Option[A]]
+    def findAll: Stream[ConnectionIO, A]
+    def update(k: Key, a: A): ConnectionIO[Int]
+    def delete(k: Key): ConnectionIO[Int]
+  }
+  object Dao {
+
+    type Aux[A, K] = Dao[A] { type Key = K }
+
+    def apply[A](implicit ev: Dao[A]): Aux[A, ev.Key] = ev
+
+    object derive {
+      def apply[A, K] = new Partial[A, K]
+      class Partial[A, K] {
+        def apply[R <: HList, S <: HList](table: String, keyCol: String)(
+          implicit ev: LabelledGeneric.Aux[A, R],
+                   ra: Read[A],
+                   wa: Write[A],
+                   ks: Keys.Aux[R, S],
+                   tl: ToList[S, Symbol],
+                   rk: Read[K],
+                   wk: Write[K]
+        ): Aux[A, K] =
+          new Dao[A] {
+            void(ev)
+
+            type Key = K
+            val cols = ks.apply().toList.map(_.name)
+
+            def insert(a: A): ConnectionIO[Key] =
+              Update[A](s"""
+                INSERT INTO $table (${cols.mkString(", ")})
+                VALUES (${cols.as("?").mkString(", ")})
+              """).withUniqueGeneratedKeys[Key](keyCol)(a)
+
+            def find(key: Key): ConnectionIO[Option[A]] =
+              Query[Key, A](s"""
+                SELECT ${cols.mkString(", ")}
+                FROM $table
+                WHERE $keyCol = ?
+              """).option(key)
+
+           def findAll: Stream[ConnectionIO, A] =
+              Query0[A](s"""
+                SELECT ${cols.mkString(", ")}
+                FROM $table
+              """).stream
+
+            def update(k: Key, a: A): ConnectionIO[Int] =
+              Update[(A, Key)](s"""
+                UPDATE $table
+                SET ${cols.map(_ + " = ?").mkString(", ")}
+                WHERE $keyCol = ?
+              """).run((a, k))
+
+            def delete(k: Key): ConnectionIO[Int] = {
+              Update[Key](s"""
+                DELETE FROM $table
+                WHERE $keyCol = ?
+              """).run(k)
+            }
+
+          }
+      }
+    }
+
+  }
+
+  // a little usage example
+
+  final case class Neighbor(name: String, age: Int)
+  object Neighbor {
+    implicit val dao: Dao.Aux[Neighbor, Int] =
+      Dao.derive[Neighbor, Int]("neighbor", "id")
+
+    implicit val show: Show[Neighbor] = Show.fromToString
+  }
+
+  val ddl: ConnectionIO[Unit] =
+    sql"""
+      CREATE TABLE IF NOT EXISTS neighbor (
+        id   SERIAL,
+        name VARCHAR NOT NULL,
+        age  INT     NOT NULL
+      )
+    """.update.run.void
+
+  val prog: ConnectionIO[String] = {
+    val dn = Dao[Neighbor]
+    import dn._
+    for {
+      _  <- ddl
+      ka <- insert(Neighbor("Alice", 42))
+      kb <- insert(Neighbor("Bob", 42))
+      oa <- find(ka)
+      _  <- delete(kb)
+    } yield show"Did some stuff. Keys were $ka and $kb. Selected value was ${oa.fold("<nothing>")(_.show)}."
+  }
+
+  val xa = Transactor.fromDriverManager[IO](
+    "org.postgresql.Driver", "jdbc:postgresql:world", "postgres", ""
+  )
+
+  def run(args: List[String]): IO[ExitCode] =
+    for {
+      a <- prog.transact(xa)
+      _ <- IO(println(a))
+    } yield ExitCode.Success
+
+}

--- a/modules/postgres/src/main/scala-2/doobie/postgres/TextPlatform.scala
+++ b/modules/postgres/src/main/scala-2/doobie/postgres/TextPlatform.scala
@@ -4,26 +4,29 @@
 
 package doobie.postgres
 
-import magnolia.{ReadOnlyCaseClass, Magnolia}
+import shapeless.{ HList, HNil, ::, Generic, Lazy }
 
-trait TextPlatform {
-  this: Text.type =>
+trait TextPlatform { this: Text.type =>
 
-  type Typeclass[T] = Text[T]
+  // HNil isn't a valid Text but a single-element HList is
+  implicit def single[A](
+    implicit csv: Text[A]
+  ): Text[A :: HNil] =
+    csv.contramap(_.head)
 
-  def combine[T](ctx: ReadOnlyCaseClass[Text, T]): Text[T] =
-    instance { (t, sb) =>
-      // cannot prove at compile-time with magnolia
-      if (ctx.parameters.isEmpty) {
-        sys.error(s"Sorry, ${ctx.typeName.short} doesnt work with `Text` because it has no columns")
-      }
+  // HLists of more that one element
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+  implicit def multiple[H, T <: HList](
+    implicit h: Text[H],
+             t: Text[T]
+  ): Text[H :: T] =
+    (h product t).contramap(l => (l.head, l.tail))
 
-      ctx.parameters.zipWithIndex.foreach {
-        case (param, idx) =>
-          if (idx != 0) sb.append(Text.DELIMETER)
-          param.typeclass.unsafeEncode(param.dereference(t), sb)
-      }
-    }
+  // Generic
+  implicit def generic[A, B](
+    implicit gen: Generic.Aux[A, B],
+             csv: Lazy[Text[B]]
+  ): Text[A] =
+    csv.value.contramap(gen.to)
 
-  implicit def generic[A]: Text[A] = macro Magnolia.gen[A]
 }

--- a/modules/quill/src/main/scala/doobie/quill/DoobieContextBase.scala
+++ b/modules/quill/src/main/scala/doobie/quill/DoobieContextBase.scala
@@ -142,7 +142,7 @@ trait DoobieContextBase[Dialect <: SqlIdiom, Naming <: NamingStrategy]
 
   // Turn an extractor into a `Read` so we can use the existing resultset.
   private implicit def extractorToRead[A](ex: Extractor[A]): Read[A] =
-    new Read[A](Nil, (rs, _) => ex(rs), (rs, _) => Some(ex(rs)))
+    new Read[A](Nil, (rs, _) => ex(rs))
 
   // Nothing to do here.
   override def close(): Unit = ()


### PR DESCRIPTION
This reverts PR #1353 which swapped out Shapeless for Magnolia. Lingering issues with unary products are blocking further development so I'm rolling this back for now. See discussions in #1343  and #1350 for context. 

Other simplifications introduced in #1343 prior to the Shapeless/Magnolia swap are also removed because one of the tests doesn't compile in 2.12, but I would consider a PR re-introducing them.