### PR TITLE
define pgisgeographyinstances for geography postgis types

### DIFF
--- a/modules/docs/src/main/mdoc/docs/15-Extensions-PostgreSQL.md
+++ b/modules/docs/src/main/mdoc/docs/15-Extensions-PostgreSQL.md
@@ -213,6 +213,25 @@ In addition to the general types above, **doobie** provides mappings for the fol
 - `Polygon`
 - `Point`
 
+[Geographic types](http://postgis.net/workshops/postgis-intro/geography.html) mappings are defined in a different object (`pgisgeographyimplicits`), to allow geometric types using geodetic coordinates.
+
+```
+import doobie.postgres.pgisgeographyimplicits._
+
+// or define the implicit conversion manually
+
+implicit val geographyPoint: Meta[Point] =
+  doobie.postgres.pgisgeographyimplicits.PointType
+```
+- Point
+- Polygon
+- MultiPoint
+- LineString
+- PointComposedGeom
+- MultiPolygon
+- MultiLineString
+
+
 ### Other Nonstandard Types
 
 - The `uuid` schema type is supported and maps to `java.util.UUID`.

--- a/modules/postgres/src/main/scala/doobie/postgres/package.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/package.scala
@@ -20,4 +20,6 @@ package object postgres
   object pgisimplicits
     extends PgisInstances
 
+  object pgisgeographyimplicits
+    extends PgisGeographyInstances
 }

--- a/modules/postgres/src/main/scala/doobie/postgres/pgisgeographyinstances.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/pgisgeographyinstances.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2013-2020 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.postgres
+
+import doobie._
+import doobie.util.invariant._
+
+import org.postgis._
+
+import scala.reflect.ClassTag
+import org.tpolecat.typename._
+
+// Implicit conversions for postgis geography types
+trait PgisGeographyInstances {
+
+  // PostGIS outer types
+  implicit val PGgeographyType: Meta[PGgeography] = Meta.Advanced.other[PGgeography]("geography")
+
+  // Constructor for geometry types via the `Geometry` member of PGgeography
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf", "org.wartremover.warts.Throw"))
+  private def geometryType[A >: Null <: Geometry: TypeName](implicit A: ClassTag[A]): Meta[A] =
+    PGgeographyType.timap[A](g =>
+      try A.runtimeClass.cast(g.getGeometry).asInstanceOf[A]
+      catch {
+        case _: ClassCastException => throw InvalidObjectMapping(A.runtimeClass, g.getGeometry.getClass)
+      })(new PGgeography(_))
+
+  // PostGIS Geometry Types
+  implicit val MultiLineStringType: Meta[MultiLineString]       = geometryType[MultiLineString]
+  implicit val MultiPolygonType: Meta[MultiPolygon]             = geometryType[MultiPolygon]
+  implicit val PointComposedGeomType: Meta[PointComposedGeom]   = geometryType[PointComposedGeom]
+  implicit val LineStringType: Meta[LineString]                 = geometryType[LineString]
+  implicit val MultiPointType: Meta[MultiPoint]                 = geometryType[MultiPoint]
+  implicit val PolygonType: Meta[Polygon]                       = geometryType[Polygon]
+  implicit val PointType: Meta[Point]                           = geometryType[Point]
+}

--- a/modules/postgres/src/test/scala/doobie/postgres/TypesSuite.scala
+++ b/modules/postgres/src/test/scala/doobie/postgres/TypesSuite.scala
@@ -205,6 +205,26 @@ class TypesSuite extends munit.ScalaCheckSuite {
   testInOut("polygon", new PGpolygon(Array(new PGpoint(1, 2), new PGpoint(3, 4))))
   skip("line", "doc says \"not fully implemented\"")
 
+  // test postgis geography mappings
+  {
+    def createPoint(lat: Double, lon: Double): Point = {
+      val p = new Point(lon, lat)
+      p.setSrid(4326)
+
+      p
+    }
+
+    import doobie.postgres.pgisgeographyimplicits._
+    val point1 = createPoint(1, 2)
+    val point2 = createPoint(1, 3)
+    val lineString = new LineString(Array[Point](point1, point2))
+    lineString.setSrid(4326)
+
+    // test geography points
+    testInOut("GEOGRAPHY(POINT)", point1)
+    testInOut("GEOGRAPHY(LINESTRING)", lineString)
+  }
+
   // 8.9 Network Address Types
   testInOut("inet", InetAddress.getByName("123.45.67.8"))
   skip("inet", "no suitable JDK type")


### PR DESCRIPTION
See #1264.

Previous reverted PR #1625 overrides default postgis PointType implicit conversion by mistake.
 
This PR adds both pgisgeographyimplicits conversions to use geomtries backed by geodetic coordinataes (postgis geography).

Here is an example that would be valid with this change:

  /// CREATE TABLE countries(name TEXT PRIMARY KEY, location GEOGRAPHY(POINT, 4326));
  case class Country(code: String, location: Option[Point])

  def findCountry(n: String): ConnectionIO[Option[Country]] =
    sql"select name, location from countries where name = $n".query[Country].option