### PR TITLE
Better Java time instances for PostgreSQL

### DIFF
--- a/modules/postgres/src/main/scala/doobie/postgres/JavaTimeInstances.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/JavaTimeInstances.scala
@@ -13,7 +13,7 @@ import java.time.{OffsetDateTime, ZoneOffset} // Using database JDBC driver nati
 /**
  * Instances for JSR-310 date time types.
  *
- * Implementation is based on https://jdbc.postgresql.org/documentation/head/8-date-time.html, using
+ * Implementation is based on https://jdbc.postgresql.org/documentation/head/java8-date-time.html, using
  * native support for Postgres JDBC driver.
  */
 trait JavaTimeInstances extends MetaConstructors {
@@ -26,8 +26,8 @@ trait JavaTimeInstances extends MetaConstructors {
    */
   implicit val JavaTimeOffsetDateTimeMeta: Meta[java.time.OffsetDateTime] =
     Basic.one[java.time.OffsetDateTime](
-      JT.Timestamp,
-      List(JT.Time),
+      JT.TimestampWithTimezone,
+      List(JT.Timestamp, JT.TimeWithTimezone),
       _.getObject(_, classOf[java.time.OffsetDateTime]), _.setObject(_, _), _.updateObject(_, _))
 
   /**
@@ -35,15 +35,6 @@ trait JavaTimeInstances extends MetaConstructors {
    */
   implicit val JavaTimeInstantMeta: Meta[java.time.Instant] =
     JavaTimeOffsetDateTimeMeta.timap(_.toInstant)(OffsetDateTime.ofInstant(_, ZoneOffset.UTC))
-
-  /**
-   * This type should map to TIMESTAMP WITH TIMEZONE (TIMESTAMPTZ)
-   * When writing to the database, the same instant is preserved if your target column is of type TIMESTAMPTZ
-   * (The JDBC driver works out the timezone conversion for you). Note that since zone information is not stored in
-   * the database column, retrieving the same value will yield the same instant in time, but in UTC.
-   */
-  implicit val JavaTimeZonedDateTimeMeta: Meta[java.time.ZonedDateTime] =
-    JavaTimeOffsetDateTimeMeta.timap(_.atZoneSameInstant(ZoneOffset.UTC))(_.toOffsetDateTime)
 
   /**
    * This type should map to TIMESTAMP
@@ -71,5 +62,14 @@ trait JavaTimeInstances extends MetaConstructors {
       JT.Time,
       Nil,
       _.getObject(_, classOf[java.time.LocalTime]), _.setObject(_, _), _.updateObject(_, _))
+
+  /**
+   * This type should map to TIME WITH TIMEZONE (TIMETZ)
+   */
+  implicit val JavaTimeOffsetTimeMeta: Meta[java.time.OffsetTime] =
+    Basic.one[java.time.OffsetTime](
+      JT.TimeWithTimezone,
+      Nil,
+      _.getObject(_, classOf[java.time.OffsetTime]), _.setObject(_, _), _.updateObject(_, _))
 
 }

--- a/modules/postgres/src/test/scala/doobie/postgres/TypesSuite.scala
+++ b/modules/postgres/src/test/scala/doobie/postgres/TypesSuite.scala
@@ -117,7 +117,6 @@ class TypesSuite extends munit.ScalaCheckSuite {
   testInOut[java.sql.Timestamp]("timestamptz")
   testInOut[java.time.Instant]("timestamptz")
   testInOutTweakExpected[java.time.OffsetDateTime]("timestamptz")(_.withOffsetSameInstant(ZoneOffset.UTC)) // +148488-07-03T02:38:17Z != +148488-07-03T00:00-02:38:17
-  testInOutTweakExpected[java.time.ZonedDateTime]("timestamptz")(_.withZoneSameInstant(ZoneOffset.UTC))
 
   /*
     local date & time (not an instant in time)


### PR DESCRIPTION
Given that the Postgres JDBC driver does not return *WithTimezone types,
change the type when creating meta column and parameter objects. This
allows the Java time instance for `OffsetDateTime` to be defined as
requiring a column to be a `TimestampWithTimezone`.