### PR TITLE
Add Type Annotation For ConnectionInterpreter

### DIFF
--- a/modules/free/src/main/scala/doobie/free/kleisliinterpreter.scala
+++ b/modules/free/src/main/scala/doobie/free/kleisliinterpreter.scala
@@ -727,7 +727,7 @@ class KleisliInterpreter[M[_]](logHandler: LogHandler[M])(implicit val asyncM: W
     override def getNetworkTimeout = primitive(_.getNetworkTimeout)
     override def getSchema = primitive(_.getSchema)
     override def getTransactionIsolation = primitive(_.getTransactionIsolation)
-    override def getTypeMap = primitive(_.getTypeMap)
+    override def getTypeMap: Kleisli[M, java.sql.Connection, java.util.Map[String,Class[_]]] = primitive(_.getTypeMap)
     override def getWarnings = primitive(_.getWarnings)
     override def isClosed = primitive(_.isClosed)
     override def isReadOnly = primitive(_.isReadOnly)


### PR DESCRIPTION
I am trying to do 1.0.0-RC2 to RC4 upgrade and I got the following message.
```
[error] ClassInProjectThatUsesDoobie:76:13: incompatible type in overriding
[error] def getTypeMap: cats.data.Kleisli[F,java.sql.Connection,java.util.Map[String,Class[_]]] (defined in trait Visitor)
[error]   with override def getTypeMap: cats.data.Kleisli[F,java.sql.Connection,java.util.Map[String,Class[_ <: Object]]] (defined in trait ConnectionInterpreter);
[error]  found   : cats.data.Kleisli[F,java.sql.Connection,java.util.Map[String,Class[_ <: Object]]]
[error]  required: cats.data.Kleisli[F,java.sql.Connection,java.util.Map[String,Class[_]]]
[error]         new ConnectionInterpreter {
[error]             ^
[error] one error found
```