### PR TITLE
Rework fragment helpers

### DIFF
--- a/modules/core/src/test/scala/doobie/util/FragmentsSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/FragmentsSuite.scala
@@ -20,124 +20,253 @@ class FragmentsSuite extends munit.FunSuite {
     "sa", ""
   )
 
-  val nel  = List(1,2,3).toNel.getOrElse(sys.error("unpossible"))
-  val fs   = List(1,2,3).map(n => fr"$n")
-  val ofs  = List(1,2,3).map(n => Some(fr"$n").filter(_ => n % 2 =!= 0))
+  val nelInt  = NonEmptyList.of(1,2,3)
+  val listInt = nelInt.toList
+  val nel1 = NonEmptyList.of(1).map(i => fr"$i")
+  val nel  = NonEmptyList.of(1,2,3).map(i => fr"$i")
+  val fs   = nel.toList
+  val someF: Option[Fragment] = Some(fr"${1}")
+  val noneF: Option[Fragment] = None
+  val ofs  = List(Some(fr"${1}"), None, Some(fr"${3}"))
 
   test("values for one column") {
-    assertEquals(values(nel).query[Unit].sql, "VALUES (?) , (?) , (?) ")
+    assertEquals(values(nelInt).query[Unit].sql, "VALUES (?) , (?) , (?) ")
   }
 
   test("values for two columns") {
     assertEquals(values(NonEmptyList.of((1, true), (2, false))).query[Unit].sql, "VALUES (?,?) , (?,?) ")
   }
