### PR TITLE
Some FS2 Micro-optimisations

### DIFF
--- a/modules/core/src/main/scala/doobie/util/yolo.scala
+++ b/modules/core/src/main/scala/doobie/util/yolo.scala
@@ -34,8 +34,7 @@ object yolo {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def quick(implicit colors: Colors = Colors.Ansi): M[Unit] =
         q.stream
-         .map(_.toString)
-         .evalMap(out(_, colors))
+         .foreach(s => out(s.toString, colors))
          .compile
          .drain
          .transact(xa)(ev)
@@ -90,7 +89,7 @@ object yolo {
     implicit class StreamYoloOps[A](pa: Stream[ConnectionIO, A]) {
       @SuppressWarnings(Array("org.wartremover.warts.ToString"))
       def quick(implicit colors: Colors = Colors.Ansi): M[Unit] =
-        pa.evalMap(a => out(a.toString, colors)).compile.drain.transact(xa)(ev)
+        pa.foreach(a => out(a.toString, colors)).compile.drain.transact(xa)(ev)
     }
 
     private def checkImpl(args: AnalysisArgs, colors: Colors): M[Unit] =

--- a/modules/postgres/src/main/scala/doobie/postgres/syntax/FragmentSyntax.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/syntax/FragmentSyntax.scala
@@ -57,7 +57,7 @@ class FragmentOps(f: Fragment) {
           case (copyIn, _) =>
             PHC.embed(copyIn, PFCI.cancelCopy)
         }.flatMap { copyIn =>
-          byteStream.chunks.evalMap(bytes =>
+          byteStream.chunks.foreach(bytes =>
             PHC.embed(copyIn, PFCI.writeToCopy(bytes.toArray, 0, bytes.size))
           )
         }.compile.drain


### PR DESCRIPTION
- Replace calls to evalMap, in which the result is unused, with foreach. This avoids emitting chunks and pull objects.
- Expand the definition of RepeatEvalChunks into a recursive pull.