### PR TITLE
Remove reference to ZonedDateTime in pgsql docs

### DIFF
--- a/modules/docs/src/main/mdoc/docs/15-Extensions-PostgreSQL.md
+++ b/modules/docs/src/main/mdoc/docs/15-Extensions-PostgreSQL.md
@@ -77,7 +77,7 @@ import doobie.postgres.implicits._
 
 ### Java 8 Time Types (JSR310)
 
-An explicit import is required to bring in mappings for `java.time.OffsetDateTime` / `java.time.Instant` / `java.time.ZonedDateTime` / `java.time.LocalDateTime` / `java.time.LocalDate` / `java.time.LocalTime`
+An explicit import is required to bring in mappings for `java.time.OffsetDateTime` / `java.time.Instant` / `java.time.LocalDateTime` / `java.time.LocalDate` / `java.time.LocalTime`
 
 ```scala mdoc:silent
 import doobie.postgres.implicits._
@@ -87,7 +87,7 @@ To ensure **doobie** performs the conversion correctly between Java 8 time types
 The correct combination of date/time types should be used:
 
 - `TIMESTAMP` maps to `java.time.LocalDateTime`
-- `TIMESTAMPTZ` maps to `java.time.Instant`, `java.time.ZonedDateTime` or `java.time.OffsetDateTime`
+- `TIMESTAMPTZ` maps to `java.time.Instant`, or `java.time.OffsetDateTime`
 - `DATE` maps to `java.time.LocalDate`
 - `TIME` maps to `java.time.LocalTime`
 


### PR DESCRIPTION
As of 1.0-RC3 the ZDT implicit is gone because it's never been correct with the actual data stored.