### PR TITLE
Postgis: Add custom mapping for geography -> point postgres conversion

### DIFF
--- a/modules/postgres/src/main/scala/doobie/postgres/pgisinstances.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/pgisinstances.scala
@@ -6,8 +6,8 @@ package doobie.postgres
 
 import doobie._
 import doobie.util.invariant._
-
 import org.postgis._
+import org.postgresql.util.PGobject
 
 import scala.reflect.ClassTag
 import org.tpolecat.typename._
@@ -15,9 +15,10 @@ import org.tpolecat.typename._
 trait PgisInstances {
 
   // PostGIS outer types
-  implicit val PGgeometryType: Meta[PGgeometry] = Meta.Advanced.other[PGgeometry]("geometry")
-  implicit val PGbox3dType: Meta[PGbox3d]       = Meta.Advanced.other[PGbox3d]("box3d")
-  implicit val PGbox2dType: Meta[PGbox2d]       = Meta.Advanced.other[PGbox2d]("box2d")
+  implicit val PGGeographyType: Meta[PGgeography] = Meta.Advanced.other[PGgeography]("geography")
+  implicit val PGgeometryType: Meta[PGgeometry]   = Meta.Advanced.other[PGgeometry]("geometry")
+  implicit val PGbox3dType: Meta[PGbox3d]         = Meta.Advanced.other[PGbox3d]("box3d")
+  implicit val PGbox2dType: Meta[PGbox2d]         = Meta.Advanced.other[PGbox2d]("box2d")
 
   // Constructor for geometry types via the `Geometry` member of PGgeometry
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf", "org.wartremover.warts.Throw"))
@@ -27,6 +28,10 @@ trait PgisInstances {
       catch {
         case _: ClassCastException => throw InvalidObjectMapping(A.runtimeClass, g.getGeometry.getClass)
       })(new PGgeometry(_))
+
+  // geography point conversions
+  implicit val geographyPointGet: Get[Point] = Get[PGgeography].tmap(g => g.getGeometry.getFirstPoint)
+  implicit val geographyPointPut: Put[Point] = Put[PGgeography].tcontramap(p => new PGgeography(p.getFirstPoint))
 
   // PostGIS Geometry Types
   implicit val GeometryType: Meta[Geometry]                     = geometryType[Geometry]

--- a/modules/postgres/src/test/scala/doobie/postgres/TypesSuite.scala
+++ b/modules/postgres/src/test/scala/doobie/postgres/TypesSuite.scala
@@ -284,6 +284,10 @@ class TypesSuite extends munit.ScalaCheckSuite {
   testInOutGeom[Polygon](pls.next())
   testInOutGeom[Point](pts.next())
 
+  val geographyPoint = new Point(41, 2)
+  geographyPoint.setSrid(4326)
+  testInOut[Point]("geography(POINT, 4326)", geographyPoint)
+
   // hstore
   testInOut[Map[String, String]]("hstore")
 }


### PR DESCRIPTION
See #1264.

This PR adds both Get/Put implicits (doobie.postgres.PgisInstances) to allow conversions between Postgis Geography(Point) (coordinates as spherical) and Point types.

Surely additional conversions (POLYLINE, POLYGON...) are needed, It can be implemented in a similar way if this implementation is correct.

Here is an example that would be valid with this change:

```scala
  /// CREATE TABLE countries(name TEXT PRIMARY KEY, location GEOGRAPHY(POINT, 4326));
  case class Country(code: String, location: Option[Point])

  def findCountry(n: String): ConnectionIO[Option[Country]] =
    sql"select name, location from countries where name = $n".query[Country].option
```