### PR TITLE
Use HikariCP 4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val catsEffectVersion    = "2.5.1"
 lazy val circeVersion         = settingKey[String]("Circe version.")
 lazy val fs2Version           = "2.5.6"
 lazy val h2Version            = "1.4.200"
-lazy val hikariVersion        = "3.4.5" // N.B. Hikari v4 introduces a breaking change via slf4j v2
+lazy val hikariVersion        = "4.0.3" // N.B. Hikari v4 introduces a breaking change via slf4j v2
 lazy val kindProjectorVersion = "0.11.2"
 lazy val monixVersion         = "3.4.0"
 lazy val quillVersion         = "3.7.1"
@@ -359,8 +359,10 @@ lazy val hikari = project
     name := "doobie-hikari",
     description := "Hikari support for doobie.",
     libraryDependencies ++= Seq(
-      "com.zaxxer"     % "HikariCP"   % hikariVersion,
+      //needs to be excluded, otherwise coursier may resolve slf4j-api 2 if > Java 11
+      "com.zaxxer"     % "HikariCP"   % hikariVersion exclude("org.slf4j", "slf4j-api"),
       "com.h2database" % "h2"         % h2Version      % "test",
+      "org.slf4j"      % "slf4j-api"  % slf4jVersion,
       "org.slf4j"      % "slf4j-nop"  % slf4jVersion   % "test"
     )
   )


### PR DESCRIPTION
This is an interesting one.
Hikari depends on slf4j-api 1.7 according to the POM, unless you
take profiles into account, which apparently coursier does.

Hikari changes the slf4j-api dependency to 2.0-alphaN when
you are running Java 11 and above, this also is reflected when you
resolve using Coursier in Java 11 or Java 8.
The only reason to do this is to use Java module support.

Most Scala libraries do not care about Java Modules, so we can safely
ignore this.

Added a dependency to Hikari4, but adds an exclusion to slf4j-api.
Added a direct dependency to slf4j-api 1.7 to fullfill the contract.