### PR TITLE
Add andFallbackFalse and orFallbackTrue fragment helpers

### DIFF
--- a/modules/core/src/main/scala/doobie/util/fragments.scala
+++ b/modules/core/src/main/scala/doobie/util/fragments.scala
@@ -53,6 +53,12 @@ object fragments {
     case None => fr"${true}"
   }
 
+  /** Returns `(f1 AND f2 AND ... fn)`, or `false` for empty `fs`. */
+  def andFallbackFalse[F[_]: Foldable](fs: F[Fragment]): Fragment = fs.toList.toNel match {
+    case Some(fs) => parentheses(fs.intercalate(fr"AND"))
+    case None => fr"${false}"
+  }
+
   /** Returns `(f1 AND f2 AND ... fn)` for all defined fragments. */
   def andOpt(fs: Option[Fragment]*): Fragment =
     and(fs.toList.unite)
@@ -61,10 +67,16 @@ object fragments {
   def or(f1: Fragment, f2: Fragment, fs: Fragment*): Fragment =
     or(f1 :: f2 :: fs.toList)
 
-  /** Returns `(f1 OR f2 OR ... fn)`, or `true` for empty `fs`. */
+  /** Returns `(f1 OR f2 OR ... fn)`, or `false` for empty `fs`. */
   def or[F[_]: Foldable](fs: F[Fragment]): Fragment = fs.toList.toNel match {
     case Some(fs) => parentheses(fs.intercalate(fr"OR"))
     case None => fr"${false}"
+  }
+
+  /** Returns `(f1 OR f2 OR ... fn)`, or `true` for empty `fs`. */
+  def orFallbackTrue[F[_]: Foldable](fs: F[Fragment]): Fragment = fs.toList.toNel match {
+    case Some(fs) => parentheses(fs.intercalate(fr"OR"))
+    case None => fr"${true}"
   }
 
   /** Returns `(f1 OR f2 OR ... fn)` for all defined fragments. */


### PR DESCRIPTION
closes https://github.com/tpolecat/doobie/issues/1850

From the example of @jatcwang  https://github.com/tpolecat/doobie/issues/1850#issuecomment-1546765160
it would be used like this:
```scala
  val role = 1
  val filters = List(fr"") // but could be empty
  and(fr"user_role = ${role}", orFallbackTrue(filters))
```
