### PR TITLE
Add Discord badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <img align="right" src="https://cdn.rawgit.com/tpolecat/doobie/series/0.5.x/doobie_logo.svg" height="150px" style="padding-left: 20px"/>
 
 [![Travis CI](https://travis-ci.org/tpolecat/doobie.svg?branch=series%2F0.5.x)](https://travis-ci.org/tpolecat/doobie)
+[![Discord](https://img.shields.io/discord/632277896739946517.svg?label=&logo=discord&logoColor=ffffff&color=404244&labelColor=6A7EC2)](https://discord.gg/7B4VfFTvsS)
 [![Join the chat at https://gitter.im/tpolecat/doobie](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/tpolecat/doobie?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Maven Central](https://img.shields.io/maven-central/v/org.tpolecat/doobie-core_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/org.tpolecat/doobie-core_2.12)
 [![Javadocs](https://javadoc.io/badge/org.tpolecat/doobie-core_2.12.svg)](https://javadoc.io/doc/org.tpolecat/doobie-core_2.12)


### PR DESCRIPTION
Making the Discord support channel more visible by adding a badge with a badge to #doobie that never expires :)

This is how it looks like:

![Screen Shot 2021-05-14 at 00 25 25](https://user-images.githubusercontent.com/33580722/118195176-02f3a180-b44b-11eb-99c7-fcd616f0a1a6.png)
