### PR TITLE
Add support for JSON in H2 using circe

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -158,6 +158,7 @@ lazy val doobie = project.in(file("."))
     example,
     free,
     h2,
+    `h2-circe`,
     hikari,
     postgres,
     `postgres-circe`,
@@ -342,6 +343,21 @@ lazy val h2 = project
     description := "H2 support for doobie.",
     libraryDependencies += "com.h2database" % "h2"  % h2Version,
     scalacOptions -= "-Xfatal-warnings" // we need to do deprecated things
+  )
+
+lazy val `h2-circe` = project
+  .in(file("modules/h2-circe"))
+  .enablePlugins(AutomateHeaderPlugin)
+  .dependsOn(core, h2)
+  .settings(doobieSettings)
+  .settings(publishSettings)
+  .settings(
+    name  := "doobie-h2-circe",
+    description := "h2 circe support for doobie.",
+    libraryDependencies ++= Seq(
+      "io.circe"    %% "circe-core"    % circeVersion,
+      "io.circe"    %% "circe-parser"  % circeVersion
+    )
   )
 
 lazy val hikari = project

--- a/modules/docs/src/main/mdoc/docs/16-Extensions-H2.md
+++ b/modules/docs/src/main/mdoc/docs/16-Extensions-H2.md
@@ -10,6 +10,26 @@ libraryDependencies += "org.tpolecat" %% "doobie-h2" % "$version$"
 
 This library pulls in H2 as a transitive dependency.
 
+There are extensions available for dealing with JSON by using Circe, if you like to use those, include this dependency:
+
+@@@ vars
+
+```scala
+libraryDependencies += "org.tpolecat" %% "doobie-h2-circe" % "$version$"
+```
+
+@@@
+
+Then, you will be able to import the implicits for dealing with JSON:
+
+@@@ vars
+
+```scala
+import doobie.h2.circe.json.implicits
+```
+
+@@@
+
 ### Array Types
 
 **doobie** supports H2 arrays of the following types:

--- a/modules/h2-circe/src/main/scala/doobie/h2/circe/Instances.scala
+++ b/modules/h2-circe/src/main/scala/doobie/h2/circe/Instances.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2013-2020 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.h2.circe
+
+import cats.Show
+import cats.data.NonEmptyList
+import cats.syntax.all._
+import doobie.enumerated.JdbcType
+import io.circe._
+import io.circe.jawn._
+import io.circe.syntax._
+import doobie.util._
+
+import java.nio.charset.StandardCharsets.UTF_8
+
+object Instances {
+
+  private implicit val byteArrayShow: Show[Array[Byte]] = Show.show(new String(_, UTF_8))
+
+  trait JsonInstances {
+    implicit val jsonPut: Put[Json] =
+      Put.Advanced.one[Array[Byte]](
+        JdbcType.VarChar,
+        NonEmptyList.of("JSON"),
+        (ps, n, a) => ps.setObject(n, a),
+        (rs, n, a) => rs.updateObject(n, a)
+      )
+        .tcontramap { a =>
+          a.noSpaces.getBytes(UTF_8)
+        }
+
+    implicit val jsonGet: Get[Json] =
+      Get.Advanced.other[Array[Byte]](
+        NonEmptyList.of("JSON")
+      ).temap(a =>
+        parse(a.show).leftMap(_.show)
+      )
+
+    def h2EncoderPutT[A: Encoder]: Put[A] =
+      Put[Json].tcontramap(_.asJson)
+
+    def h2EncoderPut[A: Encoder]: Put[A] =
+      Put[Json].contramap(_.asJson)
+
+    def h2DecoderGetT[A: Decoder]: Get[A] =
+      Get[Json].temap(json => json.as[A].leftMap(_.show))
+
+    @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+    def h2DecoderGet[A: Decoder]: Get[A] =
+      Get[Json].map(json => json.as[A].fold(throw _, identity))
+  }
+
+}

--- a/modules/h2-circe/src/main/scala/doobie/h2/circe/json/json.scala
+++ b/modules/h2-circe/src/main/scala/doobie/h2/circe/json/json.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2013-2020 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.h2.circe
+
+package object json {
+  object implicits extends doobie.h2.circe.Instances.JsonInstances
+}

