### PR TITLE
Add functions for creating HikariTransactor that automatically create connectEC

### DIFF
--- a/modules/hikari/src/main/scala/doobie/hikari/Config.scala
+++ b/modules/hikari/src/main/scala/doobie/hikari/Config.scala
@@ -19,7 +19,7 @@ import scala.concurrent.duration.Duration
 /** Configuration case class, susceptible to PureConfig.
   * Helps with creating `com.zaxxer.hikari.HikariConfig`,
   * which in turn is used to create `doobie.hikari.HikariTransactor`.
-  * See the method `HikariTransactor.fromConfig` */
+  * See the method `HikariTransactor.fromConfigAutoEc` */
 final case class Config(
   catalog: Option[String] = None,
   connectionTimeout: Duration = Duration(30, TimeUnit.SECONDS),

--- a/modules/hikari/src/main/scala/doobie/hikari/Config.scala
+++ b/modules/hikari/src/main/scala/doobie/hikari/Config.scala
@@ -99,6 +99,7 @@ object Config {
       scheduledExecutor.foreach(c.setScheduledExecutor)
       threadFactory.foreach(c.setThreadFactory)
 
+      c.validate()
       c
     }
 

--- a/modules/hikari/src/main/scala/doobie/hikari/Config.scala
+++ b/modules/hikari/src/main/scala/doobie/hikari/Config.scala
@@ -25,9 +25,9 @@ final case class Config(
   connectionTimeout: Duration = Duration(30, TimeUnit.SECONDS),
   idleTimeout: Duration = Duration(10, TimeUnit.MINUTES),
   leakDetectionThreshold: Duration = Duration.Zero,
-  maximumPoolSize: Option[Int] = None,
+  maximumPoolSize: Option[Int] = Some(10),
   maxLifetime: Duration = Duration(30, TimeUnit.MINUTES),
-  minimumIdle: Option[Int] = None,
+  minimumIdle: Option[Int] = Some(10),
   password: Option[String] = None,
   poolName: Option[String] = None,
   username: Option[String] = None,
@@ -99,7 +99,6 @@ object Config {
       scheduledExecutor.foreach(c.setScheduledExecutor)
       threadFactory.foreach(c.setThreadFactory)
 
-      c.validate()
       c
     }
 

--- a/modules/hikari/src/main/scala/doobie/hikari/HikariTransactor.scala
+++ b/modules/hikari/src/main/scala/doobie/hikari/HikariTransactor.scala
@@ -8,6 +8,7 @@ package hikari
 import java.util.Properties
 import java.util.concurrent.{ScheduledExecutorService, ThreadFactory}
 
+import cats.effect.implicits._
 import cats.effect.kernel.{ Async, Resource, Sync }
 import com.zaxxer.hikari.metrics.MetricsTrackerFactory
 import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
@@ -118,6 +119,7 @@ object HikariTransactor {
    */
   def fromHikariConfig[M[_]: Async](hikariConfig: HikariConfig): Resource[M, HikariTransactor[M]] =
   for {
+    _ <- Sync[M].delay(hikariConfig.validate()).toResource // to populate unset fields with default values, like `maximumPoolSize`
     // Also note that the number of JDBC connections is usually limited by the underlying JDBC pool. You may therefore want to limit your connection pool to the same size as the underlying JDBC pool as any additional threads are guaranteed to be blocked.
     // https://tpolecat.github.io/doobie/docs/14-Managing-Connections.html#about-threading
     connectEC <- ExecutionContexts.fixedThreadPool(hikariConfig.getMaximumPoolSize)

--- a/modules/hikari/src/main/scala/doobie/hikari/HikariTransactor.scala
+++ b/modules/hikari/src/main/scala/doobie/hikari/HikariTransactor.scala
@@ -39,7 +39,9 @@ object HikariTransactor {
       .map(Transactor.fromDataSource[M](_, connectEC))
   }
 
-  /** Resource yielding a new `HikariTransactor` configured with the given Config. */
+  /** Resource yielding a new `HikariTransactor` configured with the given Config.
+   * Unless you have a good reason, consider using `fromConfigAutoEc` which creates the `connectEC` for you.
+   */
   def fromConfig[M[_]: Async](
     config: Config,
     connectEC: ExecutionContext,
@@ -66,12 +68,43 @@ object HikariTransactor {
           threadFactory
         )
       )
-      .flatMap { hikariConfig =>
-        fromHikariConfig(hikariConfig, connectEC)
-      }
+      .flatMap(fromHikariConfig(_, connectEC))
   }
 
-  /** Resource yielding a new `HikariTransactor` configured with the given HikariConfig. */
+  /** Resource yielding a new `HikariTransactor` configured with the given Config.
+   * The `connectEC` is created automatically, with the same size as the Hikari pool.
+   */
+  def fromConfigAutoEc[M[_]: Async](
+      config: Config,
+      dataSource: Option[DataSource] = None,
+      dataSourceProperties: Option[Properties] = None,
+      healthCheckProperties: Option[Properties] = None,
+      healthCheckRegistry: Option[Object] = None,
+      metricRegistry: Option[Object] = None,
+      metricsTrackerFactory: Option[MetricsTrackerFactory] = None,
+      scheduledExecutor: Option[ScheduledExecutorService] = None,
+      threadFactory: Option[ThreadFactory] = None,
+    ): Resource[M, HikariTransactor[M]] = {
+    Resource
+      .liftK(
+        Config.makeHikariConfig(
+          config,
+          dataSource,
+          dataSourceProperties,
+          healthCheckProperties,
+          healthCheckRegistry,
+          metricRegistry,
+          metricsTrackerFactory,
+          scheduledExecutor,
+          threadFactory
+        )
+      )
+      .flatMap(fromHikariConfig(_))
+  }
+
+  /** Resource yielding a new `HikariTransactor` configured with the given HikariConfig.
+   * Unless you have a good reason, consider using the overload without explicit `connectEC`, it will be created automatically for you.
+   */
   def fromHikariConfig[M[_]: Async](
     hikariConfig: HikariConfig,
     connectEC: ExecutionContext
@@ -79,6 +112,18 @@ object HikariTransactor {
     createDataSourceResource(new HikariDataSource(hikariConfig))
       .map(Transactor.fromDataSource[M](_, connectEC))
   }
+
+  /** Resource yielding a new `HikariTransactor` configured with the given HikariConfig.
+   * The `connectEC` is created automatically, with the same size as the Hikari pool.
+   */
+  def fromHikariConfig[M[_]: Async](hikariConfig: HikariConfig): Resource[M, HikariTransactor[M]] =
+  for {
+    // Also note that the number of JDBC connections is usually limited by the underlying JDBC pool. You may therefore want to limit your connection pool to the same size as the underlying JDBC pool as any additional threads are guaranteed to be blocked.
+    // https://tpolecat.github.io/doobie/docs/14-Managing-Connections.html#about-threading
+    connectEC <- ExecutionContexts.fixedThreadPool(hikariConfig.getMaximumPoolSize)
+    result <- createDataSourceResource(new HikariDataSource(hikariConfig))
+      .map(Transactor.fromDataSource[M](_, connectEC))
+  } yield result
 
   /** Resource yielding a new `HikariTransactor` configured with the given info. */
   def newHikariTransactor[M[_]: Async](

--- a/modules/hikari/src/test/scala/doobie/hikari/ConfigSpec.scala
+++ b/modules/hikari/src/test/scala/doobie/hikari/ConfigSpec.scala
@@ -13,8 +13,10 @@ class ConfigSpec extends munit.FunSuite {
 
     import cats.effect.unsafe.implicits.global
 
-    val actual = Config.makeHikariConfig[IO](Config()).unsafeRunSync()
+    val actual = Config.makeHikariConfig[IO](Config(jdbcUrl = Some("jdbcUrl"), poolName = Some("poolName"))).unsafeRunSync()
     val expected = new HikariConfig()
+    expected.setJdbcUrl("jdbcUrl") // mandatory argument
+    expected.setPoolName("poolName") // otherwise the pool name is generated
     expected.validate()
 
     assertEquals(actual.getCatalog, expected.getCatalog)

--- a/modules/hikari/src/test/scala/doobie/hikari/ConfigSpec.scala
+++ b/modules/hikari/src/test/scala/doobie/hikari/ConfigSpec.scala
@@ -15,6 +15,7 @@ class ConfigSpec extends munit.FunSuite {
 
     val actual = Config.makeHikariConfig[IO](Config()).unsafeRunSync()
     val expected = new HikariConfig()
+    expected.validate()
 
     assertEquals(actual.getCatalog, expected.getCatalog)
     assertEquals(actual.getConnectionTimeout, expected.getConnectionTimeout)


### PR DESCRIPTION
These new methods provide good default behavior. Using these makes it difficult to shoot oneself to own foot by passing in a wrong EC.