### PR TITLE
Managing Connections page no longer breaks

### DIFF
--- a/modules/docs/src/main/mdoc/docs/14-Managing-Connections.md
+++ b/modules/docs/src/main/mdoc/docs/14-Managing-Connections.md
@@ -120,8 +120,8 @@ object HikariApp extends IOApp {
 
 And running this program gives us the desired result.
 
-```scala mdoc
-// HikariApp.main(Array()) // https://github.com/typelevel/cats-effect/issues/1560
+```scala mdoc:silent
+HikariApp.main(Array())
 ```
 
 ### Using an existing DataSource


### PR DESCRIPTION
Currently [Managing Connections page](https://tpolecat.github.io/doobie/docs/14-Managing-Connections.html#using-a-hikaricp-connection-pool) breaks after an empty code block. 

I've implemented this very complicated fix to resolve this issue.