### PR TITLE
Add parenthesis around each expression in and/or combinator

### DIFF
--- a/modules/core/src/main/scala/doobie/util/fragments.scala
+++ b/modules/core/src/main/scala/doobie/util/fragments.scala
@@ -52,7 +52,7 @@ object fragments {
   /** Returns `(f1 AND f2 AND ... fn)` for a non-empty collection.
    *  @param withParen If this is false, does not wrap the resulting expression with parenthesis */
   def and[F[_]: Reducible](fs: F[Fragment], withParen: Boolean = true): Fragment = {
-    val expr = fs.nonEmptyIntercalate(fr" AND")
+    val expr = fs.reduceLeftTo(f => parentheses0(f))((f1, f2) => f1 ++ fr0" AND " ++ parentheses0(f2))
     if (withParen) parentheses(expr) else expr
   }
 
@@ -79,7 +79,7 @@ object fragments {
    *
    * @param withParen If this is false, does not wrap the resulting expression with parenthesis */
   def or[F[_] : Reducible](fs: F[Fragment], withParen: Boolean = true): Fragment = {
-    val expr = fs.nonEmptyIntercalate(fr" OR")
+    val expr = fs.reduceLeftTo(f => parentheses0(f))((f1, f2) => f1 ++ fr0" OR " ++ parentheses0(f2))
     if (withParen) parentheses(expr) else expr
   }
 
@@ -148,8 +148,11 @@ object fragments {
   def set[F[_]: Reducible](fs: F[Fragment]): Fragment =
     fr"SET" ++ comma(fs)
 
-  /** Returns `(f)`. */
+  /** Returns `(f) `. */
   def parentheses(f: Fragment): Fragment = fr0"(" ++ f ++ fr")"
+
+  /** Returns `(f)`. */
+  def parentheses0(f: Fragment): Fragment = fr0"(" ++ f ++ fr0")"
 
   /** Returns `?,?,...,?` for the values in `a`. */
   def values[A](a: A)(implicit w: util.Write[A]): Fragment =

--- a/modules/core/src/test/scala/doobie/util/FragmentsSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/FragmentsSuite.scala
@@ -84,15 +84,15 @@ class FragmentsSuite extends munit.FunSuite {
   }
 
   test("and (vararg 2)") {
-    assertEquals(and(fs(0), fs(1)).query[Unit].sql, "(? AND ?) ")
+    assertEquals(and(fs(0), fs(1)).query[Unit].sql, "((?) AND (?)) ")
   }
 
   test("and (Reducible 1)") {
-    assertEquals(and(nel1).query[Unit].sql, "(?) ")
+    assertEquals(and(nel1).query[Unit].sql, "((?)) ")
   }
 
   test("and (Reducible many)") {
-    assertEquals(and(nel).query[Unit].sql, "(? AND ? AND ?) ")
+    assertEquals(and(nel).query[Unit].sql, "((?) AND (?) AND (?)) ")
   }
 
   test("andOpt (vararg many none)") {
@@ -100,11 +100,11 @@ class FragmentsSuite extends munit.FunSuite {
   }
 
   test("andOpt (vararg 1 Some)") {
-    assertEquals(andOpt(noneF, someF).map(_.query[Unit].sql), Some("(?) "))
+    assertEquals(andOpt(noneF, someF).map(_.query[Unit].sql), Some("((?)) "))
   }
 
   test("andOpt (vararg 2 Some)") {
-    assertEquals(andOpt(someF, someF).map(_.query[Unit].sql), Some("(? AND ?) "))
+    assertEquals(andOpt(someF, someF).map(_.query[Unit].sql), Some("((?) AND (?)) "))
   }
 
   test("andOpt (Foldable empty)") {
@@ -112,11 +112,11 @@ class FragmentsSuite extends munit.FunSuite {
   }
 
   test("andOpt (Foldable 1)") {
-    assertEquals(andOpt(nel.take(1)).map(_.query[Unit].sql), Some("(?) "))
+    assertEquals(andOpt(nel.take(1)).map(_.query[Unit].sql), Some("((?)) "))
   }
 
   test("andOpt (Foldable many)") {
-    assertEquals(andOpt(nel.toList).map(_.query[Unit].sql), Some("(? AND ? AND ?) "))
+    assertEquals(andOpt(nel.toList).map(_.query[Unit].sql), Some("((?) AND (?) AND (?)) "))
   }
 
   test("andOpt (list empty)") {
@@ -128,19 +128,19 @@ class FragmentsSuite extends munit.FunSuite {
   }
 
   test("andFallbackTrue (many)") {
-    assertEquals(andFallbackTrue(fs).query[Unit].sql, "(? AND ? AND ?) ")
+    assertEquals(andFallbackTrue(fs).query[Unit].sql, "((?) AND (?) AND (?)) ")
   }
 
   test("or (vararg 2)") {
-    assertEquals(or(fs(0), fs(1)).query[Unit].sql, "(? OR ?) ")
+    assertEquals(or(fs(0), fs(1)).query[Unit].sql, "((?) OR (?)) ")
   }
 
   test("or (Reducible 1)") {
-    assertEquals(or(nel1).query[Unit].sql, "(?) ")
+    assertEquals(or(nel1).query[Unit].sql, "((?)) ")
   }
 
   test("or (Reducible many)") {
-    assertEquals(or(nel).query[Unit].sql, "(? OR ? OR ?) ")
+    assertEquals(or(nel).query[Unit].sql, "((?) OR (?) OR (?)) ")
   }
 
   test("orOpt (vararg many none)") {
@@ -148,11 +148,11 @@ class FragmentsSuite extends munit.FunSuite {
   }
 
   test("orOpt (vararg 1 Some)") {
-    assertEquals(orOpt(noneF, someF).map(_.query[Unit].sql), Some("(?) "))
+    assertEquals(orOpt(noneF, someF).map(_.query[Unit].sql), Some("((?)) "))
   }
 
   test("orOpt (vararg 2 Some)") {
-    assertEquals(orOpt(someF, someF).map(_.query[Unit].sql), Some("(? OR ?) "))
+    assertEquals(orOpt(someF, someF).map(_.query[Unit].sql), Some("((?) OR (?)) "))
   }
 
   test("orOpt (Foldable empty)") {
@@ -160,11 +160,11 @@ class FragmentsSuite extends munit.FunSuite {
   }
 
   test("orOpt (Foldable 1)") {
-    assertEquals(orOpt(nel.take(1)).map(_.query[Unit].sql), Some("(?) "))
+    assertEquals(orOpt(nel.take(1)).map(_.query[Unit].sql), Some("((?)) "))
   }
 
   test("orOpt (Foldable many)") {
-    assertEquals(orOpt(nel.toList).map(_.query[Unit].sql), Some("(? OR ? OR ?) "))
+    assertEquals(orOpt(nel.toList).map(_.query[Unit].sql), Some("((?) OR (?) OR (?)) "))
   }
 
   test("orOpt (list empty)") {
@@ -176,31 +176,31 @@ class FragmentsSuite extends munit.FunSuite {
   }
 
   test("orFallbackFalse (many)") {
-    assertEquals(orFallbackFalse(fs).query[Unit].sql, "(? OR ? OR ?) ")
+    assertEquals(orFallbackFalse(fs).query[Unit].sql, "((?) OR (?) OR (?)) ")
   }
 
   test("whereAnd (varargs single)") {
-    assertEquals(whereAnd(fs(0)).query[Unit].sql, "WHERE ?")
+    assertEquals(whereAnd(fs(0)).query[Unit].sql, "WHERE (?)")
   }
 
   test("whereAnd (varargs many)") {
-    assertEquals(whereAnd(fs(0), fs(0), fs(0)).query[Unit].sql, "WHERE ? AND ? AND ?")
+    assertEquals(whereAnd(fs(0), fs(0), fs(0)).query[Unit].sql, "WHERE (?) AND (?) AND (?)")
   }
   
   test("whereAnd (Reducible 1)") {
-    assertEquals(whereAnd(nel1).query[Unit].sql, "WHERE ?")
+    assertEquals(whereAnd(nel1).query[Unit].sql, "WHERE (?)")
   }
   
   test("whereAnd (Reducible many)") {
-    assertEquals(whereAnd(nel).query[Unit].sql, "WHERE ? AND ? AND ?")
+    assertEquals(whereAnd(nel).query[Unit].sql, "WHERE (?) AND (?) AND (?)")
   }
 
   test("whereAndOpt (varargs many Some)") {
-    assertEquals(whereAndOpt(someF, someF).query[Unit].sql, "WHERE ? AND ?")
+    assertEquals(whereAndOpt(someF, someF).query[Unit].sql, "WHERE (?) AND (?)")
   }
 
   test("whereAndOpt (varargs 1 Some)") {
-    assertEquals(whereAndOpt(ofs(0)).query[Unit].sql, "WHERE ?")
+    assertEquals(whereAndOpt(ofs(0)).query[Unit].sql, "WHERE (?)")
   }
 
   test("whereAndOpt (varargs all none)") {
@@ -212,31 +212,31 @@ class FragmentsSuite extends munit.FunSuite {
   }
 
   test("whereAndOpt (Foldable many)") {
-    assertEquals(whereAndOpt(fs).query[Unit].sql, "WHERE ? AND ? AND ?")
+    assertEquals(whereAndOpt(fs).query[Unit].sql, "WHERE (?) AND (?) AND (?)")
   }
 
   test("whereOr (varargs single)") {
-    assertEquals(whereOr(fs(0)).query[Unit].sql, "WHERE ?")
+    assertEquals(whereOr(fs(0)).query[Unit].sql, "WHERE (?)")
   }
 
   test("whereOr (varargs many)") {
-    assertEquals(whereOr(fs(0), fs(0), fs(0)).query[Unit].sql, "WHERE ? OR ? OR ?")
+    assertEquals(whereOr(fs(0), fs(0), fs(0)).query[Unit].sql, "WHERE (?) OR (?) OR (?)")
   }
 
   test("whereOr (Reducible 1)") {
-    assertEquals(whereOr(nel1).query[Unit].sql, "WHERE ?")
+    assertEquals(whereOr(nel1).query[Unit].sql, "WHERE (?)")
   }
 
   test("whereOr (Reducible many)") {
-    assertEquals(whereOr(nel).query[Unit].sql, "WHERE ? OR ? OR ?")
+    assertEquals(whereOr(nel).query[Unit].sql, "WHERE (?) OR (?) OR (?)")
   }
 
   test("whereOrOpt (varargs many Some)") {
-    assertEquals(whereOrOpt(someF, someF).query[Unit].sql, "WHERE ? OR ?")
+    assertEquals(whereOrOpt(someF, someF).query[Unit].sql, "WHERE (?) OR (?)")
   }
 
   test("whereOrOpt (varargs 1 Some)") {
-    assertEquals(whereOrOpt(ofs(0)).query[Unit].sql, "WHERE ?")
+    assertEquals(whereOrOpt(ofs(0)).query[Unit].sql, "WHERE (?)")
   }
 
   test("whereOrOpt (varargs all none)") {
@@ -248,7 +248,7 @@ class FragmentsSuite extends munit.FunSuite {
   }
 
   test("whereOrOpt (Foldable many)") {
-    assertEquals(whereOrOpt(fs).query[Unit].sql, "WHERE ? OR ? OR ?")
+    assertEquals(whereOrOpt(fs).query[Unit].sql, "WHERE (?) OR (?) OR (?)")
   }
   
   test("orderBy (varargs 1)") {
@@ -284,7 +284,7 @@ class FragmentsSuite extends munit.FunSuite {
   }
   
   test("Usage test: whereAndOpt") {
-    assertEquals(whereAndOpt(Some(sql"hi"), orOpt(List.empty[Fragment]), orOpt(List(sql"a", sql"b"))).query[Unit].sql, "WHERE hi AND (a OR b) ")
+    assertEquals(whereAndOpt(Some(sql"hi"), orOpt(List.empty[Fragment]), orOpt(List(sql"a", sql"b"))).query[Unit].sql, "WHERE (hi) AND (((a) OR (b)) )")
   }
 
   case class Person(name: String, age: Int)


### PR DESCRIPTION
This avoids expressions from "leaking" and changing the overall semantics e.g. `and(fr"expr1", fr"expr2 OR expr3")` should be equivalent to `(expr1) AND (expr2 OR expr3)` not `expr1 AND expr2 OR expr3`