### PR TITLE
Add detail to docs for Java 8 time types

### DIFF
--- a/modules/docs/src/main/mdoc/docs/15-Extensions-PostgreSQL.md
+++ b/modules/docs/src/main/mdoc/docs/15-Extensions-PostgreSQL.md
@@ -76,15 +76,19 @@ import doobie.postgres.implicits._
 
 ### Java 8 Time Types (JSR310)
 
-An explicit import is required to bring mappings for `java.time.Instant` / `java.time.LocalDate`
+An explicit import is required to bring in mappings for `java.time.OffsetDateTime` / `java.time.Instant` / `java.time.ZonedDateTime` / `java.time.LocalDateTime` / `java.time.LocalDate` / `java.time.LocalTime`
 
 ```scala mdoc:silent
-// Provides mappings for java.time.Instant
-import doobie.implicits.legacy.instant._ 
-
-// Provides mappings for java.time.LocalDate
-import doobie.implicits.legacy.localdate._
+import doobie.postgres.implicits._
 ```
+
+To ensure **doobie** performs the conversion correctly between Java 8 time types and PostgreSQL Date/Time types when handling timezones or the lack thereof.
+The correct combination of date/time types should be used:
+
+- `TIMESTAMP` maps to `java.time.LocalDateTime`
+- `TIMESTAMPZ` maps to `java.time.Instant`, `java.time.ZonedDateTime` or `java.time.OffsetDateTime`
+- `DATE` maps to `java.time.LocalDate`
+- `TIME` maps to `java.time.LocalTime`
 
 ### Array Types
 


### PR DESCRIPTION
I recently had a problem in one of my codebases where the Java 8 and PostgreSQL date/time types had misaligned which resulted in the BST timezone being used when we wanted GMT/UTC. When resolving my problem I found this useful info in the [javadocs](https://github.com/tpolecat/doobie/blob/d99ba2ba9fedf4b0869ac4e6feb3bb49269f11fd/modules/postgres/src/main/scala/doobie/postgres/JavaTimeInstances.scala) and thought it would be very useful to have it also documented in the microsite docs.

I also modified the import required given that these docs are in the PostgreSQL extension section, which provides support for the full list of Java 8 time types supported by the Doobie PostgreSQL extension.