-
-  test("in for one column") {
-    assertEquals(in(fr"foo", nel).query[Unit].sql, "(foo IN (? , ? , ? ) ) ")
+  
+  test("in (1-column varargs)") {
+    assertEquals(in(fr"foo", 1,2,3).query[Unit].sql, "(foo IN (? , ? , ? ) ) ")
   }
 
-  test("in for two columns") {
+  test("in (1-column Reducible many)") {
+    assertEquals(in(fr"foo", nelInt).query[Unit].sql, "(foo IN (? , ? , ? ) ) ")
+  }
+
+  test("inOpt (1-column Reducible empty)") {
+    assertEquals(inOpt(fr"foo", List.empty[Int]).map(_.query[Unit].sql), None)
+  }
+
+  test("inOpt (1-column Reducible many)") {
+    assertEquals(inOpt(fr"foo", listInt).map(_.query[Unit].sql), Some("(foo IN (? , ? , ? ) ) "))
+  }
+
+  test("in (2-column varargs)") {
     assertEquals(in(fr"foo", NonEmptyList.of((1, true), (2, false))).query[Unit].sql, "(foo IN ((?,?), (?,?)) ) ")
   }
 
-  test("notIn") {
-    assertEquals(notIn(fr"foo", nel).query[Unit].sql, "(foo NOT IN (? , ? , ? ) ) ")
+  test("notIn (varargs many)") {
+    assertEquals(notIn(fr"foo", 1, 2, 3).query[Unit].sql, "(foo NOT IN (? , ? , ? ) ) ")
   }
 
-  test("and (many)") {
-    assertEquals(and(fs).query[Unit].sql, "(? AND ? AND ? ) ")
+  test("notIn (Reducible 1)") {
+    assertEquals(notIn(fr"foo", NonEmptyList.of(1)).query[Unit].sql, "(foo NOT IN (? ) ) ")
   }
 
-  test("and (two)") {
+  test("notIn (Reducible many)") {
+    assertEquals(notIn(fr"foo", nelInt).query[Unit].sql, "(foo NOT IN (? , ? , ? ) ) ")
+  }
+
+  test("notInOpt (Foldable empty)") {
+    assertEquals(notInOpt(fr"foo", List.empty[Int]).map(_.query[Unit].sql), None)
+  }
+  
+  test("notInOpt (Foldable 1)") {
+    assertEquals(notInOpt(fr"foo", List(1)).map(_.query[Unit].sql), Some("(foo NOT IN (? ) ) "))
+  }
+
+  test("notInOpt (Foldable many)") {
+    assertEquals(notInOpt(fr"foo", listInt).map(_.query[Unit].sql), Some("(foo NOT IN (? , ? , ? ) ) "))
+  }
+
+  test("and (vararg 2)") {
     assertEquals(and(fs(0), fs(1)).query[Unit].sql, "(? AND ? ) ")
   }
 
-  test("and (empty)") {
-    assertEquals(and(List[Fragment]()).query[Unit].sql, "? ")
+  test("and (Reducible 1)") {
+    assertEquals(and(nel1).query[Unit].sql, "(? ) ")
   }
 
-  test("andOpt (many)") {
-    assertEquals(andOpt(ofs: _*).query[Unit].sql, "(? AND ? ) ")
+  test("and (Reducible many)") {
+    assertEquals(and(nel).query[Unit].sql, "(? AND ? AND ? ) ")
   }
 
-  test("andOpt (one)") {
-    assertEquals(andOpt(ofs(0)).query[Unit].sql, "(? ) ")
+  test("andOpt (vararg many none)") {
+    assertEquals(andOpt(None, None).map(_.query[Unit].sql), None)
   }
 
-  test("andOpt (none)") {
-    assertEquals(andOpt(None, None).query[Unit].sql, "? ")
+  test("andOpt (vararg 1 Some)") {
+    assertEquals(andOpt(noneF, someF).map(_.query[Unit].sql), Some("(? ) "))
   }
 
-  test("or (many)") {
-    assertEquals(or(fs).query[Unit].sql, "(? OR ? OR ? ) ")
+  test("andOpt (vararg 2 Some)") {
+    assertEquals(andOpt(someF, someF).map(_.query[Unit].sql), Some("(? AND ? ) "))
   }
 
-  test("or (two)") {
+  test("andOpt (Foldable empty)") {
+    assertEquals(andOpt(List.empty[Fragment]).map(_.query[Unit].sql), None)
+  }
+
+  test("andOpt (Foldable 1)") {
+    assertEquals(andOpt(nel.take(1)).map(_.query[Unit].sql), Some("(? ) "))
+  }
+
+  test("andOpt (Foldable many)") {
+    assertEquals(andOpt(nel.toList).map(_.query[Unit].sql), Some("(? AND ? AND ? ) "))
+  }
+
+  test("andOpt (list empty)") {
+    assertEquals(andOpt(List.empty[Fragment]).map(_.query[Unit].sql), None)
+  }
+  
+  test("or (vararg 2)") {
     assertEquals(or(fs(0), fs(1)).query[Unit].sql, "(? OR ? ) ")
   }
 
-  test("or (empty)") {
-    assertEquals(or(List[Fragment]()).query[Unit].sql, "? ")
+  test("or (Reducible 1)") {
+    assertEquals(or(nel1).query[Unit].sql, "(? ) ")
   }
 
-  test("orOpt (many)") {
-    assertEquals(orOpt(ofs: _*).query[Unit].sql, "(? OR ? ) ")
+  test("or (Reducible many)") {
+    assertEquals(or(nel).query[Unit].sql, "(? OR ? OR ? ) ")
   }
 
-  test("orOpt (one)") {
-    assertEquals(orOpt(ofs(0)).query[Unit].sql, "(? ) ")
+  test("orOpt (vararg many none)") {
+    assertEquals(orOpt(None, None).map(_.query[Unit].sql), None)
   }
 
-  test("orOpt (none)") {
-    assertEquals(orOpt(None, None).query[Unit].sql, "? ")
+  test("orOpt (vararg 1 Some)") {
+    assertEquals(orOpt(noneF, someF).map(_.query[Unit].sql), Some("(? ) "))
   }
 
-  test("whereAnd (many)") {
-    assertEquals(whereAnd(fs).query[Unit].sql, "WHERE (? AND ? AND ? ) ")
+  test("orOpt (vararg 2 Some)") {
+    assertEquals(orOpt(someF, someF).map(_.query[Unit].sql), Some("(? OR ? ) "))
   }
 
-  test("whereAnd (single)") {
-    assertEquals(whereAnd(fs(0)).query[Unit].sql, "WHERE (? ) ")
+  test("orOpt (Foldable empty)") {
+    assertEquals(orOpt(List.empty[Fragment]).map(_.query[Unit].sql), None)
   }
 
-  test("whereAnd (empty)") {
-    assertEquals(whereAnd(List[Fragment]()).query[Unit].sql, "")
+  test("orOpt (Foldable 1)") {
+    assertEquals(orOpt(nel.take(1)).map(_.query[Unit].sql), Some("(? ) "))
   }
 
-  test("whereAndOpt (many)") {
-    assertEquals(whereAndOpt(ofs: _*).query[Unit].sql, "WHERE (? AND ? ) ")
+  test("orOpt (Foldable many)") {
+    assertEquals(orOpt(nel.toList).map(_.query[Unit].sql), Some("(? OR ? OR ? ) "))
   }
 
-  test("whereAndOpt (one)") {
-    assertEquals(whereAndOpt(ofs(0)).query[Unit].sql, "WHERE (? ) ")
+  test("orOpt (list empty)") {
+    assertEquals(orOpt(List.empty[Fragment]).map(_.query[Unit].sql), None)
   }
 
-  test("whereAndOpt (none)") {
+  test("whereAnd (varargs single)") {
+    assertEquals(whereAnd(fs(0)).query[Unit].sql, "WHERE ? ")
+  }
+
+  test("whereAnd (varargs many)") {
+    assertEquals(whereAnd(fs(0), fs(0), fs(0)).query[Unit].sql, "WHERE ? AND ? AND ? ")
+  }
+  
+  test("whereAnd (Reducible 1)") {
+    assertEquals(whereAnd(nel1).query[Unit].sql, "WHERE ? ")
+  }
+  
+  test("whereAnd (Reducible many)") {
+    assertEquals(whereAnd(nel).query[Unit].sql, "WHERE ? AND ? AND ? ")
+  }
+
+  test("whereAndOpt (varargs many Some)") {
+    assertEquals(whereAndOpt(someF, someF).query[Unit].sql, "WHERE ? AND ? ")
+  }
+
+  test("whereAndOpt (varargs 1 Some)") {
+    assertEquals(whereAndOpt(ofs(0)).query[Unit].sql, "WHERE ? ")
+  }
+
+  test("whereAndOpt (varargs all none)") {
     assertEquals(whereAndOpt(None, None).query[Unit].sql, "")
   }
-
-  test("whereOr (many)") {
-    assertEquals(whereOr(fs).query[Unit].sql, "WHERE (? OR ? OR ? ) ")
+  
+  test("whereAndOpt (Foldable empty)") {
+    assertEquals(whereAndOpt(List.empty[Fragment]).query[Unit].sql, "")
   }
 
-  test("whereOr (single)") {
-    assertEquals(whereOr(fs(0)).query[Unit].sql, "WHERE (? ) ")
+  test("whereAndOpt (Foldable many)") {
+    assertEquals(whereAndOpt(fs).query[Unit].sql, "WHERE ? AND ? AND ? ")
   }
 
-  test("whereOr (empty)") {
-    assertEquals(whereOr(List[Fragment]()).query[Unit].sql, "")
+  test("whereOr (varargs single)") {
+    assertEquals(whereOr(fs(0)).query[Unit].sql, "WHERE ? ")
   }
 
-  test("whereOrOpt (many)") {
-    assertEquals(whereOrOpt(ofs: _*).query[Unit].sql, "WHERE (? OR ? ) ")
+  test("whereOr (varargs many)") {
+    assertEquals(whereOr(fs(0), fs(0), fs(0)).query[Unit].sql, "WHERE ? OR ? OR ? ")
   }
 
-  test("whereOrOpt (one)") {
-    assertEquals(whereOrOpt(ofs(0)).query[Unit].sql, "WHERE (? ) ")
+  test("whereOr (Reducible 1)") {
+    assertEquals(whereOr(nel1).query[Unit].sql, "WHERE ? ")
   }
 
-  test("whereOrOpt (none)") {
+  test("whereOr (Reducible many)") {
+    assertEquals(whereOr(nel).query[Unit].sql, "WHERE ? OR ? OR ? ")
+  }
+
+  test("whereOrOpt (varargs many Some)") {
+    assertEquals(whereOrOpt(someF, someF).query[Unit].sql, "WHERE ? OR ? ")
+  }
+
+  test("whereOrOpt (varargs 1 Some)") {
+    assertEquals(whereOrOpt(ofs(0)).query[Unit].sql, "WHERE ? ")
+  }
+
+  test("whereOrOpt (varargs all none)") {
     assertEquals(whereOrOpt(None, None).query[Unit].sql, "")
+  }
+
+  test("whereOrOpt (Foldable empty)") {
+    assertEquals(whereOrOpt(List.empty[Fragment]).query[Unit].sql, "")
+  }
+
+  test("whereOrOpt (Foldable many)") {
+    assertEquals(whereOrOpt(fs).query[Unit].sql, "WHERE ? OR ? OR ? ")
+  }
+  
+  test("orderBy (varargs 1)") {
+    assertEquals(orderBy(fr0"a").query[Unit].sql, "ORDER BY a")
+  }
+
+  test("orderBy (varargs many)") {
+    assertEquals(orderBy(fr0"a", fr0"b").query[Unit].sql, "ORDER BY a, b")
+  }
+
+  test("orderBy (Reducible 1)") {
+    assertEquals(orderBy(NonEmptyList.of(fr0"a")).query[Unit].sql, "ORDER BY a")
+  }
+
+  test("orderBy (Reducible many)") {
+    assertEquals(orderBy(NonEmptyList.of(fr0"a", fr0"b")).query[Unit].sql, "ORDER BY a, b")
+  }
+
+  test("orderByOpt (varargs Some many) ") {
+    assertEquals(orderByOpt(Some(fr0"a"), Some(fr0"b")).query[Unit].sql, "ORDER BY a, b")
+  }
+
+  test("orderByOpt (varargs all None) ") {
+    assertEquals(orderByOpt(None, None).query[Unit].sql, "")
+  }
+
+  test("orderByOpt (Foldable empty) ") {
+    assertEquals(orderByOpt(List.empty[Fragment]).query[Unit].sql, "")
+  }
+
+  test("orderByOpt (Foldable many) ") {
+    assertEquals(orderByOpt(List(fr0"a", fr0"b")).query[Unit].sql, "ORDER BY a, b")
+  }
+  
+  test("Usage test: whereAndOpt") {
+    assertEquals(whereAndOpt(Some(fr"hi"), orOpt(List.empty[Fragment]), orOpt(List(fr"a", fr"b"))).query[Unit].sql, "WHERE hi AND (a OR b ) ")
   }
 
   case class Person(name: String, age: Int)


### PR DESCRIPTION
- all andOpt/orOpt calls that can lead to zero input fragments (e.g. empty list or all None var args) will now return None. This makes it compose better
- Revert and/or to only take Reducible collections
- Surrounds and/or expressions with parenthesis

Fixes #1850 
