### PR TITLE
remove jdk9+ stuff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.15, 2.13.7, 3.1.0]
-        java: [temurin@11]
+        java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -36,12 +36,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
+      - name: Setup Java (temurin@8)
+        if: matrix.java == 'temurin@8'
         uses: actions/setup-java@v2
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 8
 
       - name: Cache sbt
         uses: actions/cache@v2
@@ -90,7 +90,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.7]
-        java: [temurin@11]
+        java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -98,12 +98,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
+      - name: Setup Java (temurin@8)
+        if: matrix.java == 'temurin@8'
         uses: actions/setup-java@v2
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 8
 
       - name: Cache sbt
         uses: actions/cache@v2

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ ThisBuild / scalaVersion := scala213Version
 ThisBuild / crossScalaVersions := Seq(scala212Version, scala213Version, scala30Version)
 ThisBuild / developers += tlGitHubDev("tpolecat", "Rob Norris")
 ThisBuild / tlSonatypeUseLegacyHost := false
-ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("11"))
+ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("8"))
 ThisBuild / githubWorkflowBuildPreamble ++= Seq(
   WorkflowStep.Run(
     commands = List("docker-compose up -d"),

--- a/modules/core/src/test/scala/doobie/util/StrategySuite.scala
+++ b/modules/core/src/test/scala/doobie/util/StrategySuite.scala
@@ -8,7 +8,6 @@ import cats.effect.IO
 import cats.syntax.apply._
 import doobie._, doobie.implicits._
 
-
 class StrategySuite extends munit.FunSuite {
 
   import cats.effect.unsafe.implicits.global
@@ -45,6 +44,7 @@ class StrategySuite extends munit.FunSuite {
       override val rollback = delay(Connection.rollback = Some(())) *> super.rollback
       override val commit = delay(Connection.commit = Some(())) *> super.commit
       override def setAutoCommit(b: Boolean) = delay(Connection.autoCommit = Option(b)) *> super.setAutoCommit(b)
+      override def getTypeMap = super.getTypeMap.asInstanceOf // No idea. Type error on Java 8 if we don't do this.
     }
 
     override lazy val PreparedStatementInterpreter = new PreparedStatementInterpreter {

--- a/modules/free/src/main/scala/doobie/free/callablestatement.scala
+++ b/modules/free/src/main/scala/doobie/free/callablestatement.scala
@@ -86,9 +86,6 @@ object callablestatement { module =>
       def clearWarnings: F[Unit]
       def close: F[Unit]
       def closeOnCompletion: F[Unit]
-      def enquoteIdentifier(a: String, b: Boolean): F[String]
-      def enquoteLiteral(a: String): F[String]
-      def enquoteNCharLiteral(a: String): F[String]
       def execute: F[Boolean]
       def execute(a: String): F[Boolean]
       def execute(a: String, b: Array[Int]): F[Boolean]
@@ -190,7 +187,6 @@ object callablestatement { module =>
       def isCloseOnCompletion: F[Boolean]
       def isClosed: F[Boolean]
       def isPoolable: F[Boolean]
-      def isSimpleIdentifier(a: String): F[Boolean]
       def isWrapperFor(a: Class[_]): F[Boolean]
       def registerOutParameter(a: Int, b: Int): F[Unit]
       def registerOutParameter(a: Int, b: Int, c: Int): F[Unit]
@@ -379,15 +375,6 @@ object callablestatement { module =>
     }
     case object CloseOnCompletion extends CallableStatementOp[Unit] {
       def visit[F[_]](v: Visitor[F]) = v.closeOnCompletion
-    }
-    final case class EnquoteIdentifier(a: String, b: Boolean) extends CallableStatementOp[String] {
-      def visit[F[_]](v: Visitor[F]) = v.enquoteIdentifier(a, b)
-    }
-    final case class EnquoteLiteral(a: String) extends CallableStatementOp[String] {
-      def visit[F[_]](v: Visitor[F]) = v.enquoteLiteral(a)
-    }
-    final case class EnquoteNCharLiteral(a: String) extends CallableStatementOp[String] {
-      def visit[F[_]](v: Visitor[F]) = v.enquoteNCharLiteral(a)
     }
     case object Execute extends CallableStatementOp[Boolean] {
       def visit[F[_]](v: Visitor[F]) = v.execute
@@ -691,9 +678,6 @@ object callablestatement { module =>
     }
     case object IsPoolable extends CallableStatementOp[Boolean] {
       def visit[F[_]](v: Visitor[F]) = v.isPoolable
-    }
-    final case class IsSimpleIdentifier(a: String) extends CallableStatementOp[Boolean] {
-      def visit[F[_]](v: Visitor[F]) = v.isSimpleIdentifier(a)
     }
     final case class IsWrapperFor(a: Class[_]) extends CallableStatementOp[Boolean] {
       def visit[F[_]](v: Visitor[F]) = v.isWrapperFor(a)
@@ -1088,9 +1072,6 @@ object callablestatement { module =>
   val clearWarnings: CallableStatementIO[Unit] = FF.liftF(ClearWarnings)
   val close: CallableStatementIO[Unit] = FF.liftF(Close)
   val closeOnCompletion: CallableStatementIO[Unit] = FF.liftF(CloseOnCompletion)
-  def enquoteIdentifier(a: String, b: Boolean): CallableStatementIO[String] = FF.liftF(EnquoteIdentifier(a, b))
-  def enquoteLiteral(a: String): CallableStatementIO[String] = FF.liftF(EnquoteLiteral(a))
-  def enquoteNCharLiteral(a: String): CallableStatementIO[String] = FF.liftF(EnquoteNCharLiteral(a))
   val execute: CallableStatementIO[Boolean] = FF.liftF(Execute)
   def execute(a: String): CallableStatementIO[Boolean] = FF.liftF(Execute1(a))
   def execute(a: String, b: Array[Int]): CallableStatementIO[Boolean] = FF.liftF(Execute2(a, b))
@@ -1192,7 +1173,6 @@ object callablestatement { module =>
   val isCloseOnCompletion: CallableStatementIO[Boolean] = FF.liftF(IsCloseOnCompletion)
   val isClosed: CallableStatementIO[Boolean] = FF.liftF(IsClosed)
   val isPoolable: CallableStatementIO[Boolean] = FF.liftF(IsPoolable)
-  def isSimpleIdentifier(a: String): CallableStatementIO[Boolean] = FF.liftF(IsSimpleIdentifier(a))
   def isWrapperFor(a: Class[_]): CallableStatementIO[Boolean] = FF.liftF(IsWrapperFor(a))
   def registerOutParameter(a: Int, b: Int): CallableStatementIO[Unit] = FF.liftF(RegisterOutParameter(a, b))
   def registerOutParameter(a: Int, b: Int, c: Int): CallableStatementIO[Unit] = FF.liftF(RegisterOutParameter1(a, b, c))

--- a/modules/free/src/main/scala/doobie/free/connection.scala
+++ b/modules/free/src/main/scala/doobie/free/connection.scala
@@ -23,7 +23,6 @@ import java.sql.PreparedStatement
 import java.sql.SQLWarning
 import java.sql.SQLXML
 import java.sql.Savepoint
-import java.sql.ShardingKey
 import java.sql.Statement
 import java.sql.Struct
 import java.sql.{ Array => SqlArray }
@@ -73,7 +72,6 @@ object connection { module =>
 
       // Connection
       def abort(a: Executor): F[Unit]
-      def beginRequest: F[Unit]
       def clearWarnings: F[Unit]
       def close: F[Unit]
       def commit: F[Unit]
@@ -86,7 +84,6 @@ object connection { module =>
       def createStatement(a: Int, b: Int): F[Statement]
       def createStatement(a: Int, b: Int, c: Int): F[Statement]
       def createStruct(a: String, b: Array[AnyRef]): F[Struct]
-      def endRequest: F[Unit]
       def getAutoCommit: F[Boolean]
       def getCatalog: F[String]
       def getClientInfo: F[Properties]
@@ -125,10 +122,6 @@ object connection { module =>
       def setSavepoint: F[Savepoint]
       def setSavepoint(a: String): F[Savepoint]
       def setSchema(a: String): F[Unit]
-      def setShardingKey(a: ShardingKey): F[Unit]
-      def setShardingKey(a: ShardingKey, b: ShardingKey): F[Unit]
-      def setShardingKeyIfValid(a: ShardingKey, b: Int): F[Boolean]
-      def setShardingKeyIfValid(a: ShardingKey, b: ShardingKey, c: Int): F[Boolean]
       def setTransactionIsolation(a: Int): F[Unit]
       def setTypeMap(a: Map[String, Class[_]]): F[Unit]
       def unwrap[T](a: Class[T]): F[T]
@@ -180,9 +173,6 @@ object connection { module =>
     final case class Abort(a: Executor) extends ConnectionOp[Unit] {
       def visit[F[_]](v: Visitor[F]) = v.abort(a)
     }
-    case object BeginRequest extends ConnectionOp[Unit] {
-      def visit[F[_]](v: Visitor[F]) = v.beginRequest
-    }
     case object ClearWarnings extends ConnectionOp[Unit] {
       def visit[F[_]](v: Visitor[F]) = v.clearWarnings
     }
@@ -218,9 +208,6 @@ object connection { module =>
     }
     final case class CreateStruct(a: String, b: Array[AnyRef]) extends ConnectionOp[Struct] {
       def visit[F[_]](v: Visitor[F]) = v.createStruct(a, b)
-    }
-    case object EndRequest extends ConnectionOp[Unit] {
-      def visit[F[_]](v: Visitor[F]) = v.endRequest
     }
     case object GetAutoCommit extends ConnectionOp[Boolean] {
       def visit[F[_]](v: Visitor[F]) = v.getAutoCommit
@@ -336,18 +323,6 @@ object connection { module =>
     final case class SetSchema(a: String) extends ConnectionOp[Unit] {
       def visit[F[_]](v: Visitor[F]) = v.setSchema(a)
     }
-    final case class SetShardingKey(a: ShardingKey) extends ConnectionOp[Unit] {
-      def visit[F[_]](v: Visitor[F]) = v.setShardingKey(a)
-    }
-    final case class SetShardingKey1(a: ShardingKey, b: ShardingKey) extends ConnectionOp[Unit] {
-      def visit[F[_]](v: Visitor[F]) = v.setShardingKey(a, b)
-    }
-    final case class SetShardingKeyIfValid(a: ShardingKey, b: Int) extends ConnectionOp[Boolean] {
-      def visit[F[_]](v: Visitor[F]) = v.setShardingKeyIfValid(a, b)
-    }
-    final case class SetShardingKeyIfValid1(a: ShardingKey, b: ShardingKey, c: Int) extends ConnectionOp[Boolean] {
-      def visit[F[_]](v: Visitor[F]) = v.setShardingKeyIfValid(a, b, c)
-    }
     final case class SetTransactionIsolation(a: Int) extends ConnectionOp[Unit] {
       def visit[F[_]](v: Visitor[F]) = v.setTransactionIsolation(a)
     }
@@ -383,7 +358,6 @@ object connection { module =>
 
   // Smart constructors for Connection-specific operations.
   def abort(a: Executor): ConnectionIO[Unit] = FF.liftF(Abort(a))
-  val beginRequest: ConnectionIO[Unit] = FF.liftF(BeginRequest)
   val clearWarnings: ConnectionIO[Unit] = FF.liftF(ClearWarnings)
   val close: ConnectionIO[Unit] = FF.liftF(Close)
   val commit: ConnectionIO[Unit] = FF.liftF(Commit)
@@ -396,7 +370,6 @@ object connection { module =>
   def createStatement(a: Int, b: Int): ConnectionIO[Statement] = FF.liftF(CreateStatement1(a, b))
   def createStatement(a: Int, b: Int, c: Int): ConnectionIO[Statement] = FF.liftF(CreateStatement2(a, b, c))
   def createStruct(a: String, b: Array[AnyRef]): ConnectionIO[Struct] = FF.liftF(CreateStruct(a, b))
-  val endRequest: ConnectionIO[Unit] = FF.liftF(EndRequest)
   val getAutoCommit: ConnectionIO[Boolean] = FF.liftF(GetAutoCommit)
   val getCatalog: ConnectionIO[String] = FF.liftF(GetCatalog)
   val getClientInfo: ConnectionIO[Properties] = FF.liftF(GetClientInfo)
@@ -435,10 +408,6 @@ object connection { module =>
   val setSavepoint: ConnectionIO[Savepoint] = FF.liftF(SetSavepoint)
   def setSavepoint(a: String): ConnectionIO[Savepoint] = FF.liftF(SetSavepoint1(a))
   def setSchema(a: String): ConnectionIO[Unit] = FF.liftF(SetSchema(a))
-  def setShardingKey(a: ShardingKey): ConnectionIO[Unit] = FF.liftF(SetShardingKey(a))
-  def setShardingKey(a: ShardingKey, b: ShardingKey): ConnectionIO[Unit] = FF.liftF(SetShardingKey1(a, b))
-  def setShardingKeyIfValid(a: ShardingKey, b: Int): ConnectionIO[Boolean] = FF.liftF(SetShardingKeyIfValid(a, b))
-  def setShardingKeyIfValid(a: ShardingKey, b: ShardingKey, c: Int): ConnectionIO[Boolean] = FF.liftF(SetShardingKeyIfValid1(a, b, c))
   def setTransactionIsolation(a: Int): ConnectionIO[Unit] = FF.liftF(SetTransactionIsolation(a))
   def setTypeMap(a: Map[String, Class[_]]): ConnectionIO[Unit] = FF.liftF(SetTypeMap(a))
   def unwrap[T](a: Class[T]): ConnectionIO[T] = FF.liftF(Unwrap(a))

--- a/modules/free/src/main/scala/doobie/free/databasemetadata.scala
+++ b/modules/free/src/main/scala/doobie/free/databasemetadata.scala
@@ -221,7 +221,6 @@ object databasemetadata { module =>
       def supportsSchemasInProcedureCalls: F[Boolean]
       def supportsSchemasInTableDefinitions: F[Boolean]
       def supportsSelectForUpdate: F[Boolean]
-      def supportsSharding: F[Boolean]
       def supportsStatementPooling: F[Boolean]
       def supportsStoredFunctionsUsingCallSyntax: F[Boolean]
       def supportsStoredProcedures: F[Boolean]
@@ -769,9 +768,6 @@ object databasemetadata { module =>
     case object SupportsSelectForUpdate extends DatabaseMetaDataOp[Boolean] {
       def visit[F[_]](v: Visitor[F]) = v.supportsSelectForUpdate
     }
-    case object SupportsSharding extends DatabaseMetaDataOp[Boolean] {
-      def visit[F[_]](v: Visitor[F]) = v.supportsSharding
-    }
     case object SupportsStatementPooling extends DatabaseMetaDataOp[Boolean] {
       def visit[F[_]](v: Visitor[F]) = v.supportsStatementPooling
     }
@@ -1007,7 +1003,6 @@ object databasemetadata { module =>
   val supportsSchemasInProcedureCalls: DatabaseMetaDataIO[Boolean] = FF.liftF(SupportsSchemasInProcedureCalls)
   val supportsSchemasInTableDefinitions: DatabaseMetaDataIO[Boolean] = FF.liftF(SupportsSchemasInTableDefinitions)
   val supportsSelectForUpdate: DatabaseMetaDataIO[Boolean] = FF.liftF(SupportsSelectForUpdate)
-  val supportsSharding: DatabaseMetaDataIO[Boolean] = FF.liftF(SupportsSharding)
   val supportsStatementPooling: DatabaseMetaDataIO[Boolean] = FF.liftF(SupportsStatementPooling)
   val supportsStoredFunctionsUsingCallSyntax: DatabaseMetaDataIO[Boolean] = FF.liftF(SupportsStoredFunctionsUsingCallSyntax)
   val supportsStoredProcedures: DatabaseMetaDataIO[Boolean] = FF.liftF(SupportsStoredProcedures)

--- a/modules/free/src/main/scala/doobie/free/kleisliinterpreter.scala
+++ b/modules/free/src/main/scala/doobie/free/kleisliinterpreter.scala
@@ -45,7 +45,6 @@ import java.sql.SQLType
 import java.sql.SQLWarning
 import java.sql.SQLXML
 import java.sql.Savepoint
-import java.sql.ShardingKey
 import java.sql.Statement
 import java.sql.Struct
 import java.sql.Time
@@ -453,7 +452,6 @@ trait KleisliInterpreter[M[_]] { outer =>
     override def supportsSchemasInProcedureCalls = primitive(_.supportsSchemasInProcedureCalls)
     override def supportsSchemasInTableDefinitions = primitive(_.supportsSchemasInTableDefinitions)
     override def supportsSelectForUpdate = primitive(_.supportsSelectForUpdate)
-    override def supportsSharding = primitive(_.supportsSharding)
     override def supportsStatementPooling = primitive(_.supportsStatementPooling)
     override def supportsStoredFunctionsUsingCallSyntax = primitive(_.supportsStoredFunctionsUsingCallSyntax)
     override def supportsStoredProcedures = primitive(_.supportsStoredProcedures)
@@ -685,7 +683,6 @@ trait KleisliInterpreter[M[_]] { outer =>
 
     // domain-specific operations are implemented in terms of `primitive`
     override def abort(a: Executor) = primitive(_.abort(a))
-    override def beginRequest = primitive(_.beginRequest)
     override def clearWarnings = primitive(_.clearWarnings)
     override def close = primitive(_.close)
     override def commit = primitive(_.commit)
@@ -698,7 +695,6 @@ trait KleisliInterpreter[M[_]] { outer =>
     override def createStatement(a: Int, b: Int) = primitive(_.createStatement(a, b))
     override def createStatement(a: Int, b: Int, c: Int) = primitive(_.createStatement(a, b, c))
     override def createStruct(a: String, b: Array[AnyRef]) = primitive(_.createStruct(a, b))
-    override def endRequest = primitive(_.endRequest)
     override def getAutoCommit = primitive(_.getAutoCommit)
     override def getCatalog = primitive(_.getCatalog)
     override def getClientInfo = primitive(_.getClientInfo)
@@ -708,7 +704,7 @@ trait KleisliInterpreter[M[_]] { outer =>
     override def getNetworkTimeout = primitive(_.getNetworkTimeout)
     override def getSchema = primitive(_.getSchema)
     override def getTransactionIsolation = primitive(_.getTransactionIsolation)
-    override def getTypeMap: Kleisli[M,Connection,Map[String,Class[_]]] = primitive(_.getTypeMap)
+    override def getTypeMap = primitive(_.getTypeMap)
     override def getWarnings = primitive(_.getWarnings)
     override def isClosed = primitive(_.isClosed)
     override def isReadOnly = primitive(_.isReadOnly)
@@ -737,10 +733,6 @@ trait KleisliInterpreter[M[_]] { outer =>
     override def setSavepoint = primitive(_.setSavepoint)
     override def setSavepoint(a: String) = primitive(_.setSavepoint(a))
     override def setSchema(a: String) = primitive(_.setSchema(a))
-    override def setShardingKey(a: ShardingKey) = primitive(_.setShardingKey(a))
-    override def setShardingKey(a: ShardingKey, b: ShardingKey) = primitive(_.setShardingKey(a, b))
-    override def setShardingKeyIfValid(a: ShardingKey, b: Int) = primitive(_.setShardingKeyIfValid(a, b))
-    override def setShardingKeyIfValid(a: ShardingKey, b: ShardingKey, c: Int) = primitive(_.setShardingKeyIfValid(a, b, c))
     override def setTransactionIsolation(a: Int) = primitive(_.setTransactionIsolation(a))
     override def setTypeMap(a: Map[String, Class[_]]) = primitive(_.setTypeMap(a))
     override def unwrap[T](a: Class[T]) = primitive(_.unwrap(a))
@@ -774,9 +766,6 @@ trait KleisliInterpreter[M[_]] { outer =>
     override def clearWarnings = primitive(_.clearWarnings)
     override def close = primitive(_.close)
     override def closeOnCompletion = primitive(_.closeOnCompletion)
-    override def enquoteIdentifier(a: String, b: Boolean) = primitive(_.enquoteIdentifier(a, b))
-    override def enquoteLiteral(a: String) = primitive(_.enquoteLiteral(a))
-    override def enquoteNCharLiteral(a: String) = primitive(_.enquoteNCharLiteral(a))
     override def execute(a: String) = primitive(_.execute(a))
     override def execute(a: String, b: Array[Int]) = primitive(_.execute(a, b))
     override def execute(a: String, b: Array[String]) = primitive(_.execute(a, b))
@@ -812,7 +801,6 @@ trait KleisliInterpreter[M[_]] { outer =>
     override def isCloseOnCompletion = primitive(_.isCloseOnCompletion)
     override def isClosed = primitive(_.isClosed)
     override def isPoolable = primitive(_.isPoolable)
-    override def isSimpleIdentifier(a: String) = primitive(_.isSimpleIdentifier(a))
     override def isWrapperFor(a: Class[_]) = primitive(_.isWrapperFor(a))
     override def setCursorName(a: String) = primitive(_.setCursorName(a))
     override def setEscapeProcessing(a: Boolean) = primitive(_.setEscapeProcessing(a))
@@ -856,9 +844,6 @@ trait KleisliInterpreter[M[_]] { outer =>
     override def clearWarnings = primitive(_.clearWarnings)
     override def close = primitive(_.close)
     override def closeOnCompletion = primitive(_.closeOnCompletion)
-    override def enquoteIdentifier(a: String, b: Boolean) = primitive(_.enquoteIdentifier(a, b))
-    override def enquoteLiteral(a: String) = primitive(_.enquoteLiteral(a))
-    override def enquoteNCharLiteral(a: String) = primitive(_.enquoteNCharLiteral(a))
     override def execute = primitive(_.execute)
     override def execute(a: String) = primitive(_.execute(a))
     override def execute(a: String, b: Array[Int]) = primitive(_.execute(a, b))
@@ -900,7 +885,6 @@ trait KleisliInterpreter[M[_]] { outer =>
     override def isCloseOnCompletion = primitive(_.isCloseOnCompletion)
     override def isClosed = primitive(_.isClosed)
     override def isPoolable = primitive(_.isPoolable)
-    override def isSimpleIdentifier(a: String) = primitive(_.isSimpleIdentifier(a))
     override def isWrapperFor(a: Class[_]) = primitive(_.isWrapperFor(a))
     override def setArray(a: Int, b: SqlArray) = primitive(_.setArray(a, b))
     override def setAsciiStream(a: Int, b: InputStream) = primitive(_.setAsciiStream(a, b))
@@ -993,9 +977,6 @@ trait KleisliInterpreter[M[_]] { outer =>
     override def clearWarnings = primitive(_.clearWarnings)
     override def close = primitive(_.close)
     override def closeOnCompletion = primitive(_.closeOnCompletion)
-    override def enquoteIdentifier(a: String, b: Boolean) = primitive(_.enquoteIdentifier(a, b))
-    override def enquoteLiteral(a: String) = primitive(_.enquoteLiteral(a))
-    override def enquoteNCharLiteral(a: String) = primitive(_.enquoteNCharLiteral(a))
     override def execute = primitive(_.execute)
     override def execute(a: String) = primitive(_.execute(a))
     override def execute(a: String, b: Array[Int]) = primitive(_.execute(a, b))
@@ -1097,7 +1078,6 @@ trait KleisliInterpreter[M[_]] { outer =>
     override def isCloseOnCompletion = primitive(_.isCloseOnCompletion)
     override def isClosed = primitive(_.isClosed)
     override def isPoolable = primitive(_.isPoolable)
-    override def isSimpleIdentifier(a: String) = primitive(_.isSimpleIdentifier(a))
     override def isWrapperFor(a: Class[_]) = primitive(_.isWrapperFor(a))
     override def registerOutParameter(a: Int, b: Int) = primitive(_.registerOutParameter(a, b))
     override def registerOutParameter(a: Int, b: Int, c: Int) = primitive(_.registerOutParameter(a, b, c))

--- a/modules/free/src/main/scala/doobie/free/preparedstatement.scala
+++ b/modules/free/src/main/scala/doobie/free/preparedstatement.scala
@@ -85,9 +85,6 @@ object preparedstatement { module =>
       def clearWarnings: F[Unit]
       def close: F[Unit]
       def closeOnCompletion: F[Unit]
-      def enquoteIdentifier(a: String, b: Boolean): F[String]
-      def enquoteLiteral(a: String): F[String]
-      def enquoteNCharLiteral(a: String): F[String]
       def execute: F[Boolean]
       def execute(a: String): F[Boolean]
       def execute(a: String, b: Array[Int]): F[Boolean]
@@ -129,7 +126,6 @@ object preparedstatement { module =>
       def isCloseOnCompletion: F[Boolean]
       def isClosed: F[Boolean]
       def isPoolable: F[Boolean]
-      def isSimpleIdentifier(a: String): F[Boolean]
       def isWrapperFor(a: Class[_]): F[Boolean]
       def setArray(a: Int, b: SqlArray): F[Unit]
       def setAsciiStream(a: Int, b: InputStream): F[Unit]
@@ -259,15 +255,6 @@ object preparedstatement { module =>
     case object CloseOnCompletion extends PreparedStatementOp[Unit] {
       def visit[F[_]](v: Visitor[F]) = v.closeOnCompletion
     }
-    final case class EnquoteIdentifier(a: String, b: Boolean) extends PreparedStatementOp[String] {
-      def visit[F[_]](v: Visitor[F]) = v.enquoteIdentifier(a, b)
-    }
-    final case class EnquoteLiteral(a: String) extends PreparedStatementOp[String] {
-      def visit[F[_]](v: Visitor[F]) = v.enquoteLiteral(a)
-    }
-    final case class EnquoteNCharLiteral(a: String) extends PreparedStatementOp[String] {
-      def visit[F[_]](v: Visitor[F]) = v.enquoteNCharLiteral(a)
-    }
     case object Execute extends PreparedStatementOp[Boolean] {
       def visit[F[_]](v: Visitor[F]) = v.execute
     }
@@ -390,9 +377,6 @@ object preparedstatement { module =>
     }
     case object IsPoolable extends PreparedStatementOp[Boolean] {
       def visit[F[_]](v: Visitor[F]) = v.isPoolable
-    }
-    final case class IsSimpleIdentifier(a: String) extends PreparedStatementOp[Boolean] {
-      def visit[F[_]](v: Visitor[F]) = v.isSimpleIdentifier(a)
     }
     final case class IsWrapperFor(a: Class[_]) extends PreparedStatementOp[Boolean] {
       def visit[F[_]](v: Visitor[F]) = v.isWrapperFor(a)
@@ -607,9 +591,6 @@ object preparedstatement { module =>
   val clearWarnings: PreparedStatementIO[Unit] = FF.liftF(ClearWarnings)
   val close: PreparedStatementIO[Unit] = FF.liftF(Close)
   val closeOnCompletion: PreparedStatementIO[Unit] = FF.liftF(CloseOnCompletion)
-  def enquoteIdentifier(a: String, b: Boolean): PreparedStatementIO[String] = FF.liftF(EnquoteIdentifier(a, b))
-  def enquoteLiteral(a: String): PreparedStatementIO[String] = FF.liftF(EnquoteLiteral(a))
-  def enquoteNCharLiteral(a: String): PreparedStatementIO[String] = FF.liftF(EnquoteNCharLiteral(a))
   val execute: PreparedStatementIO[Boolean] = FF.liftF(Execute)
   def execute(a: String): PreparedStatementIO[Boolean] = FF.liftF(Execute1(a))
   def execute(a: String, b: Array[Int]): PreparedStatementIO[Boolean] = FF.liftF(Execute2(a, b))
@@ -651,7 +632,6 @@ object preparedstatement { module =>
   val isCloseOnCompletion: PreparedStatementIO[Boolean] = FF.liftF(IsCloseOnCompletion)
   val isClosed: PreparedStatementIO[Boolean] = FF.liftF(IsClosed)
   val isPoolable: PreparedStatementIO[Boolean] = FF.liftF(IsPoolable)
-  def isSimpleIdentifier(a: String): PreparedStatementIO[Boolean] = FF.liftF(IsSimpleIdentifier(a))
   def isWrapperFor(a: Class[_]): PreparedStatementIO[Boolean] = FF.liftF(IsWrapperFor(a))
   def setArray(a: Int, b: SqlArray): PreparedStatementIO[Unit] = FF.liftF(SetArray(a, b))
   def setAsciiStream(a: Int, b: InputStream): PreparedStatementIO[Unit] = FF.liftF(SetAsciiStream(a, b))

--- a/modules/free/src/main/scala/doobie/free/statement.scala
+++ b/modules/free/src/main/scala/doobie/free/statement.scala
@@ -65,9 +65,6 @@ object statement { module =>
       def clearWarnings: F[Unit]
       def close: F[Unit]
       def closeOnCompletion: F[Unit]
-      def enquoteIdentifier(a: String, b: Boolean): F[String]
-      def enquoteLiteral(a: String): F[String]
-      def enquoteNCharLiteral(a: String): F[String]
       def execute(a: String): F[Boolean]
       def execute(a: String, b: Array[Int]): F[Boolean]
       def execute(a: String, b: Array[String]): F[Boolean]
@@ -103,7 +100,6 @@ object statement { module =>
       def isCloseOnCompletion: F[Boolean]
       def isClosed: F[Boolean]
       def isPoolable: F[Boolean]
-      def isSimpleIdentifier(a: String): F[Boolean]
       def isWrapperFor(a: Class[_]): F[Boolean]
       def setCursorName(a: String): F[Unit]
       def setEscapeProcessing(a: Boolean): F[Unit]
@@ -177,15 +173,6 @@ object statement { module =>
     }
     case object CloseOnCompletion extends StatementOp[Unit] {
       def visit[F[_]](v: Visitor[F]) = v.closeOnCompletion
-    }
-    final case class EnquoteIdentifier(a: String, b: Boolean) extends StatementOp[String] {
-      def visit[F[_]](v: Visitor[F]) = v.enquoteIdentifier(a, b)
-    }
-    final case class EnquoteLiteral(a: String) extends StatementOp[String] {
-      def visit[F[_]](v: Visitor[F]) = v.enquoteLiteral(a)
-    }
-    final case class EnquoteNCharLiteral(a: String) extends StatementOp[String] {
-      def visit[F[_]](v: Visitor[F]) = v.enquoteNCharLiteral(a)
     }
     final case class Execute(a: String) extends StatementOp[Boolean] {
       def visit[F[_]](v: Visitor[F]) = v.execute(a)
@@ -292,9 +279,6 @@ object statement { module =>
     case object IsPoolable extends StatementOp[Boolean] {
       def visit[F[_]](v: Visitor[F]) = v.isPoolable
     }
-    final case class IsSimpleIdentifier(a: String) extends StatementOp[Boolean] {
-      def visit[F[_]](v: Visitor[F]) = v.isSimpleIdentifier(a)
-    }
     final case class IsWrapperFor(a: Class[_]) extends StatementOp[Boolean] {
       def visit[F[_]](v: Visitor[F]) = v.isWrapperFor(a)
     }
@@ -359,9 +343,6 @@ object statement { module =>
   val clearWarnings: StatementIO[Unit] = FF.liftF(ClearWarnings)
   val close: StatementIO[Unit] = FF.liftF(Close)
   val closeOnCompletion: StatementIO[Unit] = FF.liftF(CloseOnCompletion)
-  def enquoteIdentifier(a: String, b: Boolean): StatementIO[String] = FF.liftF(EnquoteIdentifier(a, b))
-  def enquoteLiteral(a: String): StatementIO[String] = FF.liftF(EnquoteLiteral(a))
-  def enquoteNCharLiteral(a: String): StatementIO[String] = FF.liftF(EnquoteNCharLiteral(a))
   def execute(a: String): StatementIO[Boolean] = FF.liftF(Execute(a))
   def execute(a: String, b: Array[Int]): StatementIO[Boolean] = FF.liftF(Execute1(a, b))
   def execute(a: String, b: Array[String]): StatementIO[Boolean] = FF.liftF(Execute2(a, b))
@@ -397,7 +378,6 @@ object statement { module =>
   val isCloseOnCompletion: StatementIO[Boolean] = FF.liftF(IsCloseOnCompletion)
   val isClosed: StatementIO[Boolean] = FF.liftF(IsClosed)
   val isPoolable: StatementIO[Boolean] = FF.liftF(IsPoolable)
-  def isSimpleIdentifier(a: String): StatementIO[Boolean] = FF.liftF(IsSimpleIdentifier(a))
   def isWrapperFor(a: Class[_]): StatementIO[Boolean] = FF.liftF(IsWrapperFor(a))
   def setCursorName(a: String): StatementIO[Unit] = FF.liftF(SetCursorName(a))
   def setEscapeProcessing(a: Boolean): StatementIO[Unit] = FF.liftF(SetEscapeProcessing(a))

--- a/modules/postgres/src/main/scala/doobie/postgres/free/kleisliinterpreter.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/free/kleisliinterpreter.scala
@@ -18,13 +18,21 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.io.Reader
 import java.io.Writer
+import java.lang.Class
+import java.lang.String
+import java.sql.{ Array => SqlArray }
+import java.util.Map
 import org.postgresql.PGConnection
+import org.postgresql.PGNotification
+import org.postgresql.copy.{ CopyDual => PGCopyDual }
 import org.postgresql.copy.{ CopyIn => PGCopyIn }
 import org.postgresql.copy.{ CopyManager => PGCopyManager }
 import org.postgresql.copy.{ CopyOut => PGCopyOut }
 import org.postgresql.jdbc.AutoSave
+import org.postgresql.jdbc.PreferQueryMode
 import org.postgresql.largeobject.LargeObject
 import org.postgresql.largeobject.LargeObjectManager
+import org.postgresql.replication.PGReplicationConnection
 import org.postgresql.util.ByteStreamWriter
 
 // Algebras and free monads thereof referenced by our interpreter.
@@ -310,6 +318,7 @@ trait KleisliInterpreter[M[_]] { outer =>
     override def createArrayOf(a: String, b: AnyRef) = primitive(_.createArrayOf(a, b))
     override def escapeIdentifier(a: String) = primitive(_.escapeIdentifier(a))
     override def escapeLiteral(a: String) = primitive(_.escapeLiteral(a))
+    override def getAdaptiveFetch = primitive(_.getAdaptiveFetch)
     override def getAutosave = primitive(_.getAutosave)
     override def getBackendPID = primitive(_.getBackendPID)
     override def getCopyAPI = primitive(_.getCopyAPI)
@@ -322,6 +331,7 @@ trait KleisliInterpreter[M[_]] { outer =>
     override def getPreferQueryMode = primitive(_.getPreferQueryMode)
     override def getPrepareThreshold = primitive(_.getPrepareThreshold)
     override def getReplicationAPI = primitive(_.getReplicationAPI)
+    override def setAdaptiveFetch(a: Boolean) = primitive(_.setAdaptiveFetch(a))
     override def setAutosave(a: AutoSave) = primitive(_.setAutosave(a))
     override def setDefaultFetchSize(a: Int) = primitive(_.setDefaultFetchSize(a))
     override def setPrepareThreshold(a: Int) = primitive(_.setPrepareThreshold(a))

--- a/modules/postgres/src/main/scala/doobie/postgres/free/pgconnection.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/free/pgconnection.scala
@@ -69,6 +69,7 @@ object pgconnection { module =>
       def createArrayOf(a: String, b: AnyRef): F[SqlArray]
       def escapeIdentifier(a: String): F[String]
       def escapeLiteral(a: String): F[String]
+      def getAdaptiveFetch: F[Boolean]
       def getAutosave: F[AutoSave]
       def getBackendPID: F[Int]
       def getCopyAPI: F[PGCopyManager]
@@ -81,6 +82,7 @@ object pgconnection { module =>
       def getPreferQueryMode: F[PreferQueryMode]
       def getPrepareThreshold: F[Int]
       def getReplicationAPI: F[PGReplicationConnection]
+      def setAdaptiveFetch(a: Boolean): F[Unit]
       def setAutosave(a: AutoSave): F[Unit]
       def setDefaultFetchSize(a: Int): F[Unit]
       def setPrepareThreshold(a: Int): F[Unit]
@@ -144,6 +146,9 @@ object pgconnection { module =>
     final case class EscapeLiteral(a: String) extends PGConnectionOp[String] {
       def visit[F[_]](v: Visitor[F]) = v.escapeLiteral(a)
     }
+    case object GetAdaptiveFetch extends PGConnectionOp[Boolean] {
+      def visit[F[_]](v: Visitor[F]) = v.getAdaptiveFetch
+    }
     case object GetAutosave extends PGConnectionOp[AutoSave] {
       def visit[F[_]](v: Visitor[F]) = v.getAutosave
     }
@@ -179,6 +184,9 @@ object pgconnection { module =>
     }
     case object GetReplicationAPI extends PGConnectionOp[PGReplicationConnection] {
       def visit[F[_]](v: Visitor[F]) = v.getReplicationAPI
+    }
+    final case class SetAdaptiveFetch(a: Boolean) extends PGConnectionOp[Unit] {
+      def visit[F[_]](v: Visitor[F]) = v.setAdaptiveFetch(a)
     }
     final case class SetAutosave(a: AutoSave) extends PGConnectionOp[Unit] {
       def visit[F[_]](v: Visitor[F]) = v.setAutosave(a)
@@ -219,6 +227,7 @@ object pgconnection { module =>
   def createArrayOf(a: String, b: AnyRef): PGConnectionIO[SqlArray] = FF.liftF(CreateArrayOf(a, b))
   def escapeIdentifier(a: String): PGConnectionIO[String] = FF.liftF(EscapeIdentifier(a))
   def escapeLiteral(a: String): PGConnectionIO[String] = FF.liftF(EscapeLiteral(a))
+  val getAdaptiveFetch: PGConnectionIO[Boolean] = FF.liftF(GetAdaptiveFetch)
   val getAutosave: PGConnectionIO[AutoSave] = FF.liftF(GetAutosave)
   val getBackendPID: PGConnectionIO[Int] = FF.liftF(GetBackendPID)
   val getCopyAPI: PGConnectionIO[PGCopyManager] = FF.liftF(GetCopyAPI)
@@ -231,6 +240,7 @@ object pgconnection { module =>
   val getPreferQueryMode: PGConnectionIO[PreferQueryMode] = FF.liftF(GetPreferQueryMode)
   val getPrepareThreshold: PGConnectionIO[Int] = FF.liftF(GetPrepareThreshold)
   val getReplicationAPI: PGConnectionIO[PGReplicationConnection] = FF.liftF(GetReplicationAPI)
+  def setAdaptiveFetch(a: Boolean): PGConnectionIO[Unit] = FF.liftF(SetAdaptiveFetch(a))
   def setAutosave(a: AutoSave): PGConnectionIO[Unit] = FF.liftF(SetAutosave(a))
   def setDefaultFetchSize(a: Int): PGConnectionIO[Unit] = FF.liftF(SetDefaultFetchSize(a))
   def setPrepareThreshold(a: Int): PGConnectionIO[Unit] = FF.liftF(SetPrepareThreshold(a))

--- a/modules/postgres/src/test/scala/doobie/postgres/CheckSuite.scala
+++ b/modules/postgres/src/test/scala/doobie/postgres/CheckSuite.scala
@@ -11,8 +11,6 @@ import doobie.postgres.implicits._
 import doobie.util.analysis.{ColumnTypeWarning, ColumnTypeError}
 
 import java.time.{Instant, OffsetDateTime, LocalDate, LocalDateTime, LocalTime}
-import scala.concurrent.ExecutionContext
-
 
 class CheckSuite extends munit.FunSuite {
 
@@ -30,7 +28,7 @@ class CheckSuite extends munit.FunSuite {
   }
 
   test("OffsetDateTime Read and Write typechecks") {
-    val t = OffsetDateTime.parse("2019-02-13T22:03:21.000+08")
+    val t = OffsetDateTime.parse("2019-02-13T22:03:21.000+08:00")
     successRead[OffsetDateTime](sql"SELECT '2019-02-13T22:03:21.000' :: TIMESTAMPTZ")
     successWrite[OffsetDateTime](t, "TIMESTAMPTZ")
 


### PR DESCRIPTION
Somehow [this commit](https://github.com/tpolecat/doobie/commit/3231e7928e7eee5a4a91b32d7bdc2836381d1f0e) got dropped and we ended up with JDK9+ JDBC stuff in here. This removes it and pushes the CI version back to 8.