### PR TITLE
Add Meta[A].tiemap

### DIFF
--- a/modules/core/src/main/scala/doobie/util/meta/meta.scala
+++ b/modules/core/src/main/scala/doobie/util/meta/meta.scala
@@ -5,8 +5,7 @@
 package doobie.util.meta
 
 import java.sql.{PreparedStatement, ResultSet}
-
-import cats.Invariant
+import cats.{Invariant, Show}
 import cats.data.NonEmptyList
 import doobie.enumerated.JdbcType
 import doobie.util.{Get, Put}
@@ -29,6 +28,10 @@ final class Meta[A](val get: Get[A], val put: Put[A]) {
   /** Variant of `imap` that takes a type tag, to aid in diagnostics. */
   def timap[B: TypeName](f: A => B)(g: B => A): Meta[B] =
     new Meta(get.tmap(f), put.tcontramap(g))
+
+  /** Variant of `timap` that allows the reading conversion to fail. */
+  def tiemap[B: TypeName](f: A => Either[String, B])(g: B => A)(implicit showA: Show[A]): Meta[B] =
+    new Meta(get.temap(f), put.contramap(g))
 
 }
 

--- a/modules/core/src/test/scala/doobie/util/meta/MetaSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/meta/MetaSuite.scala
@@ -4,8 +4,11 @@
 
 package doobie.util.meta
 
+import cats.effect.IO
+import doobie._, doobie.implicits._
 import doobie.util.{Get, Put}
 
+case class Foo(str: String)
 
 class MetaSuite extends munit.FunSuite {
 
@@ -20,6 +23,30 @@ class MetaSuite extends munit.FunSuite {
 
   test("Meta should imply Put") {
     def foo[A: Meta] = Put[A]
+  }
+
+}
+
+class MetaDBSuite extends munit.FunSuite {
+
+  import cats.effect.unsafe.implicits.global
+
+  lazy val xa = Transactor.fromDriverManager[IO](
+    "org.h2.Driver",
+    "jdbc:h2:mem:queryspec;DB_CLOSE_DELAY=-1",
+    "sa", ""
+  )
+
+  implicit def FooMeta: Meta[Foo] = Meta[String].tiemap(s => Either.cond(!s.isEmpty, Foo(s), "may not be empty"))(_.str)
+
+  test("Meta.tiemap should accept valid values") {
+    val x = sql"select 'bar'".query[Foo].unique.transact(xa).unsafeRunSync()
+    assertEquals(x, Foo("bar"))
+  }
+
+  test("Meta.tiemap should reject invalid values") {
+    val x = sql"select ''".query[Foo].unique.transact(xa).attempt.unsafeRunSync()
+    assertEquals(x, Left(doobie.util.invariant.InvalidValue[String, Foo]("", "may not be empty")))
   }
 
 }


### PR DESCRIPTION
Allows to construct Meta instances more easily for types whose parsing can fail.