### PR TITLE
Fix typo transcator -> transactor

### DIFF
--- a/modules/docs/src/main/mdoc/docs/13-Unit-Testing.md
+++ b/modules/docs/src/main/mdoc/docs/13-Unit-Testing.md
@@ -157,7 +157,7 @@ class AnalysisTestSuite extends FunSuite with doobie.munit.IOChecker {
 
 The `doobie-weaver` add-on provides a mix-in trait what we can add to any effectful test Suite. 
 The `check` function takes an implicit `Transactor[F]` parameter. Since Weaver has its own way 
-to manage shared resources, it is convenient to use that to allocate the transcator. 
+to manage shared resources, it is convenient to use that to allocate the transactor.
 
 ```scala mdoc:silent
 import _root_.weaver._

--- a/modules/example/src/main/scala/example/PostgresNotify.scala
+++ b/modules/example/src/main/scala/example/PostgresNotify.scala
@@ -54,7 +54,7 @@ object PostgresNotify extends IOApp.Simple {
 
   /**
     * Construct a stream of PGNotifications that prints to the console. Transform it to a
-    * runnable process using the transcactor above, and run it.
+    * runnable process using the transactor above, and run it.
     */
   def run: IO[Unit] =
     notificationStream("foo", 1.second)


### PR DESCRIPTION
A minor typo that I saw in the docs, I thought it would be helpful to open a PR for it.