### PR TITLE
Fix NPE in Scala 3 derivation for Write

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ lazy val weaverVersion        = "0.8.3"
 // Basic versioning and publishing stuff
 ThisBuild / tlBaseVersion := "1.0"
 ThisBuild / tlCiReleaseBranches := Seq("main") // publish snapshits on `main`
-ThisBuild / scalaVersion := scala213Version
+ThisBuild / scalaVersion := scala3Version
 ThisBuild / crossScalaVersions := Seq(scala212Version, scala213Version, scala3Version)
 ThisBuild / developers += tlGitHubDev("tpolecat", "Rob Norris")
 ThisBuild / tlSonatypeUseLegacyHost := false

--- a/modules/core/src/main/scala-3/util/WritePlatform.scala
+++ b/modules/core/src/main/scala-3/util/WritePlatform.scala
@@ -13,7 +13,7 @@ trait WritePlatform:
     new Write(Nil, _ => Nil, (_, _, _) => (),(_, _, _) => ())
 
   // Inductive write for writable head and tail.
-  given [H, T <: Tuple](using H: => Write[H], T: => Write[T]): Write[H *: T] =
+  given [H, T <: Tuple](using H: Write[H], T: Write[T]): Write[H *: T] =
     new Write(
       H.puts ++ T.puts,
       { case h *: t => H.toList(h) ++ T.toList(t) },

--- a/modules/core/src/main/scala/doobie/util/write.scala
+++ b/modules/core/src/main/scala/doobie/util/write.scala
@@ -10,7 +10,36 @@ import doobie.free.{ FPS, FRS, PreparedStatementIO, ResultSetIO }
 import java.sql.{ PreparedStatement, ResultSet }
 import doobie.util.fragment.Fragment
 import doobie.util.fragment.Elem
+import scala.annotation.implicitNotFound
 
+@implicitNotFound("""
+Cannot find or construct a Write instance for type:
+
+  ${A}
+
+This can happen for a few reasons, but the most common case is that a data
+member somewhere within this type doesn't have a Put instance in scope. Here are
+some debugging hints:
+
+- For Option types, ensure that a Write instance is in scope for the non-Option
+  version.
+- For types you expect to map to a single column ensure that a Put instance is
+  in scope.
+- For case classes, HLists, and shapeless records ensure that each element
+  has a Write instance in scope.
+- Lather, rinse, repeat, recursively until you find the problematic bit.
+
+You can check that an instance exists for Write in the REPL or in your code:
+
+  scala> Write[Foo]
+
+and similarly with Put:
+
+  scala> Put[Foo]
+
+And find the missing instance and construct it as needed. Refer to Chapter 12
+of the book of doobie for more information.
+""")
 final class Write[A](
   val puts: List[(Put[_], NullabilityKnown)],
   val toList: A => List[Any],

--- a/modules/core/src/test/scala-3/doobie/util/ReadSuitePlatform.scala
+++ b/modules/core/src/test/scala-3/doobie/util/ReadSuitePlatform.scala
@@ -5,9 +5,14 @@
 package doobie
 package util
 
+import Predef.augmentString
+
 trait ReadSuitePlatform { self: munit.FunSuite =>
 
   case class Woozle(a: (String, Int), b: Int *: String *: EmptyTuple, c: Boolean)
+  
+  sealed trait NoGetInstanceForThis
+  case class CaseClassWithFieldWithoutGetInstance(a: String, b: NoGetInstanceForThis)
 
   test("Read should exist for some fancy types") {
     util.Read[Woozle]
@@ -19,6 +24,19 @@ trait ReadSuitePlatform { self: munit.FunSuite =>
     util.Read[Option[Woozle]]
     util.Read[Option[(Woozle, String)]]
     util.Read[Option[(Int, Woozle *: Woozle *: String *: EmptyTuple)]]
+  }
+
+  test("Read should not exist for case class with field without Get instance") {
+    val compileError = compileErrors("util.Read[CaseClassWithFieldWithoutGetInstance]")
+    assert(
+      compileError.contains(
+        """Cannot find or construct a Read instance for type:
+          |
+          |  ReadSuitePlatform.this.CaseClassWithFieldWithoutGetInstance
+          |
+          |This can happen for a few reasons,""".stripMargin
+      )
+    )
   }
 
   test("derives") {

--- a/modules/core/src/test/scala-3/doobie/util/WriteSuitePlatform.scala
+++ b/modules/core/src/test/scala-3/doobie/util/WriteSuitePlatform.scala
@@ -5,6 +5,8 @@
 package doobie
 package util
 
+import Predef.augmentString
+
 trait WriteSuitePlatform { self: munit.FunSuite =>
 
   case class Woozle(a: (String, Int), b: Int *: String *: EmptyTuple, c: Boolean)
@@ -25,7 +27,16 @@ trait WriteSuitePlatform { self: munit.FunSuite =>
   }
 
   test("Write should not exist for case class with field without Put instance") {
-    util.Write[CaseClassWithFieldWithoutPutInstance]
+    val compileError = compileErrors("util.Write[CaseClassWithFieldWithoutPutInstance]")
+    assert(
+      compileError.contains(
+        """Cannot find or construct a Write instance for type:
+          |
+          |  WriteSuitePlatform.this.CaseClassWithFieldWithoutPutInstance
+          |
+          |This can happen for a few reasons,""".stripMargin
+      )
+    )
   }
 
   test("derives") {

--- a/modules/core/src/test/scala-3/doobie/util/WriteSuitePlatform.scala
+++ b/modules/core/src/test/scala-3/doobie/util/WriteSuitePlatform.scala
@@ -8,6 +8,9 @@ package util
 trait WriteSuitePlatform { self: munit.FunSuite =>
 
   case class Woozle(a: (String, Int), b: Int *: String *: EmptyTuple, c: Boolean)
+  
+  sealed trait NoPutInstanceForThis
+  case class CaseClassWithFieldWithoutPutInstance(a: String, b: NoPutInstanceForThis)
 
   test("Write should exist for some fancy types") {
     util.Write[Woozle]
@@ -19,6 +22,10 @@ trait WriteSuitePlatform { self: munit.FunSuite =>
     util.Write[Option[Woozle]]
     util.Write[Option[(Woozle, String)]]
     util.Write[Option[(Int, Woozle *: Woozle *: String *: EmptyTuple)]]
+  }
+
+  test("Write should not exist for case class with field without Put instance") {
+    util.Write[CaseClassWithFieldWithoutPutInstance]
   }
 
   test("derives") {


### PR DESCRIPTION
#1816 fixed NPE for Read instances, but bug persisted for Write instances.

@jatcwang mentioned that recursive definitions for Read do not exist, if that's also the case for Write we can make the same change as in #1816 but for Write.

5d52836 commit introduces test that succeeds for Read, but fails for Write. Next commit introduces the mentioned change that makes the Write test also pass.