### PR TITLE
Fix NPE in Scala 3 derivation

### DIFF
--- a/modules/core/src/main/scala-3/util/ReadPlatform.scala
+++ b/modules/core/src/main/scala-3/util/ReadPlatform.scala
@@ -13,7 +13,7 @@ trait ReadPlatform:
     new Read[EmptyTuple](Nil, (_, _) => EmptyTuple)
 
   // Read for head and tail.
-  given [H, T <: Tuple](using H: => Read[H], T: => Read[T]): Read[H *: T] =
+  given [H, T <: Tuple](using H: Read[H], T: Read[T]): Read[H *: T] =
     new Read[H *: T](
       H.gets ++ T.gets,
       (rs, n) => H.unsafeGet(rs, n) *: T.unsafeGet(rs, n + H.length)


### PR DESCRIPTION
There seems to be a bug where using by-name parameter in deriving will lead to Scala 3 compiler thinking that an instance of Read[T] exist (even though it doesn't), which leads to NPEs when it's used.

Removing the by-name should be safe, as Read only works with products and won't need to worry about recursive definitions.

Fixes #1808 