### PR TITLE
Resynchonize Freegen2 code generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
         if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-latest'
         run: sbt '++ ${{ matrix.scala }}' doc
 
+      - name: Check there are no uncommitted changes in git (to catch generated files that weren't committed)
+        run: sbt '++ ${{ matrix.scala }}' checkGitNoUncommittedChanges
+
       - name: Check Doc Site (2.13.10 only)
         if: matrix.scala == '2.13.10'
         run: sbt '++ ${{ matrix.scala }}' docs/makeSite

--- a/modules/free/src/main/scala/doobie/free/blob.scala
+++ b/modules/free/src/main/scala/doobie/free/blob.scala
@@ -4,7 +4,7 @@
 
 package doobie.free
 
-import cats.~>
+import cats.{~>, Applicative, Semigroup, Monoid}
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
 import doobie.util.log.LogEvent
@@ -16,6 +16,7 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.sql.Blob
 
+// This file is Auto-generated using FreeGen2.scala
 object blob { module =>
 
   // Algebra of operations for Blob. Each accepts a visitor as an alternative to pattern-matching.
@@ -214,5 +215,16 @@ object blob { module =>
       override def fromFuture[A](fut: BlobIO[Future[A]]): BlobIO[A] = module.fromFuture(fut)
       override def fromFutureCancelable[A](fut: BlobIO[(Future[A], BlobIO[Unit])]): BlobIO[A] = module.fromFutureCancelable(fut)
     }
+    
+  implicit def MonoidBlobIO[A : Monoid]: Monoid[BlobIO[A]] = new Monoid[BlobIO[A]] {
+    override def empty: BlobIO[A] = Applicative[BlobIO].pure(Monoid[A].empty)
+    override def combine(x: BlobIO[A], y: BlobIO[A]): BlobIO[A] =
+      Applicative[BlobIO].product(x, y).map { case (x, y) => Monoid[A].combine(x, y) }
+  }
+ 
+  implicit def SemigroupBlobIO[A : Semigroup]: Semigroup[BlobIO[A]] = new Semigroup[BlobIO[A]] {
+    override def combine(x: BlobIO[A], y: BlobIO[A]): BlobIO[A] =
+      Applicative[BlobIO].product(x, y).map { case (x, y) => Semigroup[A].combine(x, y) }
+  }  
 }
 

--- a/modules/free/src/main/scala/doobie/free/callablestatement.scala
+++ b/modules/free/src/main/scala/doobie/free/callablestatement.scala
@@ -4,7 +4,7 @@
 
 package doobie.free
 
-import cats.~>
+import cats.{~>, Applicative, Semigroup, Monoid}
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
 import doobie.util.log.LogEvent
@@ -38,6 +38,7 @@ import java.sql.{ Array => SqlArray }
 import java.util.Calendar
 import java.util.Map
 
+// This file is Auto-generated using FreeGen2.scala
 object callablestatement { module =>
 
   // Algebra of operations for CallableStatement. Each accepts a visitor as an alternative to pattern-matching.
@@ -89,6 +90,9 @@ object callablestatement { module =>
       def clearWarnings: F[Unit]
       def close: F[Unit]
       def closeOnCompletion: F[Unit]
+      def enquoteIdentifier(a: String, b: Boolean): F[String]
+      def enquoteLiteral(a: String): F[String]
+      def enquoteNCharLiteral(a: String): F[String]
       def execute: F[Boolean]
       def execute(a: String): F[Boolean]
       def execute(a: String, b: Array[Int]): F[Boolean]
@@ -190,6 +194,7 @@ object callablestatement { module =>
       def isCloseOnCompletion: F[Boolean]
       def isClosed: F[Boolean]
       def isPoolable: F[Boolean]
+      def isSimpleIdentifier(a: String): F[Boolean]
       def isWrapperFor(a: Class[_]): F[Boolean]
       def registerOutParameter(a: Int, b: Int): F[Unit]
       def registerOutParameter(a: Int, b: Int, c: Int): F[Unit]
@@ -384,6 +389,15 @@ object callablestatement { module =>
     }
     case object CloseOnCompletion extends CallableStatementOp[Unit] {
       def visit[F[_]](v: Visitor[F]) = v.closeOnCompletion
+    }
+    final case class EnquoteIdentifier(a: String, b: Boolean) extends CallableStatementOp[String] {
+      def visit[F[_]](v: Visitor[F]) = v.enquoteIdentifier(a, b)
+    }
+    final case class EnquoteLiteral(a: String) extends CallableStatementOp[String] {
+      def visit[F[_]](v: Visitor[F]) = v.enquoteLiteral(a)
+    }
+    final case class EnquoteNCharLiteral(a: String) extends CallableStatementOp[String] {
+      def visit[F[_]](v: Visitor[F]) = v.enquoteNCharLiteral(a)
     }
     case object Execute extends CallableStatementOp[Boolean] {
       def visit[F[_]](v: Visitor[F]) = v.execute
@@ -687,6 +701,9 @@ object callablestatement { module =>
     }
     case object IsPoolable extends CallableStatementOp[Boolean] {
       def visit[F[_]](v: Visitor[F]) = v.isPoolable
+    }
+    final case class IsSimpleIdentifier(a: String) extends CallableStatementOp[Boolean] {
+      def visit[F[_]](v: Visitor[F]) = v.isSimpleIdentifier(a)
     }
     final case class IsWrapperFor(a: Class[_]) extends CallableStatementOp[Boolean] {
       def visit[F[_]](v: Visitor[F]) = v.isWrapperFor(a)
@@ -1083,6 +1100,9 @@ object callablestatement { module =>
   val clearWarnings: CallableStatementIO[Unit] = FF.liftF(ClearWarnings)
   val close: CallableStatementIO[Unit] = FF.liftF(Close)
   val closeOnCompletion: CallableStatementIO[Unit] = FF.liftF(CloseOnCompletion)
+  def enquoteIdentifier(a: String, b: Boolean): CallableStatementIO[String] = FF.liftF(EnquoteIdentifier(a, b))
+  def enquoteLiteral(a: String): CallableStatementIO[String] = FF.liftF(EnquoteLiteral(a))
+  def enquoteNCharLiteral(a: String): CallableStatementIO[String] = FF.liftF(EnquoteNCharLiteral(a))
   val execute: CallableStatementIO[Boolean] = FF.liftF(Execute)
   def execute(a: String): CallableStatementIO[Boolean] = FF.liftF(Execute1(a))
   def execute(a: String, b: Array[Int]): CallableStatementIO[Boolean] = FF.liftF(Execute2(a, b))
@@ -1184,6 +1204,7 @@ object callablestatement { module =>
   val isCloseOnCompletion: CallableStatementIO[Boolean] = FF.liftF(IsCloseOnCompletion)
   val isClosed: CallableStatementIO[Boolean] = FF.liftF(IsClosed)
   val isPoolable: CallableStatementIO[Boolean] = FF.liftF(IsPoolable)
+  def isSimpleIdentifier(a: String): CallableStatementIO[Boolean] = FF.liftF(IsSimpleIdentifier(a))
   def isWrapperFor(a: Class[_]): CallableStatementIO[Boolean] = FF.liftF(IsWrapperFor(a))
   def registerOutParameter(a: Int, b: Int): CallableStatementIO[Unit] = FF.liftF(RegisterOutParameter(a, b))
   def registerOutParameter(a: Int, b: Int, c: Int): CallableStatementIO[Unit] = FF.liftF(RegisterOutParameter1(a, b, c))
@@ -1326,5 +1347,16 @@ object callablestatement { module =>
       override def fromFuture[A](fut: CallableStatementIO[Future[A]]): CallableStatementIO[A] = module.fromFuture(fut)
       override def fromFutureCancelable[A](fut: CallableStatementIO[(Future[A], CallableStatementIO[Unit])]): CallableStatementIO[A] = module.fromFutureCancelable(fut)
     }
+    
+  implicit def MonoidCallableStatementIO[A : Monoid]: Monoid[CallableStatementIO[A]] = new Monoid[CallableStatementIO[A]] {
+    override def empty: CallableStatementIO[A] = Applicative[CallableStatementIO].pure(Monoid[A].empty)
+    override def combine(x: CallableStatementIO[A], y: CallableStatementIO[A]): CallableStatementIO[A] =
+      Applicative[CallableStatementIO].product(x, y).map { case (x, y) => Monoid[A].combine(x, y) }
+  }
+ 
+  implicit def SemigroupCallableStatementIO[A : Semigroup]: Semigroup[CallableStatementIO[A]] = new Semigroup[CallableStatementIO[A]] {
+    override def combine(x: CallableStatementIO[A], y: CallableStatementIO[A]): CallableStatementIO[A] =
+      Applicative[CallableStatementIO].product(x, y).map { case (x, y) => Semigroup[A].combine(x, y) }
+  }  
 }
 

--- a/modules/free/src/main/scala/doobie/free/clob.scala
+++ b/modules/free/src/main/scala/doobie/free/clob.scala
@@ -4,7 +4,7 @@
 
 package doobie.free
 
-import cats.~>
+import cats.{~>, Applicative, Semigroup, Monoid}
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
 import doobie.util.log.LogEvent
@@ -19,6 +19,7 @@ import java.io.Writer
 import java.lang.String
 import java.sql.Clob
 
+// This file is Auto-generated using FreeGen2.scala
 object clob { module =>
 
   // Algebra of operations for Clob. Each accepts a visitor as an alternative to pattern-matching.
@@ -227,5 +228,16 @@ object clob { module =>
       override def fromFuture[A](fut: ClobIO[Future[A]]): ClobIO[A] = module.fromFuture(fut)
       override def fromFutureCancelable[A](fut: ClobIO[(Future[A], ClobIO[Unit])]): ClobIO[A] = module.fromFutureCancelable(fut)
     }
+    
+  implicit def MonoidClobIO[A : Monoid]: Monoid[ClobIO[A]] = new Monoid[ClobIO[A]] {
+    override def empty: ClobIO[A] = Applicative[ClobIO].pure(Monoid[A].empty)
+    override def combine(x: ClobIO[A], y: ClobIO[A]): ClobIO[A] =
+      Applicative[ClobIO].product(x, y).map { case (x, y) => Monoid[A].combine(x, y) }
+  }
+ 
+  implicit def SemigroupClobIO[A : Semigroup]: Semigroup[ClobIO[A]] = new Semigroup[ClobIO[A]] {
+    override def combine(x: ClobIO[A], y: ClobIO[A]): ClobIO[A] =
+      Applicative[ClobIO].product(x, y).map { case (x, y) => Semigroup[A].combine(x, y) }
+  }  
 }
 

--- a/modules/free/src/main/scala/doobie/free/connection.scala
+++ b/modules/free/src/main/scala/doobie/free/connection.scala
@@ -4,14 +4,14 @@
 
 package doobie.free
 
-import cats.{Applicative, Monoid, Semigroup, ~>}
+import cats.{~>, Applicative, Semigroup, Monoid}
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
 import doobie.util.log.LogEvent
 import doobie.WeakAsync
-
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
+
 import java.lang.Class
 import java.lang.String
 import java.sql.Blob
@@ -24,13 +24,15 @@ import java.sql.PreparedStatement
 import java.sql.SQLWarning
 import java.sql.SQLXML
 import java.sql.Savepoint
+import java.sql.ShardingKey
 import java.sql.Statement
 import java.sql.Struct
-import java.sql.{Array => SqlArray}
+import java.sql.{ Array => SqlArray }
 import java.util.Map
 import java.util.Properties
 import java.util.concurrent.Executor
 
+// This file is Auto-generated using FreeGen2.scala
 object connection { module =>
 
   // Algebra of operations for Connection. Each accepts a visitor as an alternative to pattern-matching.
@@ -75,6 +77,7 @@ object connection { module =>
 
       // Connection
       def abort(a: Executor): F[Unit]
+      def beginRequest: F[Unit]
       def clearWarnings: F[Unit]
       def close: F[Unit]
       def commit: F[Unit]
@@ -87,6 +90,7 @@ object connection { module =>
       def createStatement(a: Int, b: Int): F[Statement]
       def createStatement(a: Int, b: Int, c: Int): F[Statement]
       def createStruct(a: String, b: Array[AnyRef]): F[Struct]
+      def endRequest: F[Unit]
       def getAutoCommit: F[Boolean]
       def getCatalog: F[String]
       def getClientInfo: F[Properties]
@@ -125,6 +129,10 @@ object connection { module =>
       def setSavepoint: F[Savepoint]
       def setSavepoint(a: String): F[Savepoint]
       def setSchema(a: String): F[Unit]
+      def setShardingKey(a: ShardingKey): F[Unit]
+      def setShardingKey(a: ShardingKey, b: ShardingKey): F[Unit]
+      def setShardingKeyIfValid(a: ShardingKey, b: Int): F[Boolean]
+      def setShardingKeyIfValid(a: ShardingKey, b: ShardingKey, c: Int): F[Boolean]
       def setTransactionIsolation(a: Int): F[Unit]
       def setTypeMap(a: Map[String, Class[_]]): F[Unit]
       def unwrap[T](a: Class[T]): F[T]
@@ -182,6 +190,9 @@ object connection { module =>
     final case class Abort(a: Executor) extends ConnectionOp[Unit] {
       def visit[F[_]](v: Visitor[F]) = v.abort(a)
     }
+    case object BeginRequest extends ConnectionOp[Unit] {
+      def visit[F[_]](v: Visitor[F]) = v.beginRequest
+    }
     case object ClearWarnings extends ConnectionOp[Unit] {
       def visit[F[_]](v: Visitor[F]) = v.clearWarnings
     }
@@ -217,6 +228,9 @@ object connection { module =>
     }
     final case class CreateStruct(a: String, b: Array[AnyRef]) extends ConnectionOp[Struct] {
       def visit[F[_]](v: Visitor[F]) = v.createStruct(a, b)
+    }
+    case object EndRequest extends ConnectionOp[Unit] {
+      def visit[F[_]](v: Visitor[F]) = v.endRequest
     }
     case object GetAutoCommit extends ConnectionOp[Boolean] {
       def visit[F[_]](v: Visitor[F]) = v.getAutoCommit
@@ -332,6 +346,18 @@ object connection { module =>
     final case class SetSchema(a: String) extends ConnectionOp[Unit] {
       def visit[F[_]](v: Visitor[F]) = v.setSchema(a)
     }
+    final case class SetShardingKey(a: ShardingKey) extends ConnectionOp[Unit] {
+      def visit[F[_]](v: Visitor[F]) = v.setShardingKey(a)
+    }
+    final case class SetShardingKey1(a: ShardingKey, b: ShardingKey) extends ConnectionOp[Unit] {
+      def visit[F[_]](v: Visitor[F]) = v.setShardingKey(a, b)
+    }
+    final case class SetShardingKeyIfValid(a: ShardingKey, b: Int) extends ConnectionOp[Boolean] {
+      def visit[F[_]](v: Visitor[F]) = v.setShardingKeyIfValid(a, b)
+    }
+    final case class SetShardingKeyIfValid1(a: ShardingKey, b: ShardingKey, c: Int) extends ConnectionOp[Boolean] {
+      def visit[F[_]](v: Visitor[F]) = v.setShardingKeyIfValid(a, b, c)
+    }
     final case class SetTransactionIsolation(a: Int) extends ConnectionOp[Unit] {
       def visit[F[_]](v: Visitor[F]) = v.setTransactionIsolation(a)
     }
@@ -369,6 +395,7 @@ object connection { module =>
 
   // Smart constructors for Connection-specific operations.
   def abort(a: Executor): ConnectionIO[Unit] = FF.liftF(Abort(a))
+  val beginRequest: ConnectionIO[Unit] = FF.liftF(BeginRequest)
   val clearWarnings: ConnectionIO[Unit] = FF.liftF(ClearWarnings)
   val close: ConnectionIO[Unit] = FF.liftF(Close)
   val commit: ConnectionIO[Unit] = FF.liftF(Commit)
@@ -381,6 +408,7 @@ object connection { module =>
   def createStatement(a: Int, b: Int): ConnectionIO[Statement] = FF.liftF(CreateStatement1(a, b))
   def createStatement(a: Int, b: Int, c: Int): ConnectionIO[Statement] = FF.liftF(CreateStatement2(a, b, c))
   def createStruct(a: String, b: Array[AnyRef]): ConnectionIO[Struct] = FF.liftF(CreateStruct(a, b))
+  val endRequest: ConnectionIO[Unit] = FF.liftF(EndRequest)
   val getAutoCommit: ConnectionIO[Boolean] = FF.liftF(GetAutoCommit)
   val getCatalog: ConnectionIO[String] = FF.liftF(GetCatalog)
   val getClientInfo: ConnectionIO[Properties] = FF.liftF(GetClientInfo)
@@ -419,6 +447,10 @@ object connection { module =>
   val setSavepoint: ConnectionIO[Savepoint] = FF.liftF(SetSavepoint)
   def setSavepoint(a: String): ConnectionIO[Savepoint] = FF.liftF(SetSavepoint1(a))
   def setSchema(a: String): ConnectionIO[Unit] = FF.liftF(SetSchema(a))
+  def setShardingKey(a: ShardingKey): ConnectionIO[Unit] = FF.liftF(SetShardingKey(a))
+  def setShardingKey(a: ShardingKey, b: ShardingKey): ConnectionIO[Unit] = FF.liftF(SetShardingKey1(a, b))
+  def setShardingKeyIfValid(a: ShardingKey, b: Int): ConnectionIO[Boolean] = FF.liftF(SetShardingKeyIfValid(a, b))
+  def setShardingKeyIfValid(a: ShardingKey, b: ShardingKey, c: Int): ConnectionIO[Boolean] = FF.liftF(SetShardingKeyIfValid1(a, b, c))
   def setTransactionIsolation(a: Int): ConnectionIO[Unit] = FF.liftF(SetTransactionIsolation(a))
   def setTypeMap(a: Map[String, Class[_]]): ConnectionIO[Unit] = FF.liftF(SetTypeMap(a))
   def unwrap[T](a: Class[T]): ConnectionIO[T] = FF.liftF(Unwrap(a))
@@ -444,16 +476,16 @@ object connection { module =>
       override def fromFuture[A](fut: ConnectionIO[Future[A]]): ConnectionIO[A] = module.fromFuture(fut)
       override def fromFutureCancelable[A](fut: ConnectionIO[(Future[A], ConnectionIO[Unit])]): ConnectionIO[A] = module.fromFutureCancelable(fut)
     }
-
+    
   implicit def MonoidConnectionIO[A : Monoid]: Monoid[ConnectionIO[A]] = new Monoid[ConnectionIO[A]] {
     override def empty: ConnectionIO[A] = Applicative[ConnectionIO].pure(Monoid[A].empty)
     override def combine(x: ConnectionIO[A], y: ConnectionIO[A]): ConnectionIO[A] =
       Applicative[ConnectionIO].product(x, y).map { case (x, y) => Monoid[A].combine(x, y) }
   }
-
+ 
   implicit def SemigroupConnectionIO[A : Semigroup]: Semigroup[ConnectionIO[A]] = new Semigroup[ConnectionIO[A]] {
     override def combine(x: ConnectionIO[A], y: ConnectionIO[A]): ConnectionIO[A] =
       Applicative[ConnectionIO].product(x, y).map { case (x, y) => Semigroup[A].combine(x, y) }
-  }
+  }  
 }
 

--- a/modules/free/src/main/scala/doobie/free/databasemetadata.scala
+++ b/modules/free/src/main/scala/doobie/free/databasemetadata.scala
@@ -4,7 +4,7 @@
 
 package doobie.free
 
-import cats.~>
+import cats.{~>, Applicative, Semigroup, Monoid}
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
 import doobie.util.log.LogEvent
@@ -19,6 +19,7 @@ import java.sql.DatabaseMetaData
 import java.sql.ResultSet
 import java.sql.RowIdLifetime
 
+// This file is Auto-generated using FreeGen2.scala
 object databasemetadata { module =>
 
   // Algebra of operations for DatabaseMetaData. Each accepts a visitor as an alternative to pattern-matching.
@@ -224,6 +225,7 @@ object databasemetadata { module =>
       def supportsSchemasInProcedureCalls: F[Boolean]
       def supportsSchemasInTableDefinitions: F[Boolean]
       def supportsSelectForUpdate: F[Boolean]
+      def supportsSharding: F[Boolean]
       def supportsStatementPooling: F[Boolean]
       def supportsStoredFunctionsUsingCallSyntax: F[Boolean]
       def supportsStoredProcedures: F[Boolean]
@@ -777,6 +779,9 @@ object databasemetadata { module =>
     case object SupportsSelectForUpdate extends DatabaseMetaDataOp[Boolean] {
       def visit[F[_]](v: Visitor[F]) = v.supportsSelectForUpdate
     }
+    case object SupportsSharding extends DatabaseMetaDataOp[Boolean] {
+      def visit[F[_]](v: Visitor[F]) = v.supportsSharding
+    }
     case object SupportsStatementPooling extends DatabaseMetaDataOp[Boolean] {
       def visit[F[_]](v: Visitor[F]) = v.supportsStatementPooling
     }
@@ -1014,6 +1019,7 @@ object databasemetadata { module =>
   val supportsSchemasInProcedureCalls: DatabaseMetaDataIO[Boolean] = FF.liftF(SupportsSchemasInProcedureCalls)
   val supportsSchemasInTableDefinitions: DatabaseMetaDataIO[Boolean] = FF.liftF(SupportsSchemasInTableDefinitions)
   val supportsSelectForUpdate: DatabaseMetaDataIO[Boolean] = FF.liftF(SupportsSelectForUpdate)
+  val supportsSharding: DatabaseMetaDataIO[Boolean] = FF.liftF(SupportsSharding)
   val supportsStatementPooling: DatabaseMetaDataIO[Boolean] = FF.liftF(SupportsStatementPooling)
   val supportsStoredFunctionsUsingCallSyntax: DatabaseMetaDataIO[Boolean] = FF.liftF(SupportsStoredFunctionsUsingCallSyntax)
   val supportsStoredProcedures: DatabaseMetaDataIO[Boolean] = FF.liftF(SupportsStoredProcedures)
@@ -1052,5 +1058,16 @@ object databasemetadata { module =>
       override def fromFuture[A](fut: DatabaseMetaDataIO[Future[A]]): DatabaseMetaDataIO[A] = module.fromFuture(fut)
       override def fromFutureCancelable[A](fut: DatabaseMetaDataIO[(Future[A], DatabaseMetaDataIO[Unit])]): DatabaseMetaDataIO[A] = module.fromFutureCancelable(fut)
     }
+    
+  implicit def MonoidDatabaseMetaDataIO[A : Monoid]: Monoid[DatabaseMetaDataIO[A]] = new Monoid[DatabaseMetaDataIO[A]] {
+    override def empty: DatabaseMetaDataIO[A] = Applicative[DatabaseMetaDataIO].pure(Monoid[A].empty)
+    override def combine(x: DatabaseMetaDataIO[A], y: DatabaseMetaDataIO[A]): DatabaseMetaDataIO[A] =
+      Applicative[DatabaseMetaDataIO].product(x, y).map { case (x, y) => Monoid[A].combine(x, y) }
+  }
+ 
+  implicit def SemigroupDatabaseMetaDataIO[A : Semigroup]: Semigroup[DatabaseMetaDataIO[A]] = new Semigroup[DatabaseMetaDataIO[A]] {
+    override def combine(x: DatabaseMetaDataIO[A], y: DatabaseMetaDataIO[A]): DatabaseMetaDataIO[A] =
+      Applicative[DatabaseMetaDataIO].product(x, y).map { case (x, y) => Semigroup[A].combine(x, y) }
+  }  
 }
 

--- a/modules/free/src/main/scala/doobie/free/driver.scala
+++ b/modules/free/src/main/scala/doobie/free/driver.scala
@@ -4,7 +4,7 @@
 
 package doobie.free
 
-import cats.~>
+import cats.{~>, Applicative, Semigroup, Monoid}
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
 import doobie.util.log.LogEvent
@@ -19,6 +19,7 @@ import java.sql.DriverPropertyInfo
 import java.util.Properties
 import java.util.logging.Logger
 
+// This file is Auto-generated using FreeGen2.scala
 object driver { module =>
 
   // Algebra of operations for Driver. Each accepts a visitor as an alternative to pattern-matching.
@@ -197,5 +198,16 @@ object driver { module =>
       override def fromFuture[A](fut: DriverIO[Future[A]]): DriverIO[A] = module.fromFuture(fut)
       override def fromFutureCancelable[A](fut: DriverIO[(Future[A], DriverIO[Unit])]): DriverIO[A] = module.fromFutureCancelable(fut)
     }
+    
+  implicit def MonoidDriverIO[A : Monoid]: Monoid[DriverIO[A]] = new Monoid[DriverIO[A]] {
+    override def empty: DriverIO[A] = Applicative[DriverIO].pure(Monoid[A].empty)
+    override def combine(x: DriverIO[A], y: DriverIO[A]): DriverIO[A] =
+      Applicative[DriverIO].product(x, y).map { case (x, y) => Monoid[A].combine(x, y) }
+  }
+ 
+  implicit def SemigroupDriverIO[A : Semigroup]: Semigroup[DriverIO[A]] = new Semigroup[DriverIO[A]] {
+    override def combine(x: DriverIO[A], y: DriverIO[A]): DriverIO[A] =
+      Applicative[DriverIO].product(x, y).map { case (x, y) => Semigroup[A].combine(x, y) }
+  }  
 }
 

--- a/modules/free/src/main/scala/doobie/free/kleisliinterpreter.scala
+++ b/modules/free/src/main/scala/doobie/free/kleisliinterpreter.scala
@@ -17,6 +17,8 @@ import scala.concurrent.duration.FiniteDuration
 // Types referenced in the JDBC API
 import java.io.InputStream
 import java.io.Reader
+import java.lang.Class
+import java.lang.String
 import java.math.BigDecimal
 import java.net.URL
 import java.sql.Blob
@@ -37,6 +39,7 @@ import java.sql.SQLOutput
 import java.sql.SQLType
 import java.sql.SQLXML
 import java.sql.Savepoint
+import java.sql.ShardingKey
 import java.sql.Statement
 import java.sql.Struct
 import java.sql.Time
@@ -451,6 +454,7 @@ class KleisliInterpreter[M[_]](logHandler: LogHandlerM[M])(implicit val asyncM: 
     override def supportsSchemasInProcedureCalls = primitive(_.supportsSchemasInProcedureCalls)
     override def supportsSchemasInTableDefinitions = primitive(_.supportsSchemasInTableDefinitions)
     override def supportsSelectForUpdate = primitive(_.supportsSelectForUpdate)
+    override def supportsSharding = primitive(_.supportsSharding)
     override def supportsStatementPooling = primitive(_.supportsStatementPooling)
     override def supportsStoredFunctionsUsingCallSyntax = primitive(_.supportsStoredFunctionsUsingCallSyntax)
     override def supportsStoredProcedures = primitive(_.supportsStoredProcedures)
@@ -700,6 +704,7 @@ class KleisliInterpreter[M[_]](logHandler: LogHandlerM[M])(implicit val asyncM: 
 
     // domain-specific operations are implemented in terms of `primitive`
     override def abort(a: Executor) = primitive(_.abort(a))
+    override def beginRequest = primitive(_.beginRequest)
     override def clearWarnings = primitive(_.clearWarnings)
     override def close = primitive(_.close)
     override def commit = primitive(_.commit)
@@ -712,6 +717,7 @@ class KleisliInterpreter[M[_]](logHandler: LogHandlerM[M])(implicit val asyncM: 
     override def createStatement(a: Int, b: Int) = primitive(_.createStatement(a, b))
     override def createStatement(a: Int, b: Int, c: Int) = primitive(_.createStatement(a, b, c))
     override def createStruct(a: String, b: Array[AnyRef]) = primitive(_.createStruct(a, b))
+    override def endRequest = primitive(_.endRequest)
     override def getAutoCommit = primitive(_.getAutoCommit)
     override def getCatalog = primitive(_.getCatalog)
     override def getClientInfo = primitive(_.getClientInfo)
@@ -750,6 +756,10 @@ class KleisliInterpreter[M[_]](logHandler: LogHandlerM[M])(implicit val asyncM: 
     override def setSavepoint = primitive(_.setSavepoint)
     override def setSavepoint(a: String) = primitive(_.setSavepoint(a))
     override def setSchema(a: String) = primitive(_.setSchema(a))
+    override def setShardingKey(a: ShardingKey) = primitive(_.setShardingKey(a))
+    override def setShardingKey(a: ShardingKey, b: ShardingKey) = primitive(_.setShardingKey(a, b))
+    override def setShardingKeyIfValid(a: ShardingKey, b: Int) = primitive(_.setShardingKeyIfValid(a, b))
+    override def setShardingKeyIfValid(a: ShardingKey, b: ShardingKey, c: Int) = primitive(_.setShardingKeyIfValid(a, b, c))
     override def setTransactionIsolation(a: Int) = primitive(_.setTransactionIsolation(a))
     override def setTypeMap(a: Map[String, Class[_]]) = primitive(_.setTypeMap(a))
     override def unwrap[T](a: Class[T]) = primitive(_.unwrap(a))
@@ -786,6 +796,9 @@ class KleisliInterpreter[M[_]](logHandler: LogHandlerM[M])(implicit val asyncM: 
     override def clearWarnings = primitive(_.clearWarnings)
     override def close = primitive(_.close)
     override def closeOnCompletion = primitive(_.closeOnCompletion)
+    override def enquoteIdentifier(a: String, b: Boolean) = primitive(_.enquoteIdentifier(a, b))
+    override def enquoteLiteral(a: String) = primitive(_.enquoteLiteral(a))
+    override def enquoteNCharLiteral(a: String) = primitive(_.enquoteNCharLiteral(a))
     override def execute(a: String) = primitive(_.execute(a))
     override def execute(a: String, b: Array[Int]) = primitive(_.execute(a, b))
     override def execute(a: String, b: Array[String]) = primitive(_.execute(a, b))
@@ -821,6 +834,7 @@ class KleisliInterpreter[M[_]](logHandler: LogHandlerM[M])(implicit val asyncM: 
     override def isCloseOnCompletion = primitive(_.isCloseOnCompletion)
     override def isClosed = primitive(_.isClosed)
     override def isPoolable = primitive(_.isPoolable)
+    override def isSimpleIdentifier(a: String) = primitive(_.isSimpleIdentifier(a))
     override def isWrapperFor(a: Class[_]) = primitive(_.isWrapperFor(a))
     override def setCursorName(a: String) = primitive(_.setCursorName(a))
     override def setEscapeProcessing(a: Boolean) = primitive(_.setEscapeProcessing(a))
@@ -867,6 +881,9 @@ class KleisliInterpreter[M[_]](logHandler: LogHandlerM[M])(implicit val asyncM: 
     override def clearWarnings = primitive(_.clearWarnings)
     override def close = primitive(_.close)
     override def closeOnCompletion = primitive(_.closeOnCompletion)
+    override def enquoteIdentifier(a: String, b: Boolean) = primitive(_.enquoteIdentifier(a, b))
+    override def enquoteLiteral(a: String) = primitive(_.enquoteLiteral(a))
+    override def enquoteNCharLiteral(a: String) = primitive(_.enquoteNCharLiteral(a))
     override def execute = primitive(_.execute)
     override def execute(a: String) = primitive(_.execute(a))
     override def execute(a: String, b: Array[Int]) = primitive(_.execute(a, b))
@@ -908,6 +925,7 @@ class KleisliInterpreter[M[_]](logHandler: LogHandlerM[M])(implicit val asyncM: 
     override def isCloseOnCompletion = primitive(_.isCloseOnCompletion)
     override def isClosed = primitive(_.isClosed)
     override def isPoolable = primitive(_.isPoolable)
+    override def isSimpleIdentifier(a: String) = primitive(_.isSimpleIdentifier(a))
     override def isWrapperFor(a: Class[_]) = primitive(_.isWrapperFor(a))
     override def setArray(a: Int, b: SqlArray) = primitive(_.setArray(a, b))
     override def setAsciiStream(a: Int, b: InputStream) = primitive(_.setAsciiStream(a, b))
@@ -1003,6 +1021,9 @@ class KleisliInterpreter[M[_]](logHandler: LogHandlerM[M])(implicit val asyncM: 
     override def clearWarnings = primitive(_.clearWarnings)
     override def close = primitive(_.close)
     override def closeOnCompletion = primitive(_.closeOnCompletion)
+    override def enquoteIdentifier(a: String, b: Boolean) = primitive(_.enquoteIdentifier(a, b))
+    override def enquoteLiteral(a: String) = primitive(_.enquoteLiteral(a))
+    override def enquoteNCharLiteral(a: String) = primitive(_.enquoteNCharLiteral(a))
     override def execute = primitive(_.execute)
     override def execute(a: String) = primitive(_.execute(a))
     override def execute(a: String, b: Array[Int]) = primitive(_.execute(a, b))
@@ -1104,6 +1125,7 @@ class KleisliInterpreter[M[_]](logHandler: LogHandlerM[M])(implicit val asyncM: 
     override def isCloseOnCompletion = primitive(_.isCloseOnCompletion)
     override def isClosed = primitive(_.isClosed)
     override def isPoolable = primitive(_.isPoolable)
+    override def isSimpleIdentifier(a: String) = primitive(_.isSimpleIdentifier(a))
     override def isWrapperFor(a: Class[_]) = primitive(_.isWrapperFor(a))
     override def registerOutParameter(a: Int, b: Int) = primitive(_.registerOutParameter(a, b))
     override def registerOutParameter(a: Int, b: Int, c: Int) = primitive(_.registerOutParameter(a, b, c))

--- a/modules/free/src/main/scala/doobie/free/nclob.scala
+++ b/modules/free/src/main/scala/doobie/free/nclob.scala
@@ -4,7 +4,7 @@
 
 package doobie.free
 
-import cats.~>
+import cats.{~>, Applicative, Semigroup, Monoid}
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
 import doobie.util.log.LogEvent
@@ -20,6 +20,7 @@ import java.lang.String
 import java.sql.Clob
 import java.sql.NClob
 
+// This file is Auto-generated using FreeGen2.scala
 object nclob { module =>
 
   // Algebra of operations for NClob. Each accepts a visitor as an alternative to pattern-matching.
@@ -228,5 +229,16 @@ object nclob { module =>
       override def fromFuture[A](fut: NClobIO[Future[A]]): NClobIO[A] = module.fromFuture(fut)
       override def fromFutureCancelable[A](fut: NClobIO[(Future[A], NClobIO[Unit])]): NClobIO[A] = module.fromFutureCancelable(fut)
     }
+    
+  implicit def MonoidNClobIO[A : Monoid]: Monoid[NClobIO[A]] = new Monoid[NClobIO[A]] {
+    override def empty: NClobIO[A] = Applicative[NClobIO].pure(Monoid[A].empty)
+    override def combine(x: NClobIO[A], y: NClobIO[A]): NClobIO[A] =
+      Applicative[NClobIO].product(x, y).map { case (x, y) => Monoid[A].combine(x, y) }
+  }
+ 
+  implicit def SemigroupNClobIO[A : Semigroup]: Semigroup[NClobIO[A]] = new Semigroup[NClobIO[A]] {
+    override def combine(x: NClobIO[A], y: NClobIO[A]): NClobIO[A] =
+      Applicative[NClobIO].product(x, y).map { case (x, y) => Semigroup[A].combine(x, y) }
+  }  
 }
 

--- a/modules/free/src/main/scala/doobie/free/preparedstatement.scala
+++ b/modules/free/src/main/scala/doobie/free/preparedstatement.scala
@@ -4,7 +4,7 @@
 
 package doobie.free
 
-import cats.~>
+import cats.{~>, Applicative, Semigroup, Monoid}
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
 import doobie.util.log.LogEvent
@@ -37,6 +37,7 @@ import java.sql.Timestamp
 import java.sql.{ Array => SqlArray }
 import java.util.Calendar
 
+// This file is Auto-generated using FreeGen2.scala
 object preparedstatement { module =>
 
   // Algebra of operations for PreparedStatement. Each accepts a visitor as an alternative to pattern-matching.
@@ -88,6 +89,9 @@ object preparedstatement { module =>
       def clearWarnings: F[Unit]
       def close: F[Unit]
       def closeOnCompletion: F[Unit]
+      def enquoteIdentifier(a: String, b: Boolean): F[String]
+      def enquoteLiteral(a: String): F[String]
+      def enquoteNCharLiteral(a: String): F[String]
       def execute: F[Boolean]
       def execute(a: String): F[Boolean]
       def execute(a: String, b: Array[Int]): F[Boolean]
@@ -129,6 +133,7 @@ object preparedstatement { module =>
       def isCloseOnCompletion: F[Boolean]
       def isClosed: F[Boolean]
       def isPoolable: F[Boolean]
+      def isSimpleIdentifier(a: String): F[Boolean]
       def isWrapperFor(a: Class[_]): F[Boolean]
       def setArray(a: Int, b: SqlArray): F[Unit]
       def setAsciiStream(a: Int, b: InputStream): F[Unit]
@@ -264,6 +269,15 @@ object preparedstatement { module =>
     case object CloseOnCompletion extends PreparedStatementOp[Unit] {
       def visit[F[_]](v: Visitor[F]) = v.closeOnCompletion
     }
+    final case class EnquoteIdentifier(a: String, b: Boolean) extends PreparedStatementOp[String] {
+      def visit[F[_]](v: Visitor[F]) = v.enquoteIdentifier(a, b)
+    }
+    final case class EnquoteLiteral(a: String) extends PreparedStatementOp[String] {
+      def visit[F[_]](v: Visitor[F]) = v.enquoteLiteral(a)
+    }
+    final case class EnquoteNCharLiteral(a: String) extends PreparedStatementOp[String] {
+      def visit[F[_]](v: Visitor[F]) = v.enquoteNCharLiteral(a)
+    }
     case object Execute extends PreparedStatementOp[Boolean] {
       def visit[F[_]](v: Visitor[F]) = v.execute
     }
@@ -386,6 +400,9 @@ object preparedstatement { module =>
     }
     case object IsPoolable extends PreparedStatementOp[Boolean] {
       def visit[F[_]](v: Visitor[F]) = v.isPoolable
+    }
+    final case class IsSimpleIdentifier(a: String) extends PreparedStatementOp[Boolean] {
+      def visit[F[_]](v: Visitor[F]) = v.isSimpleIdentifier(a)
     }
     final case class IsWrapperFor(a: Class[_]) extends PreparedStatementOp[Boolean] {
       def visit[F[_]](v: Visitor[F]) = v.isWrapperFor(a)
@@ -602,6 +619,9 @@ object preparedstatement { module =>
   val clearWarnings: PreparedStatementIO[Unit] = FF.liftF(ClearWarnings)
   val close: PreparedStatementIO[Unit] = FF.liftF(Close)
   val closeOnCompletion: PreparedStatementIO[Unit] = FF.liftF(CloseOnCompletion)
+  def enquoteIdentifier(a: String, b: Boolean): PreparedStatementIO[String] = FF.liftF(EnquoteIdentifier(a, b))
+  def enquoteLiteral(a: String): PreparedStatementIO[String] = FF.liftF(EnquoteLiteral(a))
+  def enquoteNCharLiteral(a: String): PreparedStatementIO[String] = FF.liftF(EnquoteNCharLiteral(a))
   val execute: PreparedStatementIO[Boolean] = FF.liftF(Execute)
   def execute(a: String): PreparedStatementIO[Boolean] = FF.liftF(Execute1(a))
   def execute(a: String, b: Array[Int]): PreparedStatementIO[Boolean] = FF.liftF(Execute2(a, b))
@@ -643,6 +663,7 @@ object preparedstatement { module =>
   val isCloseOnCompletion: PreparedStatementIO[Boolean] = FF.liftF(IsCloseOnCompletion)
   val isClosed: PreparedStatementIO[Boolean] = FF.liftF(IsClosed)
   val isPoolable: PreparedStatementIO[Boolean] = FF.liftF(IsPoolable)
+  def isSimpleIdentifier(a: String): PreparedStatementIO[Boolean] = FF.liftF(IsSimpleIdentifier(a))
   def isWrapperFor(a: Class[_]): PreparedStatementIO[Boolean] = FF.liftF(IsWrapperFor(a))
   def setArray(a: Int, b: SqlArray): PreparedStatementIO[Unit] = FF.liftF(SetArray(a, b))
   def setAsciiStream(a: Int, b: InputStream): PreparedStatementIO[Unit] = FF.liftF(SetAsciiStream(a, b))
@@ -725,5 +746,16 @@ object preparedstatement { module =>
       override def fromFuture[A](fut: PreparedStatementIO[Future[A]]): PreparedStatementIO[A] = module.fromFuture(fut)
       override def fromFutureCancelable[A](fut: PreparedStatementIO[(Future[A], PreparedStatementIO[Unit])]): PreparedStatementIO[A] = module.fromFutureCancelable(fut)
     }
+    
+  implicit def MonoidPreparedStatementIO[A : Monoid]: Monoid[PreparedStatementIO[A]] = new Monoid[PreparedStatementIO[A]] {
+    override def empty: PreparedStatementIO[A] = Applicative[PreparedStatementIO].pure(Monoid[A].empty)
+    override def combine(x: PreparedStatementIO[A], y: PreparedStatementIO[A]): PreparedStatementIO[A] =
+      Applicative[PreparedStatementIO].product(x, y).map { case (x, y) => Monoid[A].combine(x, y) }
+  }
+ 
+  implicit def SemigroupPreparedStatementIO[A : Semigroup]: Semigroup[PreparedStatementIO[A]] = new Semigroup[PreparedStatementIO[A]] {
+    override def combine(x: PreparedStatementIO[A], y: PreparedStatementIO[A]): PreparedStatementIO[A] =
+      Applicative[PreparedStatementIO].product(x, y).map { case (x, y) => Semigroup[A].combine(x, y) }
+  }  
 }
 

--- a/modules/free/src/main/scala/doobie/free/ref.scala
+++ b/modules/free/src/main/scala/doobie/free/ref.scala
@@ -4,7 +4,7 @@
 
 package doobie.free
 
-import cats.~>
+import cats.{~>, Applicative, Semigroup, Monoid}
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
 import doobie.util.log.LogEvent
@@ -16,6 +16,7 @@ import java.lang.String
 import java.sql.Ref
 import java.util.Map
 
+// This file is Auto-generated using FreeGen2.scala
 object ref { module =>
 
   // Algebra of operations for Ref. Each accepts a visitor as an alternative to pattern-matching.
@@ -179,5 +180,16 @@ object ref { module =>
       override def fromFuture[A](fut: RefIO[Future[A]]): RefIO[A] = module.fromFuture(fut)
       override def fromFutureCancelable[A](fut: RefIO[(Future[A], RefIO[Unit])]): RefIO[A] = module.fromFutureCancelable(fut)
     }
+    
+  implicit def MonoidRefIO[A : Monoid]: Monoid[RefIO[A]] = new Monoid[RefIO[A]] {
+    override def empty: RefIO[A] = Applicative[RefIO].pure(Monoid[A].empty)
+    override def combine(x: RefIO[A], y: RefIO[A]): RefIO[A] =
+      Applicative[RefIO].product(x, y).map { case (x, y) => Monoid[A].combine(x, y) }
+  }
+ 
+  implicit def SemigroupRefIO[A : Semigroup]: Semigroup[RefIO[A]] = new Semigroup[RefIO[A]] {
+    override def combine(x: RefIO[A], y: RefIO[A]): RefIO[A] =
+      Applicative[RefIO].product(x, y).map { case (x, y) => Semigroup[A].combine(x, y) }
+  }  
 }
 

--- a/modules/free/src/main/scala/doobie/free/resultset.scala
+++ b/modules/free/src/main/scala/doobie/free/resultset.scala
@@ -4,7 +4,7 @@
 
 package doobie.free
 
-import cats.~>
+import cats.{~>, Applicative, Semigroup, Monoid}
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
 import doobie.util.log.LogEvent
@@ -36,6 +36,7 @@ import java.sql.{ Array => SqlArray }
 import java.util.Calendar
 import java.util.Map
 
+// This file is Auto-generated using FreeGen2.scala
 object resultset { module =>
 
   // Algebra of operations for ResultSet. Each accepts a visitor as an alternative to pattern-matching.
@@ -1134,5 +1135,16 @@ object resultset { module =>
       override def fromFuture[A](fut: ResultSetIO[Future[A]]): ResultSetIO[A] = module.fromFuture(fut)
       override def fromFutureCancelable[A](fut: ResultSetIO[(Future[A], ResultSetIO[Unit])]): ResultSetIO[A] = module.fromFutureCancelable(fut)
     }
+    
+  implicit def MonoidResultSetIO[A : Monoid]: Monoid[ResultSetIO[A]] = new Monoid[ResultSetIO[A]] {
+    override def empty: ResultSetIO[A] = Applicative[ResultSetIO].pure(Monoid[A].empty)
+    override def combine(x: ResultSetIO[A], y: ResultSetIO[A]): ResultSetIO[A] =
+      Applicative[ResultSetIO].product(x, y).map { case (x, y) => Monoid[A].combine(x, y) }
+  }
+ 
+  implicit def SemigroupResultSetIO[A : Semigroup]: Semigroup[ResultSetIO[A]] = new Semigroup[ResultSetIO[A]] {
+    override def combine(x: ResultSetIO[A], y: ResultSetIO[A]): ResultSetIO[A] =
+      Applicative[ResultSetIO].product(x, y).map { case (x, y) => Semigroup[A].combine(x, y) }
+  }  
 }
 

--- a/modules/free/src/main/scala/doobie/free/sqldata.scala
+++ b/modules/free/src/main/scala/doobie/free/sqldata.scala
@@ -4,7 +4,7 @@
 
 package doobie.free
 
-import cats.~>
+import cats.{~>, Applicative, Semigroup, Monoid}
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
 import doobie.util.log.LogEvent
@@ -17,6 +17,7 @@ import java.sql.SQLData
 import java.sql.SQLInput
 import java.sql.SQLOutput
 
+// This file is Auto-generated using FreeGen2.scala
 object sqldata { module =>
 
   // Algebra of operations for SQLData. Each accepts a visitor as an alternative to pattern-matching.
@@ -175,5 +176,16 @@ object sqldata { module =>
       override def fromFuture[A](fut: SQLDataIO[Future[A]]): SQLDataIO[A] = module.fromFuture(fut)
       override def fromFutureCancelable[A](fut: SQLDataIO[(Future[A], SQLDataIO[Unit])]): SQLDataIO[A] = module.fromFutureCancelable(fut)
     }
+    
+  implicit def MonoidSQLDataIO[A : Monoid]: Monoid[SQLDataIO[A]] = new Monoid[SQLDataIO[A]] {
+    override def empty: SQLDataIO[A] = Applicative[SQLDataIO].pure(Monoid[A].empty)
+    override def combine(x: SQLDataIO[A], y: SQLDataIO[A]): SQLDataIO[A] =
+      Applicative[SQLDataIO].product(x, y).map { case (x, y) => Monoid[A].combine(x, y) }
+  }
+ 
+  implicit def SemigroupSQLDataIO[A : Semigroup]: Semigroup[SQLDataIO[A]] = new Semigroup[SQLDataIO[A]] {
+    override def combine(x: SQLDataIO[A], y: SQLDataIO[A]): SQLDataIO[A] =
+      Applicative[SQLDataIO].product(x, y).map { case (x, y) => Semigroup[A].combine(x, y) }
+  }  
 }
 

--- a/modules/free/src/main/scala/doobie/free/sqlinput.scala
+++ b/modules/free/src/main/scala/doobie/free/sqlinput.scala
@@ -4,7 +4,7 @@
 
 package doobie.free
 
-import cats.~>
+import cats.{~>, Applicative, Semigroup, Monoid}
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
 import doobie.util.log.LogEvent
@@ -30,6 +30,7 @@ import java.sql.Time
 import java.sql.Timestamp
 import java.sql.{ Array => SqlArray }
 
+// This file is Auto-generated using FreeGen2.scala
 object sqlinput { module =>
 
   // Algebra of operations for SQLInput. Each accepts a visitor as an alternative to pattern-matching.
@@ -313,5 +314,16 @@ object sqlinput { module =>
       override def fromFuture[A](fut: SQLInputIO[Future[A]]): SQLInputIO[A] = module.fromFuture(fut)
       override def fromFutureCancelable[A](fut: SQLInputIO[(Future[A], SQLInputIO[Unit])]): SQLInputIO[A] = module.fromFutureCancelable(fut)
     }
+    
+  implicit def MonoidSQLInputIO[A : Monoid]: Monoid[SQLInputIO[A]] = new Monoid[SQLInputIO[A]] {
+    override def empty: SQLInputIO[A] = Applicative[SQLInputIO].pure(Monoid[A].empty)
+    override def combine(x: SQLInputIO[A], y: SQLInputIO[A]): SQLInputIO[A] =
+      Applicative[SQLInputIO].product(x, y).map { case (x, y) => Monoid[A].combine(x, y) }
+  }
+ 
+  implicit def SemigroupSQLInputIO[A : Semigroup]: Semigroup[SQLInputIO[A]] = new Semigroup[SQLInputIO[A]] {
+    override def combine(x: SQLInputIO[A], y: SQLInputIO[A]): SQLInputIO[A] =
+      Applicative[SQLInputIO].product(x, y).map { case (x, y) => Semigroup[A].combine(x, y) }
+  }  
 }
 

--- a/modules/free/src/main/scala/doobie/free/sqloutput.scala
+++ b/modules/free/src/main/scala/doobie/free/sqloutput.scala
@@ -4,7 +4,7 @@
 
 package doobie.free
 
-import cats.~>
+import cats.{~>, Applicative, Semigroup, Monoid}
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
 import doobie.util.log.LogEvent
@@ -32,6 +32,7 @@ import java.sql.Time
 import java.sql.Timestamp
 import java.sql.{ Array => SqlArray }
 
+// This file is Auto-generated using FreeGen2.scala
 object sqloutput { module =>
 
   // Algebra of operations for SQLOutput. Each accepts a visitor as an alternative to pattern-matching.
@@ -315,5 +316,16 @@ object sqloutput { module =>
       override def fromFuture[A](fut: SQLOutputIO[Future[A]]): SQLOutputIO[A] = module.fromFuture(fut)
       override def fromFutureCancelable[A](fut: SQLOutputIO[(Future[A], SQLOutputIO[Unit])]): SQLOutputIO[A] = module.fromFutureCancelable(fut)
     }
+    
+  implicit def MonoidSQLOutputIO[A : Monoid]: Monoid[SQLOutputIO[A]] = new Monoid[SQLOutputIO[A]] {
+    override def empty: SQLOutputIO[A] = Applicative[SQLOutputIO].pure(Monoid[A].empty)
+    override def combine(x: SQLOutputIO[A], y: SQLOutputIO[A]): SQLOutputIO[A] =
+      Applicative[SQLOutputIO].product(x, y).map { case (x, y) => Monoid[A].combine(x, y) }
+  }
+ 
+  implicit def SemigroupSQLOutputIO[A : Semigroup]: Semigroup[SQLOutputIO[A]] = new Semigroup[SQLOutputIO[A]] {
+    override def combine(x: SQLOutputIO[A], y: SQLOutputIO[A]): SQLOutputIO[A] =
+      Applicative[SQLOutputIO].product(x, y).map { case (x, y) => Semigroup[A].combine(x, y) }
+  }  
 }
 

--- a/modules/postgres/src/main/scala/doobie/postgres/free/copyin.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/free/copyin.scala
@@ -4,7 +4,7 @@
 
 package doobie.postgres.free
 
-import cats.~>
+import cats.{~>, Applicative, Semigroup, Monoid}
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
 import doobie.util.log.LogEvent
@@ -15,6 +15,7 @@ import scala.concurrent.duration.FiniteDuration
 import org.postgresql.copy.{ CopyIn => PGCopyIn }
 import org.postgresql.util.ByteStreamWriter
 
+// This file is Auto-generated using FreeGen2.scala
 object copyin { module =>
 
   // Algebra of operations for PGCopyIn. Each accepts a visitor as an alternative to pattern-matching.
@@ -208,5 +209,16 @@ object copyin { module =>
       override def fromFuture[A](fut: CopyInIO[Future[A]]): CopyInIO[A] = module.fromFuture(fut)
       override def fromFutureCancelable[A](fut: CopyInIO[(Future[A], CopyInIO[Unit])]): CopyInIO[A] = module.fromFutureCancelable(fut)
     }
+    
+  implicit def MonoidCopyInIO[A : Monoid]: Monoid[CopyInIO[A]] = new Monoid[CopyInIO[A]] {
+    override def empty: CopyInIO[A] = Applicative[CopyInIO].pure(Monoid[A].empty)
+    override def combine(x: CopyInIO[A], y: CopyInIO[A]): CopyInIO[A] =
+      Applicative[CopyInIO].product(x, y).map { case (x, y) => Monoid[A].combine(x, y) }
+  }
+ 
+  implicit def SemigroupCopyInIO[A : Semigroup]: Semigroup[CopyInIO[A]] = new Semigroup[CopyInIO[A]] {
+    override def combine(x: CopyInIO[A], y: CopyInIO[A]): CopyInIO[A] =
+      Applicative[CopyInIO].product(x, y).map { case (x, y) => Semigroup[A].combine(x, y) }
+  }  
 }
 

--- a/modules/postgres/src/main/scala/doobie/postgres/free/copymanager.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/free/copymanager.scala
@@ -4,7 +4,7 @@
 
 package doobie.postgres.free
 
-import cats.~>
+import cats.{~>, Applicative, Semigroup, Monoid}
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
 import doobie.util.log.LogEvent
@@ -23,6 +23,7 @@ import org.postgresql.copy.{ CopyManager => PGCopyManager }
 import org.postgresql.copy.{ CopyOut => PGCopyOut }
 import org.postgresql.util.ByteStreamWriter
 
+// This file is Auto-generated using FreeGen2.scala
 object copymanager { module =>
 
   // Algebra of operations for PGCopyManager. Each accepts a visitor as an alternative to pattern-matching.
@@ -216,5 +217,16 @@ object copymanager { module =>
       override def fromFuture[A](fut: CopyManagerIO[Future[A]]): CopyManagerIO[A] = module.fromFuture(fut)
       override def fromFutureCancelable[A](fut: CopyManagerIO[(Future[A], CopyManagerIO[Unit])]): CopyManagerIO[A] = module.fromFutureCancelable(fut)
     }
+    
+  implicit def MonoidCopyManagerIO[A : Monoid]: Monoid[CopyManagerIO[A]] = new Monoid[CopyManagerIO[A]] {
+    override def empty: CopyManagerIO[A] = Applicative[CopyManagerIO].pure(Monoid[A].empty)
+    override def combine(x: CopyManagerIO[A], y: CopyManagerIO[A]): CopyManagerIO[A] =
+      Applicative[CopyManagerIO].product(x, y).map { case (x, y) => Monoid[A].combine(x, y) }
+  }
+ 
+  implicit def SemigroupCopyManagerIO[A : Semigroup]: Semigroup[CopyManagerIO[A]] = new Semigroup[CopyManagerIO[A]] {
+    override def combine(x: CopyManagerIO[A], y: CopyManagerIO[A]): CopyManagerIO[A] =
+      Applicative[CopyManagerIO].product(x, y).map { case (x, y) => Semigroup[A].combine(x, y) }
+  }  
 }
 

--- a/modules/postgres/src/main/scala/doobie/postgres/free/copyout.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/free/copyout.scala
@@ -4,7 +4,7 @@
 
 package doobie.postgres.free
 
-import cats.~>
+import cats.{~>, Applicative, Semigroup, Monoid}
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
 import doobie.util.log.LogEvent
@@ -14,6 +14,7 @@ import scala.concurrent.duration.FiniteDuration
 
 import org.postgresql.copy.{ CopyOut => PGCopyOut }
 
+// This file is Auto-generated using FreeGen2.scala
 object copyout { module =>
 
   // Algebra of operations for PGCopyOut. Each accepts a visitor as an alternative to pattern-matching.
@@ -197,5 +198,16 @@ object copyout { module =>
       override def fromFuture[A](fut: CopyOutIO[Future[A]]): CopyOutIO[A] = module.fromFuture(fut)
       override def fromFutureCancelable[A](fut: CopyOutIO[(Future[A], CopyOutIO[Unit])]): CopyOutIO[A] = module.fromFutureCancelable(fut)
     }
+    
+  implicit def MonoidCopyOutIO[A : Monoid]: Monoid[CopyOutIO[A]] = new Monoid[CopyOutIO[A]] {
+    override def empty: CopyOutIO[A] = Applicative[CopyOutIO].pure(Monoid[A].empty)
+    override def combine(x: CopyOutIO[A], y: CopyOutIO[A]): CopyOutIO[A] =
+      Applicative[CopyOutIO].product(x, y).map { case (x, y) => Monoid[A].combine(x, y) }
+  }
+ 
+  implicit def SemigroupCopyOutIO[A : Semigroup]: Semigroup[CopyOutIO[A]] = new Semigroup[CopyOutIO[A]] {
+    override def combine(x: CopyOutIO[A], y: CopyOutIO[A]): CopyOutIO[A] =
+      Applicative[CopyOutIO].product(x, y).map { case (x, y) => Semigroup[A].combine(x, y) }
+  }  
 }
 

--- a/modules/postgres/src/main/scala/doobie/postgres/free/kleisliinterpreter.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/free/kleisliinterpreter.scala
@@ -19,6 +19,8 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.io.Reader
 import java.io.Writer
+import java.lang.Class
+import java.lang.String
 import org.postgresql.PGConnection
 import org.postgresql.copy.{ CopyIn => PGCopyIn }
 import org.postgresql.copy.{ CopyManager => PGCopyManager }

--- a/modules/postgres/src/main/scala/doobie/postgres/free/largeobject.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/free/largeobject.scala
@@ -4,7 +4,7 @@
 
 package doobie.postgres.free
 
-import cats.~>
+import cats.{~>, Applicative, Semigroup, Monoid}
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
 import doobie.util.log.LogEvent
@@ -16,6 +16,7 @@ import java.io.InputStream
 import java.io.OutputStream
 import org.postgresql.largeobject.LargeObject
 
+// This file is Auto-generated using FreeGen2.scala
 object largeobject { module =>
 
   // Algebra of operations for LargeObject. Each accepts a visitor as an alternative to pattern-matching.
@@ -254,5 +255,16 @@ object largeobject { module =>
       override def fromFuture[A](fut: LargeObjectIO[Future[A]]): LargeObjectIO[A] = module.fromFuture(fut)
       override def fromFutureCancelable[A](fut: LargeObjectIO[(Future[A], LargeObjectIO[Unit])]): LargeObjectIO[A] = module.fromFutureCancelable(fut)
     }
+    
+  implicit def MonoidLargeObjectIO[A : Monoid]: Monoid[LargeObjectIO[A]] = new Monoid[LargeObjectIO[A]] {
+    override def empty: LargeObjectIO[A] = Applicative[LargeObjectIO].pure(Monoid[A].empty)
+    override def combine(x: LargeObjectIO[A], y: LargeObjectIO[A]): LargeObjectIO[A] =
+      Applicative[LargeObjectIO].product(x, y).map { case (x, y) => Monoid[A].combine(x, y) }
+  }
+ 
+  implicit def SemigroupLargeObjectIO[A : Semigroup]: Semigroup[LargeObjectIO[A]] = new Semigroup[LargeObjectIO[A]] {
+    override def combine(x: LargeObjectIO[A], y: LargeObjectIO[A]): LargeObjectIO[A] =
+      Applicative[LargeObjectIO].product(x, y).map { case (x, y) => Semigroup[A].combine(x, y) }
+  }  
 }
 

--- a/modules/postgres/src/main/scala/doobie/postgres/free/largeobjectmanager.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/free/largeobjectmanager.scala
@@ -4,7 +4,7 @@
 
 package doobie.postgres.free
 
-import cats.~>
+import cats.{~>, Applicative, Semigroup, Monoid}
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
 import doobie.util.log.LogEvent
@@ -15,6 +15,7 @@ import scala.concurrent.duration.FiniteDuration
 import org.postgresql.largeobject.LargeObject
 import org.postgresql.largeobject.LargeObjectManager
 
+// This file is Auto-generated using FreeGen2.scala
 object largeobjectmanager { module =>
 
   // Algebra of operations for LargeObjectManager. Each accepts a visitor as an alternative to pattern-matching.
@@ -208,5 +209,16 @@ object largeobjectmanager { module =>
       override def fromFuture[A](fut: LargeObjectManagerIO[Future[A]]): LargeObjectManagerIO[A] = module.fromFuture(fut)
       override def fromFutureCancelable[A](fut: LargeObjectManagerIO[(Future[A], LargeObjectManagerIO[Unit])]): LargeObjectManagerIO[A] = module.fromFutureCancelable(fut)
     }
+    
+  implicit def MonoidLargeObjectManagerIO[A : Monoid]: Monoid[LargeObjectManagerIO[A]] = new Monoid[LargeObjectManagerIO[A]] {
+    override def empty: LargeObjectManagerIO[A] = Applicative[LargeObjectManagerIO].pure(Monoid[A].empty)
+    override def combine(x: LargeObjectManagerIO[A], y: LargeObjectManagerIO[A]): LargeObjectManagerIO[A] =
+      Applicative[LargeObjectManagerIO].product(x, y).map { case (x, y) => Monoid[A].combine(x, y) }
+  }
+ 
+  implicit def SemigroupLargeObjectManagerIO[A : Semigroup]: Semigroup[LargeObjectManagerIO[A]] = new Semigroup[LargeObjectManagerIO[A]] {
+    override def combine(x: LargeObjectManagerIO[A], y: LargeObjectManagerIO[A]): LargeObjectManagerIO[A] =
+      Applicative[LargeObjectManagerIO].product(x, y).map { case (x, y) => Semigroup[A].combine(x, y) }
+  }  
 }
 

--- a/modules/postgres/src/main/scala/doobie/postgres/free/pgconnection.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/free/pgconnection.scala
@@ -4,7 +4,7 @@
 
 package doobie.postgres.free
 
-import cats.~>
+import cats.{~>, Applicative, Semigroup, Monoid}
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free => FF } // alias because some algebras have an op called Free
 import doobie.util.log.LogEvent
@@ -24,6 +24,7 @@ import org.postgresql.jdbc.PreferQueryMode
 import org.postgresql.largeobject.LargeObjectManager
 import org.postgresql.replication.PGReplicationConnection
 
+// This file is Auto-generated using FreeGen2.scala
 object pgconnection { module =>
 
   // Algebra of operations for PGConnection. Each accepts a visitor as an alternative to pattern-matching.
@@ -277,5 +278,16 @@ object pgconnection { module =>
       override def fromFuture[A](fut: PGConnectionIO[Future[A]]): PGConnectionIO[A] = module.fromFuture(fut)
       override def fromFutureCancelable[A](fut: PGConnectionIO[(Future[A], PGConnectionIO[Unit])]): PGConnectionIO[A] = module.fromFutureCancelable(fut)
     }
+    
+  implicit def MonoidPGConnectionIO[A : Monoid]: Monoid[PGConnectionIO[A]] = new Monoid[PGConnectionIO[A]] {
+    override def empty: PGConnectionIO[A] = Applicative[PGConnectionIO].pure(Monoid[A].empty)
+    override def combine(x: PGConnectionIO[A], y: PGConnectionIO[A]): PGConnectionIO[A] =
+      Applicative[PGConnectionIO].product(x, y).map { case (x, y) => Monoid[A].combine(x, y) }
+  }
+ 
+  implicit def SemigroupPGConnectionIO[A : Semigroup]: Semigroup[PGConnectionIO[A]] = new Semigroup[PGConnectionIO[A]] {
+    override def combine(x: PGConnectionIO[A], y: PGConnectionIO[A]): PGConnectionIO[A] =
+      Applicative[PGConnectionIO].product(x, y).map { case (x, y) => Semigroup[A].combine(x, y) }
+  }  
 }
 


### PR DESCRIPTION
- compile command will now always run freegen2 first
- Allow listing classes to exclude from imports in the generated kleisliinterpreter.scala file to avoid unused import warning
- Add check in CI and fail if there are diffs