### PR TITLE
Enable support for `derives` in Scala 3 for `Read`, `Write` and `Text`

### DIFF
--- a/modules/core/src/main/scala-3/util/ReadPlatform.scala
+++ b/modules/core/src/main/scala-3/util/ReadPlatform.scala
@@ -20,7 +20,7 @@ trait ReadPlatform:
     )
 
   // Generic Read for products.
-  given [P <: Product, A](
+  given derived [P <: Product, A](
     using m: Mirror.ProductOf[P],
           i: A =:= m.MirroredElemTypes,
           w: Read[A]

--- a/modules/core/src/main/scala-3/util/WritePlatform.scala
+++ b/modules/core/src/main/scala-3/util/WritePlatform.scala
@@ -22,7 +22,7 @@ trait WritePlatform:
     )
 
   // Generic write for products.
-  given [P <: Product, A](
+  given derived[P <: Product, A](
     using m: Mirror.ProductOf[P],
           i: m.MirroredElemTypes =:= A,
           w: Write[A]

--- a/modules/core/src/test/scala-3/doobie/util/ReadSuitePlatform.scala
+++ b/modules/core/src/test/scala-3/doobie/util/ReadSuitePlatform.scala
@@ -21,4 +21,7 @@ trait ReadSuitePlatform { self: munit.FunSuite =>
     util.Read[Option[(Int, Woozle *: Woozle *: String *: EmptyTuple)]]
   }
 
+  test("derives") {
+    case class Foo(a: String, b: Int) derives util.Read
+  }
 }

--- a/modules/core/src/test/scala-3/doobie/util/WriteSuitePlatform.scala
+++ b/modules/core/src/test/scala-3/doobie/util/WriteSuitePlatform.scala
@@ -21,4 +21,7 @@ trait WriteSuitePlatform { self: munit.FunSuite =>
     util.Write[Option[(Int, Woozle *: Woozle *: String *: EmptyTuple)]]
   }
 
+  test("derives") {
+    case class Foo(a: String, b: Int) derives util.Write
+  }
 }

--- a/modules/postgres/src/main/scala-3/doobie/postgres/TextPlatform.scala
+++ b/modules/postgres/src/main/scala-3/doobie/postgres/TextPlatform.scala
@@ -17,7 +17,7 @@ trait TextPlatform { this: Text.type =>
     (h product t).contramap(l => (l.head, l.tail))
 
   // Put is available for single-element products.
-  given [P <: Product, A](
+  given derived[P <: Product, A](
     using m: Mirror.ProductOf[P],
           i: m.MirroredElemTypes =:= A,
           t: Text[A]

--- a/modules/postgres/src/test/scala-2/doobie/postgres/TextSuitePlatform.scala
+++ b/modules/postgres/src/test/scala-2/doobie/postgres/TextSuitePlatform.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2013-2020 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.postgres
+
+trait TextSuitePlatform { self: munit.FunSuite =>
+
+}

--- a/modules/postgres/src/test/scala-3/postgres/TextSuitePlatform.scala
+++ b/modules/postgres/src/test/scala-3/postgres/TextSuitePlatform.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2013-2020 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.postgres
+
+trait TextSuitePlatform { self: munit.FunSuite =>
+  test("derives") {
+    case class Foo(a: String, b: Int) derives Text
+  }
+}


### PR DESCRIPTION
In order for this keyword to work, there needs to be a `derived` method available in the companion objects. This gives some of the `given`s the expected name.

This is what it looks like without this patch:
```
[error] -- [E008] Not Found Error: /home/.../doobie/modules/core/src/test/scala-3/doobie/util/ReadSuitePlatform.scala:25:51 
[error] 25 |    case class Foo(a: String, b: Int) derives util.Read
[error]    |                                                   ^
[error]    |value derived is not a member of object doobie.util.Read, but could be made available as an extension method.
[error]    |
[error]    |The following import might make progress towards fixing the problem:
[error]    |
[error]    |  import munit.Clue.generate
[error]    |
[error] one error found
```