### PR TITLE
Fix instance derivation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,8 @@ jobs:
       - name: Check there are no uncommitted changes in git (to catch generated files that weren't committed)
         run: sbt '++ ${{ matrix.scala }}' checkGitNoUncommittedChanges
 
-      - name: Check Doc Site (2.13.13 only)
-        if: matrix.scala == '2.13.13'
+      - name: Check Doc Site (2.13.14 only)
+        if: matrix.scala == '2.13.14'
         run: sbt '++ ${{ matrix.scala }}' docs/makeSite
 
       - name: Make target directories

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val shapelessVersion     = "2.3.10"
 lazy val silencerVersion      = "1.7.1"
 lazy val specs2Version        = "4.20.5"
 lazy val scala212Version      = "2.12.19"
-lazy val scala213Version      = "2.13.13"
+lazy val scala213Version      = "2.13.14"
 lazy val scala3Version       = "3.3.3"
 // scala-steward:off
 lazy val slf4jVersion         = "1.7.36"

--- a/modules/core/src/main/scala-2/util/ReadPlatform.scala
+++ b/modules/core/src/main/scala-2/util/ReadPlatform.scala
@@ -9,77 +9,127 @@ import shapeless.labelled.{ field, FieldType }
 
 trait ReadPlatform extends LowerPriorityRead {
 
-  implicit def recordRead[K <: Symbol, H, T <: HList](
-    implicit H: Lazy[Read[H] OrElse MkRead[H]],
-              T: Lazy[MkRead[T]]
-  ): MkRead[FieldType[K, H] :: T] = {
-    val head = H.value.unify
+  // Derivation base case for product types (1-element)
+  implicit def productBase[H](
+    implicit H:Read[H] OrElse MkRead[H],
+  ): MkRead[H :: HNil] = {
+    val head = H.unify
 
-    new MkRead[FieldType[K, H] :: T](
-      head.gets ++ T.value.gets,
-      (rs, n) => field[K](head.unsafeGet(rs, n)) :: T.value.unsafeGet(rs, n + head.length)
+    new MkRead[H :: HNil](
+      head.gets,
+      (rs, n) => head.unsafeGet(rs, n) :: HNil
     )
   }
 
+  // Derivation base case for shapeless record (1-element)
+  implicit def recordBase[K <: Symbol, H](
+    implicit H: Read[H] OrElse MkRead[H],
+  ): MkRead[FieldType[K, H] :: HNil] = {
+    val head = H.unify
+
+    new MkRead[FieldType[K, H] :: HNil](
+      head.gets,
+      (rs, n) => field[K](head.unsafeGet(rs, n)) :: HNil
+    )
+  }
 }
 
-trait LowerPriorityRead extends EvenLower {
+trait LowerPriorityRead extends EvenLowerPriorityRead {
 
+  // Derivation inductive case for product types 
   implicit def product[H, T <: HList](
-    implicit H: Lazy[Read[H] OrElse MkRead[H]],
-              T: Lazy[MkRead[T]]
+    implicit H: Read[H] OrElse MkRead[H],
+              T: MkRead[T]
   ): MkRead[H :: T] = {
-    val head = H.value.unify
+    val head = H.unify
 
     new MkRead[H :: T](
-      head.gets ++ T.value.gets,
-      (rs, n) => head.unsafeGet(rs, n) :: T.value.unsafeGet(rs, n + head.length)
+      head.gets ++ T.gets,
+      (rs, n) => head.unsafeGet(rs, n) :: T.unsafeGet(rs, n + head.length)
     )
   }
 
-  implicit val emptyProduct: MkRead[HNil] =
-    new MkRead[HNil](Nil, (_, _) => HNil)
+  // Derivation inductive case for shapeless records  
+  implicit def record[K <: Symbol, H, T <: HList](
+    implicit H: Read[H] OrElse MkRead[H],
+    T:MkRead[T]
+  ): MkRead[FieldType[K, H] :: T] = {
+    val head = H.unify
 
+    new MkRead[FieldType[K, H] :: T](
+      head.gets ++ T.gets,
+      (rs, n) => field[K](head.unsafeGet(rs, n)) :: T.unsafeGet(rs, n + head.length)
+    )
+  }
+
+  // Derivation for product types (i.e. case class)
   implicit def generic[F, G](implicit gen: Generic.Aux[F, G], G: Lazy[MkRead[G]]): MkRead[F] =
     new MkRead[F](G.value.gets, (rs, n) => gen.from(G.value.unsafeGet(rs, n)))
 
+  // Derivation base case for Option of product types (1-element)
+  implicit def optProductBase[H](
+    implicit H: Read[Option[H]] OrElse MkRead[Option[H]],
+    N: H <:!< Option[α] forSome { type α }
+  ): MkRead[Option[H :: HNil]] = {
+    void(N)
+    val head = H.unify
+
+    new MkRead[Option[H :: HNil]](
+      head.gets,
+      (rs, n) =>
+        head.unsafeGet(rs, n).map(_ :: HNil)
+    )
+  }
+
+  // Derivation base case for Option of product types (where the head element is Option)
+  implicit def optProductOptBase[H](
+    implicit H: Read[Option[H]] OrElse MkRead[Option[H]],
+  ): MkRead[Option[Option[H] :: HNil]] = {
+    val head = H.unify
+
+    new MkRead[Option[Option[H] :: HNil]](
+      head.gets,
+      (rs, n) => head.unsafeGet(rs, n).map(h => Some(h) :: HNil)
+    )
+  }
+
 }
 
-trait EvenLower {
+trait EvenLowerPriorityRead {
 
-  implicit val ohnil: MkRead[Option[HNil]] =
-    new MkRead[Option[HNil]](Nil, (_, _) => Some(HNil))
-
-  implicit def ohcons1[H, T <: HList](
-    implicit H: Lazy[Read[Option[H]] OrElse MkRead[Option[H]]],
-              T: Lazy[MkRead[Option[T]]],
+  // Read[Option[H]], Read[Option[T]] implies Read[Option[H *: T]]
+  implicit def optProduct[H, T <: HList](
+    implicit H: Read[Option[H]] OrElse MkRead[Option[H]],
+              T: MkRead[Option[T]],
               N: H <:!< Option[α] forSome { type α }
   ): MkRead[Option[H :: T]] = {
     void(N)
-    val head = H.value.unify
+    val head = H.unify
 
     new MkRead[Option[H :: T]](
-      head.gets ++ T.value.gets,
+      head.gets ++ T.gets,
       (rs, n) =>
         for {
           h <- head.unsafeGet(rs, n)
-          t <- T.value.unsafeGet(rs, n + head.length)
+          t <- T.unsafeGet(rs, n + head.length)
         } yield h :: t
     )
   }
 
-  implicit def ohcons2[H, T <: HList](
-    implicit H: Lazy[Read[Option[H]] OrElse MkRead[Option[H]]],
-              T: Lazy[MkRead[Option[T]]]
+  // Read[Option[H]], Read[Option[T]] implies Read[Option[Option[H] *: T]]
+  implicit def optProductOpt[H, T <: HList](
+    implicit H: Read[Option[H]] OrElse MkRead[Option[H]],
+              T: MkRead[Option[T]]
   ): MkRead[Option[Option[H] :: T]] = {
-    val head = H.value.unify
+    val head = H.unify
 
     new MkRead[Option[Option[H] :: T]](
-      head.gets ++ T.value.gets,
-      (rs, n) => T.value.unsafeGet(rs, n + head.length).map(head.unsafeGet(rs, n) :: _)
+      head.gets ++ T.gets,
+      (rs, n) => T.unsafeGet(rs, n + head.length).map(head.unsafeGet(rs, n) :: _)
     )
   }
 
+  // Derivation for optional of product types (i.e. case class)
   implicit def ogeneric[A, Repr <: HList](
     implicit G: Generic.Aux[A, Repr],
               B: Lazy[MkRead[Option[Repr]]]

--- a/modules/core/src/main/scala-2/util/WritePlatform.scala
+++ b/modules/core/src/main/scala-2/util/WritePlatform.scala
@@ -9,17 +9,31 @@ import shapeless.labelled.{ FieldType }
 
 trait WritePlatform extends LowerPriorityWrite {
 
-  implicit def recordWrite[K <: Symbol, H, T <: HList](
-    implicit H: Lazy[Write[H] OrElse MkWrite[H]],
-              T: Lazy[MkWrite[T]]
-  ): MkWrite[FieldType[K, H] :: T] = {
-    val head = H.value.unify
+  // Derivation base case for product types (1-element)
+  implicit def productBase[H](
+    implicit H: Write[H] OrElse MkWrite[H],
+  ): MkWrite[H :: HNil] = {
+    val head = H.unify
+
+    new MkWrite[H :: HNil](
+      head.puts,
+      { case h :: HNil => head.toList(h) },
+      { case (ps, n, h :: HNil) => head.unsafeSet(ps, n, h); },
+      { case (rs, n, h :: HNil) => head.unsafeUpdate(rs, n, h); }
+    )
+  }
+
+  // Derivation base case for shapelss record (1-element)
+  implicit def recordBase[K <: Symbol, H](
+    implicit H: Write[H] OrElse MkWrite[H],
+  ): MkWrite[FieldType[K, H] :: HNil] = {
+    val head = H.unify
 
     new MkWrite(
-      head.puts ++ T.value.puts,
-      { case h :: t => head.toList(h) ++ T.value.toList(t) },
-      { case (ps, n, h :: t) => head.unsafeSet(ps, n, h); T.value.unsafeSet(ps, n + head.length, t) },
-      { case (rs, n, h :: t) => head.unsafeUpdate(rs, n, h); T.value.unsafeUpdate(rs, n + head.length, t) }
+      head.puts,
+      { case h :: HNil => head.toList(h) },
+      { case (ps, n, h :: HNil) => head.unsafeSet(ps, n, h) },
+      { case (rs, n, h :: HNil) => head.unsafeUpdate(rs, n, h) }
     )
   }
 
@@ -27,23 +41,22 @@ trait WritePlatform extends LowerPriorityWrite {
 
 trait LowerPriorityWrite extends EvenLowerPriorityWrite {
 
+  // Derivation inductive case for product types 
   implicit def product[H, T <: HList](
-    implicit H: Lazy[Write[H] OrElse MkWrite[H]],
-              T: Lazy[MkWrite[T]]
+    implicit H: Write[H] OrElse MkWrite[H],
+              T: MkWrite[T]
   ): MkWrite[H :: T] = {
-    val head = H.value.unify
+    val head = H.unify
 
     new MkWrite(
-      head.puts ++ T.value.puts,
-      { case h :: t => head.toList(h) ++ T.value.toList(t) },
-      { case (ps, n, h :: t) => head.unsafeSet(ps, n, h); T.value.unsafeSet(ps, n + head.length, t) },
-      { case (rs, n, h :: t) => head.unsafeUpdate(rs, n, h); T.value.unsafeUpdate(rs, n + head.length, t) }
+      head.puts ++ T.puts,
+      { case h :: t => head.toList(h) ++ T.toList(t) },
+      { case (ps, n, h :: t) => head.unsafeSet(ps, n, h); T.unsafeSet(ps, n + head.length, t) },
+      { case (rs, n, h :: t) => head.unsafeUpdate(rs, n, h); T.unsafeUpdate(rs, n + head.length, t) }
     )
   }
 
-  implicit val emptyProduct: MkWrite[HNil] =
-    new MkWrite[HNil](Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
-
+  // Derivation for product types (i.e. case class)
   implicit def generic[B, A](implicit gen: Generic.Aux[B, A], A: Lazy[MkWrite[A]]): MkWrite[B] =
     new MkWrite[B](
       A.value.puts,
@@ -52,51 +65,109 @@ trait LowerPriorityWrite extends EvenLowerPriorityWrite {
       (rs, n, b) => A.value.unsafeUpdate(rs, n, gen.to(b))
     )
 
+  // Derivation inductive case for shapeless records  
+  implicit def record[K <: Symbol, H, T <: HList](
+    implicit H: Write[H] OrElse MkWrite[H],
+    T: MkWrite[T]
+  ): MkWrite[FieldType[K, H] :: T] = {
+    val head = H.unify
+
+    new MkWrite(
+      head.puts ++ T.puts,
+      { case h :: t => head.toList(h) ++ T.toList(t) },
+      { case (ps, n, h :: t) => head.unsafeSet(ps, n, h); T.unsafeSet(ps, n + head.length, t) },
+      { case (rs, n, h :: t) => head.unsafeUpdate(rs, n, h); T.unsafeUpdate(rs, n + head.length, t) }
+    )
+  }
+
+  // Derivation base case for Option of product types (1-element)
+  implicit def optProductBase[H](
+    implicit H: Write[Option[H]] OrElse MkWrite[Option[H]],
+    N: H <:!< Option[α] forSome { type α }
+  ): MkWrite[Option[H :: HNil]] = {
+    void(N)
+    val head = H.unify
+    
+    def withHead[A](opt: Option[H :: HNil])(f: Option[H] => A): A = {
+      f(opt.map(_.head))
+    }
+
+    new MkWrite(
+      head.puts,
+      withHead(_)(head.toList(_)),
+      (ps, n, i) => withHead(i)(h => head.unsafeSet(ps, n, h)),
+      (rs, n, i) => withHead(i)(h => head.unsafeUpdate(rs, n, h))
+    )
+
+  }
+
+  // Derivation base case for Option of product types (where the head element is Option)
+  implicit def optProductOptBase[H](
+    implicit H: Write[Option[H]] OrElse MkWrite[Option[H]],
+  ): MkWrite[Option[Option[H] :: HNil]] = {
+    val head = H.unify
+
+    def withHead[A](opt: Option[Option[H] :: HNil])(f: Option[H] => A): A = {
+      opt match {
+        case Some(h :: _) => f(h)
+        case None => f(None)
+      }
+    }
+
+    new MkWrite(
+      head.puts,
+      withHead(_) { h => head.toList(h)},
+      (ps, n, i) => withHead(i){ h => head.unsafeSet(ps, n, h) },
+      (rs, n, i) => withHead(i){ h => head.unsafeUpdate(rs, n, h) }
+    )
+
+  }
+
 }
 
 trait EvenLowerPriorityWrite {
 
-  implicit val ohnil: MkWrite[Option[HNil]] =
-    new MkWrite[Option[HNil]](Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ())
-
-  implicit def ohcons1[H, T <: HList](
-    implicit H: Lazy[Write[Option[H]] OrElse MkWrite[Option[H]]],
-             T: Lazy[MkWrite[Option[T]]],
+  // Write[Option[H]], Write[Option[T]] implies Write[Option[H *: T]]
+  implicit def optPorduct[H, T <: HList](
+    implicit H: Write[Option[H]] OrElse MkWrite[Option[H]],
+             T: MkWrite[Option[T]],
              N: H <:!< Option[α] forSome { type α }
   ): MkWrite[Option[H :: T]] = {
     void(N)
-    val head = H.value.unify
+    val head = H.unify
 
     def split[A](i: Option[H :: T])(f: (Option[H], Option[T]) => A): A =
       i.fold(f(None, None)) { case h :: t => f(Some(h), Some(t)) }
 
     new MkWrite(
-      head.puts ++ T.value.puts,
-      split(_) { (h, t) => head.toList(h) ++ T.value.toList(t) },
-      (ps, n, i) => split(i) { (h, t) => head.unsafeSet(ps, n, h); T.value.unsafeSet(ps, n + head.length, t) },
-      (rs, n, i) => split(i) { (h, t) => head.unsafeUpdate(rs, n, h); T.value.unsafeUpdate(rs, n + head.length, t) }
+      head.puts ++ T.puts,
+      split(_) { (h, t) => head.toList(h) ++ T.toList(t) },
+      (ps, n, i) => split(i) { (h, t) => head.unsafeSet(ps, n, h); T.unsafeSet(ps, n + head.length, t) },
+      (rs, n, i) => split(i) { (h, t) => head.unsafeUpdate(rs, n, h); T.unsafeUpdate(rs, n + head.length, t) }
     )
 
   }
 
-  implicit def ohcons2[H, T <: HList](
-    implicit H: Lazy[Write[Option[H]] OrElse MkWrite[Option[H]]],
-             T: Lazy[MkWrite[Option[T]]]
+  // Write[Option[H]], Write[Option[T]] implies Write[Option[Option[H] *: T]]
+  implicit def optProductOpt[H, T <: HList](
+    implicit H: Write[Option[H]] OrElse MkWrite[Option[H]],
+             T: MkWrite[Option[T]]
   ): MkWrite[Option[Option[H] :: T]] = {
-    val head = H.value.unify
+    val head = H.unify
 
     def split[A](i: Option[Option[H] :: T])(f: (Option[H], Option[T]) => A): A =
       i.fold(f(None, None)) { case oh :: t => f(oh, Some(t)) }
 
     new MkWrite(
-      head.puts ++ T.value.puts,
-      split(_) { (h, t) => head.toList(h) ++ T.value.toList(t) },
-      (ps, n, i) => split(i) { (h, t) => head.unsafeSet(ps, n, h); T.value.unsafeSet(ps, n + head.length, t) },
-      (rs, n, i) => split(i) { (h, t) => head.unsafeUpdate(rs, n, h); T.value.unsafeUpdate(rs, n + head.length, t) }
+      head.puts ++ T.puts,
+      split(_) { (h, t) => head.toList(h) ++ T.toList(t) },
+      (ps, n, i) => split(i) { (h, t) => head.unsafeSet(ps, n, h); T.unsafeSet(ps, n + head.length, t) },
+      (rs, n, i) => split(i) { (h, t) => head.unsafeUpdate(rs, n, h); T.unsafeUpdate(rs, n + head.length, t) }
     )
 
   }
 
+  // Derivation for optional of product types (i.e. case class)
   implicit def ogeneric[B, A <: HList](
     implicit G: Generic.Aux[B, A],
              A: Lazy[MkWrite[Option[A]]]

--- a/modules/core/src/main/scala-3/util/ReadPlatform.scala
+++ b/modules/core/src/main/scala-3/util/ReadPlatform.scala
@@ -9,14 +9,41 @@ import doobie.util.shapeless.OrElse
 
 trait ReadPlatform:
 
-  // Trivial Read for EmptyTuple
-  given readEmpty: MkRead[EmptyTuple] =
-    new MkRead[EmptyTuple](Nil, (_, _) => EmptyTuple)
+  // Generic Read for products.
+  given derived[P <: Product, A](
+    using m: Mirror.ProductOf[P],
+    i: A =:= m.MirroredElemTypes,
+    w: MkRead[A]
+  ): MkRead[P] = {
+    val read = w.map(a => m.fromProduct(i(a)))
+    MkRead.lift(read)
+  }
+
+  // Generic Read for option of products.
+  given derivedOption[P <: Product, A](
+    using m: Mirror.ProductOf[P],
+    i: A =:= m.MirroredElemTypes,
+    w: MkRead[Option[A]]
+  ): MkRead[Option[P]] = {
+    val read = w.map(a => a.map(a => m.fromProduct(i(a))))
+    MkRead.lift(read)
+  }
+
+  // Derivation base case for product types (1-element)
+  given productBase[H](
+    using H: Read[H] OrElse MkRead[H],
+  ): MkRead[H *: EmptyTuple] = {
+    val head = H.unify
+    new MkRead(
+      head.gets,
+      (rs, n) => head.unsafeGet(rs, n) *: EmptyTuple
+    )
+  }
 
   // Read for head and tail.
-  given readTuple[H, T <: Tuple](
+  given product[H, T <: Tuple](
     using H: Read[H] OrElse MkRead[H],
-          T: => MkRead[T]
+          T: MkRead[T]
   ): MkRead[H *: T] = {
     val head = H.unify
 
@@ -26,25 +53,19 @@ trait ReadPlatform:
     )
   }
 
-  // Generic Read for products.
-  given derived[P <: Product, A](
-    using m: Mirror.ProductOf[P],
-          i: A =:= m.MirroredElemTypes,
-          w: MkRead[A]
-  ): MkRead[P] = {
-    val read = w.map(a => m.fromProduct(i(a)))
-    MkRead.lift(read)
-  }
-
-  given roe: MkRead[Option[EmptyTuple]] =
-    new MkRead[Option[EmptyTuple]](Nil, (_, _) => Some(EmptyTuple))
-
-  given rou: MkRead[Option[Unit]] =
-    new MkRead[Option[Unit]](Nil, (_, _) => Some(()))
-
-  given cons1[H, T <: Tuple](
+  given optProductBase[H](
     using H: Read[Option[H]] OrElse MkRead[Option[H]],
-          T: => MkRead[Option[T]],
+  ): MkRead[Option[H *: EmptyTuple]] = {
+    val head = H.unify
+    MkRead[Option[H *: EmptyTuple]](
+      head.gets,
+      (rs, n) => head.unsafeGet(rs, n).map(_ *: EmptyTuple)
+    )
+  }
+  
+  given optProduct[H, T <: Tuple](
+    using H: Read[Option[H]] OrElse MkRead[Option[H]],
+          T: MkRead[Option[T]],
   ): MkRead[Option[H *: T]] = {
     val head = H.unify
 
@@ -57,10 +78,21 @@ trait ReadPlatform:
         } yield h *: t
     )
   }
-
-  given cons2[H, T <: Tuple](
+  
+  given optProductOptBase[H](
     using H: Read[Option[H]] OrElse MkRead[Option[H]],
-          T: => MkRead[Option[T]]
+  ): MkRead[Option[Option[H] *: EmptyTuple]] = {
+    val head = H.unify
+
+    MkRead[Option[Option[H] *: EmptyTuple]](
+      head.gets,
+      (rs, n) => head.unsafeGet(rs, n).map(h => Some(h) *: EmptyTuple)
+    )
+  }
+  
+  given optProductOpt[H, T <: Tuple](
+    using H: Read[Option[H]] OrElse MkRead[Option[H]],
+          T: MkRead[Option[T]]
   ): MkRead[Option[Option[H] *: T]] = {
     val head = H.unify
 
@@ -68,14 +100,4 @@ trait ReadPlatform:
       head.gets ++ T.gets,
       (rs, n) => T.unsafeGet(rs, n + head.length).map(head.unsafeGet(rs, n) *: _)
     )
-  }
-
-  // Generic Read for option of products.
-  given readOptionProduct[P <: Product, A](
-    using m: Mirror.ProductOf[P],
-          i: A =:= m.MirroredElemTypes,
-          w: MkRead[Option[A]]
-  ): MkRead[Option[P]] = {
-    val read = w.map(a => a.map(a => m.fromProduct(i(a))))
-    MkRead.lift(read)
   }

--- a/modules/core/src/main/scala/doobie/util/package.scala
+++ b/modules/core/src/main/scala/doobie/util/package.scala
@@ -8,7 +8,8 @@ package doobie
 package object util {
 
   val unlabeled: String = "unlabeled"
-  
-  private[util] def void(a: Any*): Unit =
-    (a, ())._2
+
+  private[util] def void(a: Any*): Unit = {
+    val _ = a
+  }
 }

--- a/modules/core/src/main/scala/doobie/util/read.scala
+++ b/modules/core/src/main/scala/doobie/util/read.scala
@@ -81,7 +81,10 @@ object Read {
     }
 
   implicit val unit: Read[Unit] =
-    new Read(Nil, (_, _) => ()) {}
+    Read(Nil, (_, _) => ())
+
+  implicit val optionUnit: Read[Option[Unit]] =
+    Read(Nil, (_, _) => Some(()))
 
   implicit def fromGet[A](implicit ev: Get[A]): Read[A] =
     new Read(List((ev, NoNulls)), ev.unsafeGetNonNullable) {}

--- a/modules/core/src/main/scala/doobie/util/write.scala
+++ b/modules/core/src/main/scala/doobie/util/write.scala
@@ -6,10 +6,12 @@ package doobie.util
 
 import cats.ContravariantSemigroupal
 import doobie.enumerated.Nullability._
-import doobie.free.{ FPS, FRS, PreparedStatementIO, ResultSetIO }
-import java.sql.{ PreparedStatement, ResultSet }
+import doobie.free.{FPS, FRS, PreparedStatementIO, ResultSetIO}
+
+import java.sql.{PreparedStatement, ResultSet}
 import doobie.util.fragment.Fragment
 import doobie.util.fragment.Elem
+
 import scala.annotation.implicitNotFound
 
 @implicitNotFound("""
@@ -108,8 +110,20 @@ object Write {
       def product[A, B](fa: Write[A], fb: Write[B]) = fa.product(fb)
     }
 
+  private def doNothing[P, A](p: P, i: Int, a: A): Unit = {
+    void(p, i, a)
+  }
+  
+  private def empty[A](a: A): List[Any] = {
+    void(a)
+    List.empty
+  }
+
   implicit val unitComposite: Write[Unit] =
-    new Write[Unit](Nil, _ => Nil, (_, _, _) => (), (_, _, _) => ()) {}
+    Write[Unit](Nil, empty _, doNothing _, doNothing _)
+    
+  implicit val optionUnit: Write[Option[Unit]] =
+    Write[Option[Unit]](Nil, empty _, doNothing _, doNothing _)
 
   implicit def fromPut[A](implicit P: Put[A]): Write[A] =
     new Write[A](

--- a/modules/core/src/test/scala-2/doobie/util/ReadSuitePlatform.scala
+++ b/modules/core/src/test/scala-2/doobie/util/ReadSuitePlatform.scala
@@ -18,7 +18,7 @@ trait ReadSuitePlatform { self: munit.FunSuite =>
     Read[A]
     Read[(A, A)]
   }: @nowarn("msg=.*DL is never used.*")
-
+  
   case class Woozle(a: (String, Int), b: Int :: String :: HNil, c: Boolean)
 
   test("Read should exist for some fancy types") {

--- a/modules/core/src/test/scala/doobie/util/TestTypes.scala
+++ b/modules/core/src/test/scala/doobie/util/TestTypes.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2013-2020 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.util
+
+import doobie.Meta
+
+object TestTypes {
+  case class LenStr1(n: Int, s: String)
+
+  case class LenStr2(n: Int, s: String)
+  object LenStr2 {
+    implicit val LenStrMeta: Meta[LenStr2] =
+      Meta[String].timap(s => LenStr2(s.length, s))(_.s)
+  }
+
+  case object CaseObj
+  
+  case class SimpleCaseClass(i: Option[Int], s: String, os: Option[String]) 
+  case class ComplexCaseClass(sc: SimpleCaseClass, osc: Option[SimpleCaseClass], i: Option[Int], s: String)
+
+}

--- a/modules/postgres/src/main/scala/doobie/postgres/package.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/package.scala
@@ -4,8 +4,6 @@
 
 package doobie
 
-import doobie.postgres.PostgresJavaTimeMetaInstances
-
 package object postgres
   extends postgres.free.Types
      with postgres.free.Modules


### PR DESCRIPTION
Remove instances for HNil / EmptyTuple (alone), as this causes auto-derivation of Read/Write instances for _any_ case object which leads to incorrect SQL being generated.

The fix is to change the base case to product 1s (A :: HNil, or A *: EmptyTuple in Scala 3)

- Add more round-trip tests to fully test the logic
- Align names of derivation methods

Fixes #1991