--- a/modules/h2-circe/src/test/scala/doobie/h2/circe/H2JsonSuite.scala
+++ b/modules/h2-circe/src/test/scala/doobie/h2/circe/H2JsonSuite.scala
@@ -1,0 +1,81 @@
+// Copyright (c) 2013-2020 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.h2.circe
+
+import cats.effect.IO
+import doobie._
+import doobie.implicits._
+import io.circe.{Decoder, Encoder, Json}
+
+class H2JsonSuite extends munit.FunSuite {
+
+  import cats.effect.unsafe.implicits.global
+
+  val xa = Transactor.fromDriverManager[IO](
+    "org.h2.Driver",
+    "jdbc:h2:mem:testdb",
+    "sa", ""
+  )
+
+  def inOut[A: Write: Read](col: String, a: A) =
+    for {
+      _  <- Update0(s"CREATE TEMPORARY TABLE TEST (value $col)", None).run
+      a0 <- Update[A](s"INSERT INTO TEST VALUES (?)", None).withUniqueGeneratedKeys[A]("value")(a)
+    } yield a0
+
+  @SuppressWarnings(Array("org.wartremover.warts.StringPlusAny"))
+  def testInOut[A](col: String, a: A, t: Transactor[IO])(implicit m: Get[A], p: Put[A]) = {
+    test(s"Mapping for $col as ${m.typeStack} - write+read $col as ${m.typeStack}") {
+      assertEquals(inOut(col, a).transact(t).attempt.unsafeRunSync(), Right(a))
+    }
+    test(s"Mapping for $col as ${m.typeStack} - write+read $col as Option[${m.typeStack}] (Some)") {
+      assertEquals(inOut[Option[A]](col, Some(a)).transact(t).attempt.unsafeRunSync(), Right(Some(a)))
+    }
+    test(s"Mapping for $col as ${m.typeStack} - write+read $col as Option[${m.typeStack}] (None)") {
+      assertEquals(inOut[Option[A]](col, None).transact(t).attempt.unsafeRunSync(), Right(None))
+    }
+  }
+
+  {
+    import doobie.h2.circe.json.implicits._
+    testInOut("json", Json.obj("something" -> Json.fromString("Yellow")), xa)
+  }
+
+
+  // Explicit Type Checks
+
+  test("json should check ok for read") {
+    import doobie.h2.circe.json.implicits._
+
+    val a = sql"SELECT '{}' FORMAT JSON".query[Json].analysis.transact(xa).unsafeRunSync()
+    assertEquals(a.columnTypeErrors, Nil)
+  }
+  test("json should check ok for write") {
+    import doobie.h2.circe.json.implicits._
+
+    val a = sql"SELECT ${Json.obj()} FORMAT JSON".query[Json].analysis.transact(xa).unsafeRunSync()
+    assertEquals(a.parameterTypeErrors, Nil)
+  }
+
+  // Encoder / Decoders
+  private case class Foo(x: Json)
+  private object Foo{
+    import doobie.h2.circe.json.implicits._
+    implicit val fooEncoder: Encoder[Foo] = Encoder[Json].contramap(_.x)
+    implicit val fooDecoder: Decoder[Foo] = Decoder[Json].map(Foo(_))
+    implicit val fooGet : Get[Foo] = h2DecoderGetT[Foo]
+    implicit val fooPut : Put[Foo] = h2EncoderPutT[Foo]
+  }
+
+  test("fooGet should check ok for read") {
+    val a = sql"SELECT '{}' FORMAT JSON".query[Foo].analysis.transact(xa).unsafeRunSync()
+    assertEquals(a.columnTypeErrors, Nil)
+  }
+  test("fooPut check ok for write") {
+    val a = sql"SELECT ${Foo(Json.obj())} FORMAT JSON".query[Foo].analysis.transact(xa).unsafeRunSync()
+    assertEquals(a.parameterTypeErrors, Nil)
+  }
+
+}


### PR DESCRIPTION
This PR introduces support for JSON type in H2.

Code and tests are based on Postgres implementation.

I've tried using native H2 type `ValueJson`, but H2 really insists on using VARCHAR/bytearray:

```scala
    implicit val jsonPut: Put[Json] =
      Put.Advanced.other[ValueJson](
        NonEmptyList.of("JSON", "json")
      ).tcontramap(a =>
        ValueJson.fromJson(a.noSpaces)
      )
	  
	implicit val jsonGet: Get[Json] =
      Get.Advanced.other[ValueJson](
        NonEmptyList.of("JSON", "json")
      ).temap(a =>
        parse(a.getString).leftMap(_.show)
      )
```