### PR TITLE
Define Read's ap in terms of product (alternative fix of #1485)

### DIFF
--- a/modules/core/src/test/scala/doobie/util/ReadSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/ReadSuite.scala
@@ -75,4 +75,15 @@ class ReadSuite extends munit.FunSuite with ReadSuitePlatform {
     assertEquals(o, List((1, 2, 3, 4, 5)))
   }
 
+  test("Read should select correct columns when combined with `product`") {
+    import cats.syntax.all._
+    import doobie.implicits._
+    val r = util.Read[Int].product(util.Read[Int].product(util.Read[Int]))
+
+    val q = sql"SELECT 1, 2, 3".query(r).to[List]
+    val o = q.transact(xa).unsafeRunSync()
+
+    assertEquals(o, List((1, (2, 3))))
+  }
+
 }


### PR DESCRIPTION
Fixes incorrect column ordering issue when using product

An alternative approach of #1485 to fixing the issue 