### PR TITLE
Provide loghandler to interpreters

### DIFF
--- a/modules/core/src/main/scala/doobie/aliases.scala
+++ b/modules/core/src/main/scala/doobie/aliases.scala
@@ -21,6 +21,7 @@ trait Types {
   /** @group Type Aliases - Core */ type SqlState                 = doobie.enumerated.SqlState
   /** @group Type Aliases - Core */ type Transactor[M[_]]         = doobie.util.transactor.Transactor[M]
   /** @group Type Aliases - Core */ type LogHandler               = doobie.util.log.LogHandler
+  /** @group Type Aliases - Core */ type LogHandlerM[M[_]]        = doobie.util.log.LogHandlerM[M]
   /** @group Type Aliases - Core */ type Fragment                 = doobie.util.fragment.Fragment
   /** @group Type Aliases - Core */ type KleisliInterpreter[F[_]] = doobie.free.KleisliInterpreter[F]
   /** @group Type Aliases - Core */ type DataSourceTransactor[F[_]] = doobie.util.transactor.Transactor.Aux[F, javax.sql.DataSource]
@@ -40,6 +41,7 @@ trait Modules {
   /** @group Module Aliases - Core */ val  SqlState           = doobie.enumerated.SqlState
   /** @group Module Aliases - Core */ val  Transactor         = doobie.util.transactor.Transactor
   /** @group Module Aliases - Core */ val  LogHandler         = doobie.util.log.LogHandler
+  /** @group Module Aliases - Core */ val  LogHandlerM        = doobie.util.log.LogHandlerM
   /** @group Module Aliases - Core */ val  Fragment           = doobie.util.fragment.Fragment
   /** @group Module Aliases - Core */ val  KleisliInterpreter = doobie.free.KleisliInterpreter
   /** @group Module Aliases - Core */ val  Fragments          = doobie.util.fragments

--- a/modules/core/src/main/scala/doobie/util/transactor.scala
+++ b/modules/core/src/main/scala/doobie/util/transactor.scala
@@ -321,10 +321,11 @@ object transactor  {
      * @param blocker for blocking database operations
      * @group Constructors
      */
-    def fromConnection[M[_]: Applicative]: FromConnectionUnapplied[M] = new FromConnectionUnapplied[M](LogHandlerM.noop)
+    def fromConnection[M[_]]: FromConnectionUnapplied[M] = new FromConnectionUnapplied[M](None)
 
-    class FromConnectionUnapplied[M[_]](logHandler: LogHandlerM[M]) {
-      def withLogHandler(logHandler: LogHandlerM[M]) = new FromConnectionUnapplied(logHandler)
+    class FromConnectionUnapplied[M[_]](maybeLogHandler: Option[LogHandlerM[M]]) {
+      def withLogHandler(logHandler: LogHandlerM[M]) = new FromConnectionUnapplied(Some(logHandler))
+      private def logHandler(implicit A: Applicative[M]): LogHandlerM[M] = maybeLogHandler.getOrElse(LogHandlerM.noop)
 
       def apply(connection: Connection)(implicit async: Async[M]): Transactor.Aux[M, Connection] = {
         val connect = (c: Connection) => Resource.pure[M, Connection](c)

--- a/modules/core/src/main/scala/doobie/util/update.scala
+++ b/modules/core/src/main/scala/doobie/util/update.scala
@@ -49,7 +49,12 @@ object update {
     private def executeUpdate[T](a: A): PreparedStatementIO[Int] = {
       val args = write.toList(a)
       def diff(a: Long, b: Long) = FiniteDuration((a - b).abs, NANOSECONDS)
-      def log(e: LogEvent) = FPS.delay(logHandler.unsafeRun(e))
+      def log(e: LogEvent): PreparedStatementIO[Unit] =
+        for {
+          _ <- FPS.delay(logHandler.unsafeRun(e))
+          _ <- FPS.performLogging(e)
+        } yield ()
+
       for {
         t0 <- now
         en <- FPS.executeUpdate.attempt

--- a/modules/core/src/test/scala/doobie/issue/262.scala
+++ b/modules/core/src/test/scala/doobie/issue/262.scala
@@ -12,7 +12,7 @@ class `262` extends munit.FunSuite {
   import cats.effect.unsafe.implicits.global
 
   // an interpreter that returns null when we ask for statement metadata
-  object Interp extends KleisliInterpreter[IO](None) {
+  object Interp extends KleisliInterpreter[IO](LogHandlerM.noop) {
     override lazy val PreparedStatementInterpreter =
       new PreparedStatementInterpreter {
         override def getMetaData = primitive(_ => null)

--- a/modules/core/src/test/scala/doobie/issue/262.scala
+++ b/modules/core/src/test/scala/doobie/issue/262.scala
@@ -12,9 +12,7 @@ class `262` extends munit.FunSuite {
   import cats.effect.unsafe.implicits.global
 
   // an interpreter that returns null when we ask for statement metadata
-  object Interp extends KleisliInterpreter[IO] {
-    val asyncM = WeakAsync[IO]
-
+  object Interp extends KleisliInterpreter[IO](None) {
     override lazy val PreparedStatementInterpreter =
       new PreparedStatementInterpreter {
         override def getMetaData = primitive(_ => null)

--- a/modules/core/src/test/scala/doobie/util/StrategySuite.scala
+++ b/modules/core/src/test/scala/doobie/util/StrategySuite.scala
@@ -21,7 +21,7 @@ class StrategySuite extends munit.FunSuite {
 
   // an instrumented interpreter
   @SuppressWarnings(Array("org.wartremover.warts.Var"))
-  class Interp extends KleisliInterpreter[IO](None) {
+  class Interp extends KleisliInterpreter[IO](LogHandlerM.noop) {
 
     object Connection {
       var autoCommit: Option[Boolean] = None

--- a/modules/core/src/test/scala/doobie/util/StrategySuite.scala
+++ b/modules/core/src/test/scala/doobie/util/StrategySuite.scala
@@ -21,9 +21,7 @@ class StrategySuite extends munit.FunSuite {
 
   // an instrumented interpreter
   @SuppressWarnings(Array("org.wartremover.warts.Var"))
-  class Interp extends KleisliInterpreter[IO] {
-
-    val asyncM = WeakAsync[IO]
+  class Interp extends KleisliInterpreter[IO](None) {
 
     object Connection {
       var autoCommit: Option[Boolean] = None

--- a/modules/docs/src/main/mdoc/docs/03-Connecting.md
+++ b/modules/docs/src/main/mdoc/docs/03-Connecting.md
@@ -135,7 +135,7 @@ import cats.data.Kleisli
 import doobie.free.connection.ConnectionOp
 import java.sql.Connection
 
-val interpreter = KleisliInterpreter[IO].ConnectionInterpreter
+val interpreter = KleisliInterpreter[IO](None).ConnectionInterpreter
 val kleisli = program1.foldMap(interpreter)
 val io3 = IO(null: java.sql.Connection) >>= kleisli.run
 io3.unsafeRunSync() // sneaky; program1 never looks at the connection

--- a/modules/docs/src/main/mdoc/docs/03-Connecting.md
+++ b/modules/docs/src/main/mdoc/docs/03-Connecting.md
@@ -135,7 +135,7 @@ import cats.data.Kleisli
 import doobie.free.connection.ConnectionOp
 import java.sql.Connection
 
-val interpreter = KleisliInterpreter[IO](None).ConnectionInterpreter
+val interpreter = KleisliInterpreter[IO](LogHandlerM.noop).ConnectionInterpreter
 val kleisli = program1.foldMap(interpreter)
 val io3 = IO(null: java.sql.Connection) >>= kleisli.run
 io3.unsafeRunSync() // sneaky; program1 never looks at the connection

--- a/modules/example/src/main/scala/example/Coproduct.scala
+++ b/modules/example/src/main/scala/example/Coproduct.scala
@@ -88,7 +88,7 @@ object Coproduct extends IOApp.Simple {
   // Our interpreter must be parameterized over a connection so we can add transaction boundaries
   // before and after.
   val interp: Cop ~> Kleisli[IO, Connection, *] = {
-    consoleInterp.liftK[Connection] or KleisliInterpreter[IO].ConnectionInterpreter
+    consoleInterp.liftK[Connection] or KleisliInterpreter[IO](None).ConnectionInterpreter
   }
 
   // Our interpreted program

--- a/modules/example/src/main/scala/example/Coproduct.scala
+++ b/modules/example/src/main/scala/example/Coproduct.scala
@@ -88,7 +88,7 @@ object Coproduct extends IOApp.Simple {
   // Our interpreter must be parameterized over a connection so we can add transaction boundaries
   // before and after.
   val interp: Cop ~> Kleisli[IO, Connection, *] = {
-    consoleInterp.liftK[Connection] or KleisliInterpreter[IO](None).ConnectionInterpreter
+    consoleInterp.liftK[Connection] or KleisliInterpreter[IO](LogHandlerM.noop).ConnectionInterpreter
   }
 
   // Our interpreted program

--- a/modules/free/src/main/scala/doobie/free/callablestatement.scala
+++ b/modules/free/src/main/scala/doobie/free/callablestatement.scala
@@ -7,6 +7,7 @@ package doobie.free
 import cats.~>
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
+import doobie.util.log.LogEvent
 import doobie.WeakAsync
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
@@ -76,6 +77,7 @@ object callablestatement { module =>
       def canceled: F[Unit]
       def onCancel[A](fa: CallableStatementIO[A], fin: CallableStatementIO[Unit]): F[A]
       def fromFuture[A](fut: CallableStatementIO[Future[A]]): F[A]
+      def performLogging(event: LogEvent): F[Unit]
 
       // CallableStatement
       def addBatch: F[Unit]
@@ -353,6 +355,9 @@ object callablestatement { module =>
     }
     case class FromFuture[A](fut: CallableStatementIO[Future[A]]) extends CallableStatementOp[A] {
       def visit[F[_]](v: Visitor[F]) = v.fromFuture(fut)
+    }
+    case class PerformLogging(event: LogEvent) extends CallableStatementOp[Unit] {
+      def visit[F[_]](v: Visitor[F]) = v.performLogging(event)
     }
 
     // CallableStatement-specific operations.
@@ -1078,6 +1083,7 @@ object callablestatement { module =>
   val canceled = FF.liftF[CallableStatementOp, Unit](Canceled)
   def onCancel[A](fa: CallableStatementIO[A], fin: CallableStatementIO[Unit]) = FF.liftF[CallableStatementOp, A](OnCancel(fa, fin))
   def fromFuture[A](fut: CallableStatementIO[Future[A]]) = FF.liftF[CallableStatementOp, A](FromFuture(fut))
+  def performLogging(event: LogEvent) = FF.liftF[CallableStatementOp, Unit](PerformLogging(event))
 
   // Smart constructors for CallableStatement-specific operations.
   val addBatch: CallableStatementIO[Unit] = FF.liftF(AddBatch)

--- a/modules/free/src/main/scala/doobie/free/connection.scala
+++ b/modules/free/src/main/scala/doobie/free/connection.scala
@@ -7,6 +7,7 @@ package doobie.free
 import cats.~>
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
+import doobie.util.log.LogEvent
 import doobie.WeakAsync
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
@@ -70,6 +71,7 @@ object connection { module =>
       def canceled: F[Unit]
       def onCancel[A](fa: ConnectionIO[A], fin: ConnectionIO[Unit]): F[A]
       def fromFuture[A](fut: ConnectionIO[Future[A]]): F[A]
+      def performLogging(event: LogEvent): F[Unit]
 
       // Connection
       def abort(a: Executor): F[Unit]
@@ -174,6 +176,9 @@ object connection { module =>
     }
     case class FromFuture[A](fut: ConnectionIO[Future[A]]) extends ConnectionOp[A] {
       def visit[F[_]](v: Visitor[F]) = v.fromFuture(fut)
+    }
+    case class PerformLogging(event: LogEvent) extends ConnectionOp[Unit] {
+      def visit[F[_]](v: Visitor[F]) = v.performLogging(event)
     }
 
     // Connection-specific operations.
@@ -380,6 +385,7 @@ object connection { module =>
   val canceled = FF.liftF[ConnectionOp, Unit](Canceled)
   def onCancel[A](fa: ConnectionIO[A], fin: ConnectionIO[Unit]) = FF.liftF[ConnectionOp, A](OnCancel(fa, fin))
   def fromFuture[A](fut: ConnectionIO[Future[A]]) = FF.liftF[ConnectionOp, A](FromFuture(fut))
+  def performLogging(event: LogEvent) = FF.liftF[ConnectionOp, Unit](PerformLogging(event))
 
   // Smart constructors for Connection-specific operations.
   def abort(a: Executor): ConnectionIO[Unit] = FF.liftF(Abort(a))

--- a/modules/free/src/main/scala/doobie/free/databasemetadata.scala
+++ b/modules/free/src/main/scala/doobie/free/databasemetadata.scala
@@ -7,6 +7,7 @@ package doobie.free
 import cats.~>
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
+import doobie.util.log.LogEvent
 import doobie.WeakAsync
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
@@ -57,6 +58,7 @@ object databasemetadata { module =>
       def canceled: F[Unit]
       def onCancel[A](fa: DatabaseMetaDataIO[A], fin: DatabaseMetaDataIO[Unit]): F[A]
       def fromFuture[A](fut: DatabaseMetaDataIO[Future[A]]): F[A]
+      def performLogging(event: LogEvent): F[Unit]
 
       // DatabaseMetaData
       def allProceduresAreCallable: F[Boolean]
@@ -280,6 +282,9 @@ object databasemetadata { module =>
     }
     case class FromFuture[A](fut: DatabaseMetaDataIO[Future[A]]) extends DatabaseMetaDataOp[A] {
       def visit[F[_]](v: Visitor[F]) = v.fromFuture(fut)
+    }
+    case class PerformLogging(event: LogEvent) extends DatabaseMetaDataOp[Unit] {
+      def visit[F[_]](v: Visitor[F]) = v.performLogging(event)
     }
 
     // DatabaseMetaData-specific operations.
@@ -843,6 +848,7 @@ object databasemetadata { module =>
   val canceled = FF.liftF[DatabaseMetaDataOp, Unit](Canceled)
   def onCancel[A](fa: DatabaseMetaDataIO[A], fin: DatabaseMetaDataIO[Unit]) = FF.liftF[DatabaseMetaDataOp, A](OnCancel(fa, fin))
   def fromFuture[A](fut: DatabaseMetaDataIO[Future[A]]) = FF.liftF[DatabaseMetaDataOp, A](FromFuture(fut))
+  def performLogging(event: LogEvent) = FF.liftF[DatabaseMetaDataOp, Unit](PerformLogging(event))
 
   // Smart constructors for DatabaseMetaData-specific operations.
   val allProceduresAreCallable: DatabaseMetaDataIO[Boolean] = FF.liftF(AllProceduresAreCallable)

--- a/modules/free/src/main/scala/doobie/free/kleisliinterpreter.scala
+++ b/modules/free/src/main/scala/doobie/free/kleisliinterpreter.scala
@@ -75,12 +75,12 @@ import doobie.free.callablestatement.{ CallableStatementIO, CallableStatementOp 
 import doobie.free.resultset.{ ResultSetIO, ResultSetOp }
 
 object KleisliInterpreter {
-  def apply[M[_]: WeakAsync](logHandler: Option[LogHandlerM[M]]): KleisliInterpreter[M] =
+  def apply[M[_]: WeakAsync](logHandler: LogHandlerM[M]): KleisliInterpreter[M] =
     new KleisliInterpreter[M](logHandler)
 }
 
 // Family of interpreters into Kleisli arrows for some monad M.
-class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val asyncM: WeakAsync[M]) { outer =>
+class KleisliInterpreter[M[_]](logHandler: LogHandlerM[M])(implicit val asyncM: WeakAsync[M]) { outer =>
   import WeakAsync._
 
   // The 14 interpreters, with definitions below. These can be overridden to customize behavior.
@@ -167,7 +167,7 @@ class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val 
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[NClob]
 
-    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler.run(event))
 
     // for operations using NClobIO we must call ourself recursively
     override def handleErrorWith[A](fa: NClobIO[A])(f: Throwable => NClobIO[A]) = outer.handleErrorWith(this)(fa)(f)
@@ -206,7 +206,7 @@ class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val 
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[Blob]
 
-    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler.run(event))
 
     // for operations using BlobIO we must call ourself recursively
     override def handleErrorWith[A](fa: BlobIO[A])(f: Throwable => BlobIO[A]) = outer.handleErrorWith(this)(fa)(f)
@@ -243,7 +243,7 @@ class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val 
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[Clob]
 
-    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler.run(event))
 
     // for operations using ClobIO we must call ourself recursively
     override def handleErrorWith[A](fa: ClobIO[A])(f: Throwable => ClobIO[A]) = outer.handleErrorWith(this)(fa)(f)
@@ -282,7 +282,7 @@ class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val 
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[DatabaseMetaData]
 
-    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler.run(event))
 
     // for operations using DatabaseMetaDataIO we must call ourself recursively
     override def handleErrorWith[A](fa: DatabaseMetaDataIO[A])(f: Throwable => DatabaseMetaDataIO[A]) = outer.handleErrorWith(this)(fa)(f)
@@ -487,7 +487,7 @@ class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val 
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[Driver]
 
-    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler.run(event))
 
     // for operations using DriverIO we must call ourself recursively
     override def handleErrorWith[A](fa: DriverIO[A])(f: Throwable => DriverIO[A]) = outer.handleErrorWith(this)(fa)(f)
@@ -520,7 +520,7 @@ class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val 
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[Ref]
 
-    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler.run(event))
 
     // for operations using RefIO we must call ourself recursively
     override def handleErrorWith[A](fa: RefIO[A])(f: Throwable => RefIO[A]) = outer.handleErrorWith(this)(fa)(f)
@@ -550,7 +550,7 @@ class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val 
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[SQLData]
 
-    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler.run(event))
 
     // for operations using SQLDataIO we must call ourself recursively
     override def handleErrorWith[A](fa: SQLDataIO[A])(f: Throwable => SQLDataIO[A]) = outer.handleErrorWith(this)(fa)(f)
@@ -579,7 +579,7 @@ class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val 
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[SQLInput]
 
-    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler.run(event))
 
     // for operations using SQLInputIO we must call ourself recursively
     override def handleErrorWith[A](fa: SQLInputIO[A])(f: Throwable => SQLInputIO[A]) = outer.handleErrorWith(this)(fa)(f)
@@ -633,7 +633,7 @@ class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val 
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[SQLOutput]
 
-    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler.run(event))
 
     // for operations using SQLOutputIO we must call ourself recursively
     override def handleErrorWith[A](fa: SQLOutputIO[A])(f: Throwable => SQLOutputIO[A]) = outer.handleErrorWith(this)(fa)(f)
@@ -687,7 +687,7 @@ class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val 
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[Connection]
 
-    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler.run(event))
 
     // for operations using ConnectionIO we must call ourself recursively
     override def handleErrorWith[A](fa: ConnectionIO[A])(f: Throwable => ConnectionIO[A]) = outer.handleErrorWith(this)(fa)(f)
@@ -773,7 +773,7 @@ class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val 
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[Statement]
 
-    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler.run(event))
 
     // for operations using StatementIO we must call ourself recursively
     override def handleErrorWith[A](fa: StatementIO[A])(f: Throwable => StatementIO[A]) = outer.handleErrorWith(this)(fa)(f)
@@ -855,7 +855,7 @@ class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val 
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[PreparedStatement]
 
-    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler.run(event))
 
     // for operations using PreparedStatementIO we must call ourself recursively
     override def handleErrorWith[A](fa: PreparedStatementIO[A])(f: Throwable => PreparedStatementIO[A]) = outer.handleErrorWith(this)(fa)(f)
@@ -994,7 +994,7 @@ class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val 
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[CallableStatement]
 
-    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler.run(event))
 
     // for operations using CallableStatementIO we must call ourself recursively
     override def handleErrorWith[A](fa: CallableStatementIO[A])(f: Throwable => CallableStatementIO[A]) = outer.handleErrorWith(this)(fa)(f)
@@ -1253,7 +1253,7 @@ class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val 
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[ResultSet]
 
-    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler.run(event))
 
     // for operations using ResultSetIO we must call ourself recursively
     override def handleErrorWith[A](fa: ResultSetIO[A])(f: Throwable => ResultSetIO[A]) = outer.handleErrorWith(this)(fa)(f)

--- a/modules/free/src/main/scala/doobie/free/nclob.scala
+++ b/modules/free/src/main/scala/doobie/free/nclob.scala
@@ -7,6 +7,7 @@ package doobie.free
 import cats.~>
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
+import doobie.util.log.LogEvent
 import doobie.WeakAsync
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
@@ -58,6 +59,7 @@ object nclob { module =>
       def canceled: F[Unit]
       def onCancel[A](fa: NClobIO[A], fin: NClobIO[Unit]): F[A]
       def fromFuture[A](fut: NClobIO[Future[A]]): F[A]
+      def performLogging(event: LogEvent): F[Unit]
 
       // NClob
       def free: F[Unit]
@@ -115,6 +117,9 @@ object nclob { module =>
     }
     case class FromFuture[A](fut: NClobIO[Future[A]]) extends NClobOp[A] {
       def visit[F[_]](v: Visitor[F]) = v.fromFuture(fut)
+    }
+    case class PerformLogging(event: LogEvent) extends NClobOp[Unit] {
+      def visit[F[_]](v: Visitor[F]) = v.performLogging(event)
     }
 
     // NClob-specific operations.
@@ -180,6 +185,7 @@ object nclob { module =>
   val canceled = FF.liftF[NClobOp, Unit](Canceled)
   def onCancel[A](fa: NClobIO[A], fin: NClobIO[Unit]) = FF.liftF[NClobOp, A](OnCancel(fa, fin))
   def fromFuture[A](fut: NClobIO[Future[A]]) = FF.liftF[NClobOp, A](FromFuture(fut))
+  def performLogging(event: LogEvent) = FF.liftF[NClobOp, Unit](PerformLogging(event))
 
   // Smart constructors for NClob-specific operations.
   val free: NClobIO[Unit] = FF.liftF(Free)

--- a/modules/free/src/main/scala/doobie/free/preparedstatement.scala
+++ b/modules/free/src/main/scala/doobie/free/preparedstatement.scala
@@ -7,6 +7,7 @@ package doobie.free
 import cats.~>
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
+import doobie.util.log.LogEvent
 import doobie.WeakAsync
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
@@ -75,6 +76,7 @@ object preparedstatement { module =>
       def canceled: F[Unit]
       def onCancel[A](fa: PreparedStatementIO[A], fin: PreparedStatementIO[Unit]): F[A]
       def fromFuture[A](fut: PreparedStatementIO[Future[A]]): F[A]
+      def performLogging(event: LogEvent): F[Unit]
 
       // PreparedStatement
       def addBatch: F[Unit]
@@ -232,6 +234,9 @@ object preparedstatement { module =>
     }
     case class FromFuture[A](fut: PreparedStatementIO[Future[A]]) extends PreparedStatementOp[A] {
       def visit[F[_]](v: Visitor[F]) = v.fromFuture(fut)
+    }
+    case class PerformLogging(event: LogEvent) extends PreparedStatementOp[Unit] {
+      def visit[F[_]](v: Visitor[F]) = v.performLogging(event)
     }
 
     // PreparedStatement-specific operations.
@@ -597,6 +602,7 @@ object preparedstatement { module =>
   val canceled = FF.liftF[PreparedStatementOp, Unit](Canceled)
   def onCancel[A](fa: PreparedStatementIO[A], fin: PreparedStatementIO[Unit]) = FF.liftF[PreparedStatementOp, A](OnCancel(fa, fin))
   def fromFuture[A](fut: PreparedStatementIO[Future[A]]) = FF.liftF[PreparedStatementOp, A](FromFuture(fut))
+  def performLogging(event: LogEvent) = FF.liftF[PreparedStatementOp, Unit](PerformLogging(event))
 
   // Smart constructors for PreparedStatement-specific operations.
   val addBatch: PreparedStatementIO[Unit] = FF.liftF(AddBatch)

--- a/modules/free/src/main/scala/doobie/free/statement.scala
+++ b/modules/free/src/main/scala/doobie/free/statement.scala
@@ -7,6 +7,7 @@ package doobie.free
 import cats.~>
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
+import doobie.util.log.LogEvent
 import doobie.WeakAsync
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
@@ -57,6 +58,7 @@ object statement { module =>
       def canceled: F[Unit]
       def onCancel[A](fa: StatementIO[A], fin: StatementIO[Unit]): F[A]
       def fromFuture[A](fut: StatementIO[Future[A]]): F[A]
+      def performLogging(event: LogEvent): F[Unit]
 
       // Statement
       def addBatch(a: String): F[Unit]
@@ -157,6 +159,9 @@ object statement { module =>
     }
     case class FromFuture[A](fut: StatementIO[Future[A]]) extends StatementOp[A] {
       def visit[F[_]](v: Visitor[F]) = v.fromFuture(fut)
+    }
+    case class PerformLogging(event: LogEvent) extends StatementOp[Unit] {
+      def visit[F[_]](v: Visitor[F]) = v.performLogging(event)
     }
 
     // Statement-specific operations.
@@ -351,6 +356,7 @@ object statement { module =>
   val canceled = FF.liftF[StatementOp, Unit](Canceled)
   def onCancel[A](fa: StatementIO[A], fin: StatementIO[Unit]) = FF.liftF[StatementOp, A](OnCancel(fa, fin))
   def fromFuture[A](fut: StatementIO[Future[A]]) = FF.liftF[StatementOp, A](FromFuture(fut))
+  def performLogging(event: LogEvent) = FF.liftF[StatementOp, Unit](PerformLogging(event))
 
   // Smart constructors for Statement-specific operations.
   def addBatch(a: String): StatementIO[Unit] = FF.liftF(AddBatch(a))

--- a/modules/free/src/main/scala/doobie/util/log.scala
+++ b/modules/free/src/main/scala/doobie/util/log.scala
@@ -4,6 +4,7 @@
 
 package doobie.util
 
+import cats.Applicative
 import cats.effect.Sync
 
 import java.util.logging.Logger
@@ -106,6 +107,9 @@ object log {
    * @group Handlers
    */
   object LogHandlerM {
+    def noop[M[_]: Applicative]: LogHandlerM[M] =
+      _ => Applicative[M].unit
+
     def apply[M[_]: Sync](f: LogEvent => Unit): LogHandlerM[M] =
       (logEvent: LogEvent) => Sync[M].delay(f(logEvent))
 

--- a/modules/h2/src/main/scala/doobie/h2/H2Transactor.scala
+++ b/modules/h2/src/main/scala/doobie/h2/H2Transactor.scala
@@ -22,7 +22,7 @@ object H2Transactor {
   ): Resource[M, H2Transactor[M]] = {
     val alloc = Async[M].delay(JdbcConnectionPool.create(url, user, pass))
     val free  = (ds: JdbcConnectionPool) => Async[M].delay(ds.dispose())
-    Resource.make(alloc)(free).map(Transactor.fromDataSource[M].withLogHandler(logHandler)(_, connectEC))
+    Resource.make(alloc)(free).map(Transactor.fromDataSource[M].withLogHandler(logHandler.getOrElse(LogHandlerM.noop))(_, connectEC))
   }
 
 }

--- a/modules/h2/src/main/scala/doobie/h2/H2Transactor.scala
+++ b/modules/h2/src/main/scala/doobie/h2/H2Transactor.scala
@@ -7,6 +7,7 @@ package h2
 
 import cats.effect.kernel._
 import org.h2.jdbcx.JdbcConnectionPool
+
 import scala.concurrent.ExecutionContext
 
 object H2Transactor {
@@ -16,11 +17,12 @@ object H2Transactor {
     url:        String,
     user:       String,
     pass:       String,
-    connectEC:  ExecutionContext
+    connectEC:  ExecutionContext,
+    logHandler: Option[LogHandlerM[M]] = None
   ): Resource[M, H2Transactor[M]] = {
     val alloc = Async[M].delay(JdbcConnectionPool.create(url, user, pass))
     val free  = (ds: JdbcConnectionPool) => Async[M].delay(ds.dispose())
-    Resource.make(alloc)(free).map(Transactor.fromDataSource[M](_, connectEC))
+    Resource.make(alloc)(free).map(Transactor.fromDataSource[M].withLogHandler(logHandler)(_, connectEC))
   }
 
 }

--- a/modules/postgres/src/main/scala/doobie/postgres/free/kleisliinterpreter.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/free/kleisliinterpreter.scala
@@ -45,12 +45,12 @@ import doobie.postgres.free.largeobjectmanager.{ LargeObjectManagerIO, LargeObje
 import doobie.postgres.free.pgconnection.{ PGConnectionIO, PGConnectionOp }
 
 object KleisliInterpreter {
-  def apply[M[_]: WeakAsync](logHandler: Option[LogHandlerM[M]]): KleisliInterpreter[M] =
+  def apply[M[_]: WeakAsync](logHandler: LogHandlerM[M]): KleisliInterpreter[M] =
     new KleisliInterpreter[M](logHandler)
 }
 
 // Family of interpreters into Kleisli arrows for some monad M.
-class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val asyncM: WeakAsync[M]) { outer =>
+class KleisliInterpreter[M[_]](logHandler: LogHandlerM[M])(implicit val asyncM: WeakAsync[M]) { outer =>
   import WeakAsync._
 
   // The 6 interpreters, with definitions below. These can be overridden to customize behavior.
@@ -121,7 +121,7 @@ class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val 
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[PGCopyIn]
 
-    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler.run(event))
 
     // for operations using CopyInIO we must call ourself recursively
     override def handleErrorWith[A](fa: CopyInIO[A])(f: Throwable => CopyInIO[A]) = outer.handleErrorWith(this)(fa)(f)
@@ -157,7 +157,7 @@ class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val 
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[PGCopyManager]
 
-    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler.run(event))
 
     // for operations using CopyManagerIO we must call ourself recursively
     override def handleErrorWith[A](fa: CopyManagerIO[A])(f: Throwable => CopyManagerIO[A]) = outer.handleErrorWith(this)(fa)(f)
@@ -193,7 +193,7 @@ class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val 
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[PGCopyOut]
 
-    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler.run(event))
 
     // for operations using CopyOutIO we must call ourself recursively
     override def handleErrorWith[A](fa: CopyOutIO[A])(f: Throwable => CopyOutIO[A]) = outer.handleErrorWith(this)(fa)(f)
@@ -227,7 +227,7 @@ class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val 
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[LargeObject]
 
-    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler.run(event))
 
     // for operations using LargeObjectIO we must call ourself recursively
     override def handleErrorWith[A](fa: LargeObjectIO[A])(f: Throwable => LargeObjectIO[A]) = outer.handleErrorWith(this)(fa)(f)
@@ -272,7 +272,7 @@ class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val 
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[LargeObjectManager]
 
-    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler.run(event))
 
     // for operations using LargeObjectManagerIO we must call ourself recursively
     override def handleErrorWith[A](fa: LargeObjectManagerIO[A])(f: Throwable => LargeObjectManagerIO[A]) = outer.handleErrorWith(this)(fa)(f)
@@ -308,7 +308,7 @@ class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val 
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[PGConnection]
 
-    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler.run(event))
 
     // for operations using PGConnectionIO we must call ourself recursively
     override def handleErrorWith[A](fa: PGConnectionIO[A])(f: Throwable => PGConnectionIO[A]) = outer.handleErrorWith(this)(fa)(f)

--- a/modules/postgres/src/main/scala/doobie/postgres/free/kleisliinterpreter.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/free/kleisliinterpreter.scala
@@ -10,6 +10,7 @@ import cats.data.Kleisli
 import cats.effect.kernel.{ Poll, Sync }
 import cats.free.Free
 import doobie.WeakAsync
+import doobie.util.log.{LogEvent, LogHandlerM}
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
@@ -18,13 +19,21 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.io.Reader
 import java.io.Writer
+import java.lang.Class
+import java.lang.String
+import java.sql.{ Array => SqlArray }
+import java.util.Map
 import org.postgresql.PGConnection
+import org.postgresql.PGNotification
+import org.postgresql.copy.{ CopyDual => PGCopyDual }
 import org.postgresql.copy.{ CopyIn => PGCopyIn }
 import org.postgresql.copy.{ CopyManager => PGCopyManager }
 import org.postgresql.copy.{ CopyOut => PGCopyOut }
 import org.postgresql.jdbc.AutoSave
+import org.postgresql.jdbc.PreferQueryMode
 import org.postgresql.largeobject.LargeObject
 import org.postgresql.largeobject.LargeObjectManager
+import org.postgresql.replication.PGReplicationConnection
 import org.postgresql.util.ByteStreamWriter
 
 // Algebras and free monads thereof referenced by our interpreter.
@@ -36,19 +45,12 @@ import doobie.postgres.free.largeobjectmanager.{ LargeObjectManagerIO, LargeObje
 import doobie.postgres.free.pgconnection.{ PGConnectionIO, PGConnectionOp }
 
 object KleisliInterpreter {
-
-  def apply[M[_]](
-    implicit am: WeakAsync[M]
-  ): KleisliInterpreter[M] =
-    new KleisliInterpreter[M] {
-      val asyncM = am
-    }
+  def apply[M[_]: WeakAsync](logHandler: Option[LogHandlerM[M]]): KleisliInterpreter[M] =
+    new KleisliInterpreter[M](logHandler)
 }
 
 // Family of interpreters into Kleisli arrows for some monad M.
-trait KleisliInterpreter[M[_]] { outer =>
-
-  implicit val asyncM: WeakAsync[M]
+class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val asyncM: WeakAsync[M]) { outer =>
   import WeakAsync._
 
   // The 6 interpreters, with definitions below. These can be overridden to customize behavior.
@@ -118,7 +120,9 @@ trait KleisliInterpreter[M[_]] { outer =>
     override def delay[A](thunk: => A) = outer.delay(thunk)
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[PGCopyIn]
-    
+
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+
     // for operations using CopyInIO we must call ourself recursively
     override def handleErrorWith[A](fa: CopyInIO[A])(f: Throwable => CopyInIO[A]) = outer.handleErrorWith(this)(fa)(f)
     override def forceR[A, B](fa: CopyInIO[A])(fb: CopyInIO[B]) = outer.forceR(this)(fa)(fb)
@@ -152,7 +156,9 @@ trait KleisliInterpreter[M[_]] { outer =>
     override def delay[A](thunk: => A) = outer.delay(thunk)
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[PGCopyManager]
-    
+
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+
     // for operations using CopyManagerIO we must call ourself recursively
     override def handleErrorWith[A](fa: CopyManagerIO[A])(f: Throwable => CopyManagerIO[A]) = outer.handleErrorWith(this)(fa)(f)
     override def forceR[A, B](fa: CopyManagerIO[A])(fb: CopyManagerIO[B]) = outer.forceR(this)(fa)(fb)
@@ -186,7 +192,9 @@ trait KleisliInterpreter[M[_]] { outer =>
     override def delay[A](thunk: => A) = outer.delay(thunk)
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[PGCopyOut]
-    
+
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+
     // for operations using CopyOutIO we must call ourself recursively
     override def handleErrorWith[A](fa: CopyOutIO[A])(f: Throwable => CopyOutIO[A]) = outer.handleErrorWith(this)(fa)(f)
     override def forceR[A, B](fa: CopyOutIO[A])(fb: CopyOutIO[B]) = outer.forceR(this)(fa)(fb)
@@ -218,7 +226,9 @@ trait KleisliInterpreter[M[_]] { outer =>
     override def delay[A](thunk: => A) = outer.delay(thunk)
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[LargeObject]
-    
+
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+
     // for operations using LargeObjectIO we must call ourself recursively
     override def handleErrorWith[A](fa: LargeObjectIO[A])(f: Throwable => LargeObjectIO[A]) = outer.handleErrorWith(this)(fa)(f)
     override def forceR[A, B](fa: LargeObjectIO[A])(fb: LargeObjectIO[B]) = outer.forceR(this)(fa)(fb)
@@ -261,7 +271,9 @@ trait KleisliInterpreter[M[_]] { outer =>
     override def delay[A](thunk: => A) = outer.delay(thunk)
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[LargeObjectManager]
-    
+
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+
     // for operations using LargeObjectManagerIO we must call ourself recursively
     override def handleErrorWith[A](fa: LargeObjectManagerIO[A])(f: Throwable => LargeObjectManagerIO[A]) = outer.handleErrorWith(this)(fa)(f)
     override def forceR[A, B](fa: LargeObjectManagerIO[A])(fb: LargeObjectManagerIO[B]) = outer.forceR(this)(fa)(fb)
@@ -295,7 +307,9 @@ trait KleisliInterpreter[M[_]] { outer =>
     override def delay[A](thunk: => A) = outer.delay(thunk)
     override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
     override def canceled = outer.canceled[PGConnection]
-    
+
+    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+
     // for operations using PGConnectionIO we must call ourself recursively
     override def handleErrorWith[A](fa: PGConnectionIO[A])(f: Throwable => PGConnectionIO[A]) = outer.handleErrorWith(this)(fa)(f)
     override def forceR[A, B](fa: PGConnectionIO[A])(fb: PGConnectionIO[B]) = outer.forceR(this)(fa)(fb)

--- a/modules/postgres/src/main/scala/doobie/postgres/free/pgconnection.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/free/pgconnection.scala
@@ -7,6 +7,7 @@ package doobie.postgres.free
 import cats.~>
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
+import doobie.util.log.LogEvent
 import doobie.WeakAsync
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
@@ -62,6 +63,7 @@ object pgconnection { module =>
       def canceled: F[Unit]
       def onCancel[A](fa: PGConnectionIO[A], fin: PGConnectionIO[Unit]): F[A]
       def fromFuture[A](fut: PGConnectionIO[Future[A]]): F[A]
+      def performLogging(event: LogEvent): F[Unit]
 
       // PGConnection
       def addDataType(a: String, b: Class[_ <: org.postgresql.util.PGobject]): F[Unit]
@@ -126,6 +128,9 @@ object pgconnection { module =>
     }
     case class FromFuture[A](fut: PGConnectionIO[Future[A]]) extends PGConnectionOp[A] {
       def visit[F[_]](v: Visitor[F]) = v.fromFuture(fut)
+    }
+    case class PerformLogging(event: LogEvent) extends PGConnectionOp[Unit] {
+      def visit[F[_]](v: Visitor[F]) = v.performLogging(event)
     }
 
     // PGConnection-specific operations.
@@ -212,6 +217,7 @@ object pgconnection { module =>
   val canceled = FF.liftF[PGConnectionOp, Unit](Canceled)
   def onCancel[A](fa: PGConnectionIO[A], fin: PGConnectionIO[Unit]) = FF.liftF[PGConnectionOp, A](OnCancel(fa, fin))
   def fromFuture[A](fut: PGConnectionIO[Future[A]]) = FF.liftF[PGConnectionOp, A](FromFuture(fut))
+  def performLogging(event: LogEvent) = FF.liftF[PGConnectionOp, Unit](PerformLogging(event))
 
   // Smart constructors for PGConnection-specific operations.
   def addDataType(a: String, b: Class[_ <: org.postgresql.util.PGobject]): PGConnectionIO[Unit] = FF.liftF(AddDataType(a, b))

--- a/modules/postgres/src/main/scala/doobie/postgres/hi/connection.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/hi/connection.scala
@@ -16,7 +16,7 @@ object connection {
 
   // An intepreter for lifting PGConnectionIO into ConnectionIO
   val defaultInterpreter: PFPC.PGConnectionOp ~> Kleisli[ConnectionIO, PGConnection, *] =
-    KleisliInterpreter[ConnectionIO](None).PGConnectionInterpreter
+    KleisliInterpreter[ConnectionIO](LogHandlerM.noop).PGConnectionInterpreter
 
   val pgGetBackendPID: ConnectionIO[Int] =
     pgGetConnection(PFPC.getBackendPID)

--- a/modules/postgres/src/main/scala/doobie/postgres/hi/connection.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/hi/connection.scala
@@ -16,7 +16,7 @@ object connection {
 
   // An intepreter for lifting PGConnectionIO into ConnectionIO
   val defaultInterpreter: PFPC.PGConnectionOp ~> Kleisli[ConnectionIO, PGConnection, *] =
-    KleisliInterpreter[ConnectionIO].PGConnectionInterpreter
+    KleisliInterpreter[ConnectionIO](None).PGConnectionInterpreter
 
   val pgGetBackendPID: ConnectionIO[Int] =
     pgGetConnection(PFPC.getBackendPID)

--- a/project/FreeGen2.scala
+++ b/project/FreeGen2.scala
@@ -415,7 +415,7 @@ class FreeGen2(managed: List[Class[_]], pkg: String, renames: Map[Class[_], Stri
        |    override def suspend[A](hint: Sync.Type)(thunk: => A) = outer.suspend(hint)(thunk)
        |    override def canceled = outer.canceled[${sname}]
        |
-       |    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler match {case Some(lh) => lh.run(event); case None => asyncM.pure(())})
+       |    override def performLogging(event: LogEvent) = Kleisli(_ => logHandler.run(event))
        |
        |    // for operations using ${ioname} we must call ourself recursively
        |    override def handleErrorWith[A](fa: ${ioname}[A])(f: Throwable => ${ioname}[A]) = outer.handleErrorWith(this)(fa)(f)
@@ -464,12 +464,12 @@ class FreeGen2(managed: List[Class[_]], pkg: String, renames: Map[Class[_], Stri
       |${managed.map(_.getSimpleName).map(c => s"import ${pkg}.${c.toLowerCase}.{ ${c}IO, ${c}Op }").mkString("\n")}
       |
       |object KleisliInterpreter {
-      |  def apply[M[_]: WeakAsync](logHandler: Option[LogHandlerM[M]]): KleisliInterpreter[M] =
+      |  def apply[M[_]: WeakAsync](logHandler: LogHandlerM[M]): KleisliInterpreter[M] =
       |    new KleisliInterpreter[M](logHandler)
       |}
       |
       |// Family of interpreters into Kleisli arrows for some monad M.
-      |class KleisliInterpreter[M[_]](logHandler: Option[LogHandlerM[M]])(implicit val asyncM: WeakAsync[M]) { outer =>
+      |class KleisliInterpreter[M[_]](logHandler: LogHandlerM[M])(implicit val asyncM: WeakAsync[M]) { outer =>
       |  import WeakAsync._
       |
       |  // The ${managed.length} interpreters, with definitions below. These can be overridden to customize behavior.


### PR DESCRIPTION
(I've reworded and squashed the PR to make it easier to review)

Hey there. This PR seems to work as is,but I think it would benefit a lot from some discussion, especially regarding what the exposed API should be, naming, possible extensions if there are other things the interpreters could be more knowledgeable about.

### Problematic use case

We've been working on improving logging and tracing lately, and to that end we want to log mostly everything doobie does. We've actually been doing it for a while, and as a result we have hundreds of boilerplatey and convention-driven calls to `updateWithLogHandler` and friends, as I'm sure you can imagine. It gets worse when you need parameters to the `LogHandler`, because now all the DAOs are classes with parameters instead of static objects

### Proposed solution 

The idea behind this PR is to make that logging part of the interpreter rather than the queries and updates. Effectively, that means you can provide a `LogHandlerM` (an effectful copy of `LogHandler`) when creating an `xa`. Obviously it should have a better name, and maybe we would want to remove/deprecate the current query logging API.

### How

I generated a new node for all the algebras, `case class PerformLogging(logEvent: LogEvent) extends ...Op[LogHandler]`. 
This enables programs in all the generated algebras to log `LogEvent`s. The logging itself now runs in the output effect of the interpreter, so it can just delegate.

Currently it's added to all algebras even though it's likely only needed by `PreparedStatementIO`. 

This means that the interpreter, and in turn `xa` need a new optional parameter. This new parameter causes some friction in the API for creating an `xa`, since there are already many overloads and so default parameters are out of the picture. I sketched a builder-like pattern which I think we could grow in a binary-compatible way after 1.0 for `Transactor.fromDriverManager`

### Specific/General

Right now just a `LogHandlerM` is provided to the interpreter, but maybe it should be an `InterpreterParams` type instead, if there are more things like this which it could be useful to configure.

I also thought about adding it a bit later in the execution, so we would have interpreters with a signature like `NClobOp ~> Kleisli[M, (NClob, InterpreterParams), *]`, but didn't want to venture there unless that was seen to be clearly better.


### effectful `LogHandlerM`

`LogHandler` had to become effectful, the main driver for me other than it fitting better in with the rest, was that I'm experimenting with using `IOLocal` to thread through context/spans for logging. Running those effects disconnected from the rest of the IO runtime breaks that use case.


