### PR TITLE
Add Monoid and Semigroup instances for ConnectionIO

### DIFF
--- a/modules/core/src/main/scala/doobie/free/Aliases.scala
+++ b/modules/core/src/main/scala/doobie/free/Aliases.scala
@@ -4,6 +4,7 @@
 
 package doobie.free
 
+import cats.{Monoid, Semigroup}
 import doobie.WeakAsync
 
 trait Types {
@@ -53,6 +54,12 @@ trait Instances  {
 
   /** @group Typeclass Instances */  implicit lazy val WeakAsyncConnectionIO: WeakAsync[ConnectionIO] =
     connection.WeakAsyncConnectionIO
+
+  /** @group Typeclass Instances */  implicit def MonoidConnectionIO[A: Monoid]: Monoid[ConnectionIO[A]] =
+    connection.MonoidConnectionIO[A]
+
+  /** @group Typeclass Instances */  implicit def SemigroupConnectionIO[A: Semigroup]: Semigroup[ConnectionIO[A]] =
+    connection.SemigroupConnectionIO[A]
 
   /** @group Typeclass Instances */  implicit lazy val WeakAsyncDatabaseMetaDataIO: WeakAsync[DatabaseMetaDataIO] =
     databasemetadata.WeakAsyncDatabaseMetaDataIO

--- a/modules/core/src/test/scala/doobie/util/ConnectionIOSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/ConnectionIOSuite.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2013-2020 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.util
+
+import cats.Applicative
+import cats.implicits._
+import cats.effect.IO
+import cats.kernel.Monoid
+import doobie._
+import doobie.implicits._
+
+class ConnectionIOSuite extends munit.FunSuite {
+
+  import cats.effect.unsafe.implicits.global
+
+  val xa = Transactor.fromDriverManager[IO](
+    "org.h2.Driver",
+    "jdbc:h2:mem:queryspec;DB_CLOSE_DELAY=-1",
+    "sa", ""
+  )
+
+  test("Semigroup ConnectionIO") {
+    val prg = Applicative[ConnectionIO].pure(List(1, 2, 3)) combine Applicative[ConnectionIO].pure(List(4, 5, 6))
+    assertEquals(prg.transact(xa).unsafeRunSync(), List(1,2,3,4,5,6))
+  }
+
+  test("Monoid ConnectionIO") {
+    assertEquals(Monoid[ConnectionIO[List[Int]]].empty.transact(xa).unsafeRunSync(), Nil)
+  }
+
+}

--- a/modules/free/src/main/scala/doobie/free/connection.scala
+++ b/modules/free/src/main/scala/doobie/free/connection.scala
@@ -4,13 +4,13 @@
 
 package doobie.free
 
-import cats.~>
-import cats.effect.kernel.{ CancelScope, Poll, Sync }
-import cats.free.{ Free => FF } // alias because some algebras have an op called Free
+import cats.{Applicative, Monoid, Semigroup, ~>}
+import cats.effect.kernel.{CancelScope, Poll, Sync}
+import cats.free.{Free => FF}
 import doobie.WeakAsync
+
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
-
 import java.lang.Class
 import java.lang.String
 import java.sql.Blob
@@ -25,7 +25,7 @@ import java.sql.SQLXML
 import java.sql.Savepoint
 import java.sql.Statement
 import java.sql.Struct
-import java.sql.{ Array => SqlArray }
+import java.sql.{Array => SqlArray}
 import java.util.Map
 import java.util.Properties
 import java.util.concurrent.Executor
@@ -432,5 +432,16 @@ object connection { module =>
       override def onCancel[A](fa: ConnectionIO[A], fin: ConnectionIO[Unit]): ConnectionIO[A] = module.onCancel(fa, fin)
       override def fromFuture[A](fut: ConnectionIO[Future[A]]): ConnectionIO[A] = module.fromFuture(fut)
     }
+
+  implicit def MonoidConnectionIO[A : Monoid]: Monoid[ConnectionIO[A]] = new Monoid[ConnectionIO[A]] {
+    override def empty: ConnectionIO[A] = Applicative[ConnectionIO].pure(Monoid[A].empty)
+    override def combine(x: ConnectionIO[A], y: ConnectionIO[A]): ConnectionIO[A] =
+      Applicative[ConnectionIO].product(x, y).map { case (x, y) => Monoid[A].combine(x, y) }
+  }
+
+  implicit def SemigroupConnectionIO[A : Semigroup]: Semigroup[ConnectionIO[A]] = new Semigroup[ConnectionIO[A]] {
+    override def combine(x: ConnectionIO[A], y: ConnectionIO[A]): ConnectionIO[A] =
+      Applicative[ConnectionIO].product(x, y).map { case (x, y) => Semigroup[A].combine(x, y) }
+  }
 }
 


### PR DESCRIPTION
Using this quite a lot to combine affected rows, but also upon retrieval of stuff to combine sets together.

I've found there is a generic way to express this:

```scala
implicit final def semigroupF[A](implicit A: Semigroup[A], F: Apply[F]): Semigroup[F[A]] =
    Apply.semigroup[F, A]
```

It's however not standard in cats, and I think it would fit here well?

Any suggestions welcome!