### PR TITLE
Remove lazy initialization of modules

### DIFF
--- a/modules/core/src/main/scala/doobie/free/Aliases.scala
+++ b/modules/core/src/main/scala/doobie/free/Aliases.scala
@@ -25,34 +25,34 @@ trait Types {
 }
 
 trait Modules {
-  /** @group Module Aliases - Free API */ lazy val FB   = blob
-  /** @group Module Aliases - Free API */ lazy val FCS  = callablestatement
-  /** @group Module Aliases - Free API */ lazy val FCL  = clob
-  /** @group Module Aliases - Free API */ lazy val FC   = connection
-  /** @group Module Aliases - Free API */ lazy val FDMD = databasemetadata
-  /** @group Module Aliases - Free API */ lazy val FD   = driver
-  /** @group Module Aliases - Free API */ lazy val FNCL = nclob
-  /** @group Module Aliases - Free API */ lazy val FPS  = preparedstatement
-  /** @group Module Aliases - Free API */ lazy val FREF = ref
-  /** @group Module Aliases - Free API */ lazy val FRS  = resultset
-  /** @group Module Aliases - Free API */ lazy val FSD  = sqldata
-  /** @group Module Aliases - Free API */ lazy val FSI  = sqlinput
-  /** @group Module Aliases - Free API */ lazy val FSO  = sqloutput
-  /** @group Module Aliases - Free API */ lazy val FS   = statement
+  /** @group Module Aliases - Free API */ val FB   = blob
+  /** @group Module Aliases - Free API */ val FCS  = callablestatement
+  /** @group Module Aliases - Free API */ val FCL  = clob
+  /** @group Module Aliases - Free API */ val FC   = connection
+  /** @group Module Aliases - Free API */ val FDMD = databasemetadata
+  /** @group Module Aliases - Free API */ val FD   = driver
+  /** @group Module Aliases - Free API */ val FNCL = nclob
+  /** @group Module Aliases - Free API */ val FPS  = preparedstatement
+  /** @group Module Aliases - Free API */ val FREF = ref
+  /** @group Module Aliases - Free API */ val FRS  = resultset
+  /** @group Module Aliases - Free API */ val FSD  = sqldata
+  /** @group Module Aliases - Free API */ val FSI  = sqlinput
+  /** @group Module Aliases - Free API */ val FSO  = sqloutput
+  /** @group Module Aliases - Free API */ val FS   = statement
 }
 
 trait Instances  {
 
-  /** @group Typeclass Instances */  implicit lazy val WeakAsyncBlobIO: WeakAsync[BlobIO] =
+  /** @group Typeclass Instances */  implicit val WeakAsyncBlobIO: WeakAsync[BlobIO] =
     blob.WeakAsyncBlobIO
 
-  /** @group Typeclass Instances */  implicit lazy val WeakAsyncCallableStatementIO: WeakAsync[CallableStatementIO] =
+  /** @group Typeclass Instances */  implicit val WeakAsyncCallableStatementIO: WeakAsync[CallableStatementIO] =
     callablestatement.WeakAsyncCallableStatementIO
 
-  /** @group Typeclass Instances */  implicit lazy val WeakAsyncClobIO: WeakAsync[ClobIO] =
+  /** @group Typeclass Instances */  implicit val WeakAsyncClobIO: WeakAsync[ClobIO] =
     clob.WeakAsyncClobIO
 
-  /** @group Typeclass Instances */  implicit lazy val WeakAsyncConnectionIO: WeakAsync[ConnectionIO] =
+  /** @group Typeclass Instances */  implicit val WeakAsyncConnectionIO: WeakAsync[ConnectionIO] =
     connection.WeakAsyncConnectionIO
 
   /** @group Typeclass Instances */  implicit def MonoidConnectionIO[A: Monoid]: Monoid[ConnectionIO[A]] =
@@ -61,34 +61,34 @@ trait Instances  {
   /** @group Typeclass Instances */  implicit def SemigroupConnectionIO[A: Semigroup]: Semigroup[ConnectionIO[A]] =
     connection.SemigroupConnectionIO[A]
 
-  /** @group Typeclass Instances */  implicit lazy val WeakAsyncDatabaseMetaDataIO: WeakAsync[DatabaseMetaDataIO] =
+  /** @group Typeclass Instances */  implicit val WeakAsyncDatabaseMetaDataIO: WeakAsync[DatabaseMetaDataIO] =
     databasemetadata.WeakAsyncDatabaseMetaDataIO
 
-  /** @group Typeclass Instances */  implicit lazy val WeakAsyncDriverIO: WeakAsync[DriverIO] =
+  /** @group Typeclass Instances */  implicit val WeakAsyncDriverIO: WeakAsync[DriverIO] =
     driver.WeakAsyncDriverIO
 
-  /** @group Typeclass Instances */  implicit lazy val WeakAsyncNClobIO: WeakAsync[NClobIO] =
+  /** @group Typeclass Instances */  implicit val WeakAsyncNClobIO: WeakAsync[NClobIO] =
     nclob.WeakAsyncNClobIO
 
-  /** @group Typeclass Instances */  implicit lazy val WeakAsyncPreparedStatementIO: WeakAsync[PreparedStatementIO] =
+  /** @group Typeclass Instances */  implicit val WeakAsyncPreparedStatementIO: WeakAsync[PreparedStatementIO] =
     preparedstatement.WeakAsyncPreparedStatementIO
 
-  /** @group Typeclass Instances */  implicit lazy val WeakAsyncRefIO: WeakAsync[RefIO] =
+  /** @group Typeclass Instances */  implicit val WeakAsyncRefIO: WeakAsync[RefIO] =
     ref.WeakAsyncRefIO
 
-  /** @group Typeclass Instances */  implicit lazy val WeakAsyncResultSetIO: WeakAsync[ResultSetIO] =
+  /** @group Typeclass Instances */  implicit val WeakAsyncResultSetIO: WeakAsync[ResultSetIO] =
     resultset.WeakAsyncResultSetIO
 
-  /** @group Typeclass Instances */  implicit lazy val WeakAsyncSQLDataIO: WeakAsync[SQLDataIO] =
+  /** @group Typeclass Instances */  implicit val WeakAsyncSQLDataIO: WeakAsync[SQLDataIO] =
     sqldata.WeakAsyncSQLDataIO
 
-  /** @group Typeclass Instances */  implicit lazy val WeakAsyncSQLInputIO: WeakAsync[SQLInputIO] =
+  /** @group Typeclass Instances */  implicit val WeakAsyncSQLInputIO: WeakAsync[SQLInputIO] =
     sqlinput.WeakAsyncSQLInputIO
 
-  /** @group Typeclass Instances */  implicit lazy val WeakAsyncSQLOutputIO: WeakAsync[SQLOutputIO] =
+  /** @group Typeclass Instances */  implicit val WeakAsyncSQLOutputIO: WeakAsync[SQLOutputIO] =
     sqloutput.WeakAsyncSQLOutputIO
 
-  /** @group Typeclass Instances */  implicit lazy val WeakAsyncStatementIO: WeakAsync[StatementIO] =
+  /** @group Typeclass Instances */  implicit val WeakAsyncStatementIO: WeakAsync[StatementIO] =
     statement.WeakAsyncStatementIO
 
 }

--- a/modules/core/src/main/scala/doobie/hi/Aliases.scala
+++ b/modules/core/src/main/scala/doobie/hi/Aliases.scala
@@ -5,8 +5,8 @@
 package doobie.hi
 
 trait Modules {
-  /** @group Module Aliases - High level (safer) API */ lazy val HC  = doobie.hi.connection
-  /** @group Module Aliases - High level (safer) API */ lazy val HS  = doobie.hi.statement
-  /** @group Module Aliases - High level (safer) API */ lazy val HPS = doobie.hi.preparedstatement
-  /** @group Module Aliases - High level (safer) API */ lazy val HRS = doobie.hi.resultset
+  /** @group Module Aliases - High level (safer) API */ val HC  = doobie.hi.connection
+  /** @group Module Aliases - High level (safer) API */ val HS  = doobie.hi.statement
+  /** @group Module Aliases - High level (safer) API */ val HPS = doobie.hi.preparedstatement
+  /** @group Module Aliases - High level (safer) API */ val HRS = doobie.hi.resultset
 }

--- a/modules/core/src/main/scala/doobie/hi/statement.scala
+++ b/modules/core/src/main/scala/doobie/hi/statement.scala
@@ -10,6 +10,10 @@ import doobie.enumerated.FetchDirection
 import doobie.enumerated.ResultSetConcurrency
 import doobie.enumerated.ResultSetType
 import doobie.implicits._
+import doobie.free.{
+  statement => IFS,
+  resultset => IFRS
+}
 
 import java.sql.SQLWarning
 
@@ -23,43 +27,43 @@ object statement {
 
   /** @group Batching */
   def addBatch(sql: String): StatementIO[Unit] =
-    FS.addBatch(sql)
+    IFS.addBatch(sql)
 
   /** @group Batching */
   val clearBatch: StatementIO[Unit] =
-    FS.clearBatch
+    IFS.clearBatch
 
   /** @group Execution */
   val executeBatch: StatementIO[List[Int]] =
-    FS.executeBatch.map(_.toIndexedSeq.toList) // intArrayOps does not have `toList` in 2.13
+    IFS.executeBatch.map(_.toIndexedSeq.toList) // intArrayOps does not have `toList` in 2.13
 
   /** @group Execution */
   def executeQuery[A](sql: String)(k: ResultSetIO[A]): StatementIO[A] =
-    FS.executeQuery(sql).bracket(s => FS.embed(s, k))(s => FS.embed(s, FRS.close))
+    IFS.executeQuery(sql).bracket(s => IFS.embed(s, k))(s => IFS.embed(s, IFRS.close))
 
   /** @group Execution */
   def executeUpdate(sql: String): StatementIO[Int] =
-    FS.executeUpdate(sql)
+    IFS.executeUpdate(sql)
 
   /** @group Properties */
   val getFetchDirection: StatementIO[FetchDirection] =
-    FS.getFetchDirection.flatMap(FetchDirection.fromIntF[StatementIO])
+    IFS.getFetchDirection.flatMap(FetchDirection.fromIntF[StatementIO])
 
   /** @group Properties */
   val getFetchSize: StatementIO[Int] =
-    FS.getFetchSize
+    IFS.getFetchSize
 
   /** @group Results */
   def getGeneratedKeys[A](k: ResultSetIO[A]): StatementIO[A] =
-    FS.getGeneratedKeys.bracket(s => FS.embed(s, k))(s => FS.embed(s, FRS.close))
+    IFS.getGeneratedKeys.bracket(s => IFS.embed(s, k))(s => IFS.embed(s, IFRS.close))
 
   /** @group Properties */
   val getMaxFieldSize: StatementIO[Int] =
-    FS.getMaxFieldSize
+    IFS.getMaxFieldSize
 
   /** @group Properties */
   val getMaxRows: StatementIO[Int] =
-    FS.getMaxRows
+    IFS.getMaxRows
 
   // /** @group Batching */
   // def getMoreResults(a: Int): StatementIO[Boolean] =
@@ -67,62 +71,62 @@ object statement {
 
   /** @group Batching */
   val getMoreResults: StatementIO[Boolean] =
-    FS.getMoreResults
+    IFS.getMoreResults
 
   /** @group Properties */
   val getQueryTimeout: StatementIO[Int] =
-    FS.getQueryTimeout
+    IFS.getQueryTimeout
 
   /** @group Batching */
   def getResultSet[A](k: ResultSetIO[A]): StatementIO[A] =
-    FS.getResultSet.flatMap(s => FS.embed(s, k))
+    IFS.getResultSet.flatMap(s => IFS.embed(s, k))
 
   /** @group Properties */
   val getResultSetConcurrency: StatementIO[ResultSetConcurrency] =
-    FS.getResultSetConcurrency.flatMap(ResultSetConcurrency.fromIntF[StatementIO])
+    IFS.getResultSetConcurrency.flatMap(ResultSetConcurrency.fromIntF[StatementIO])
 
   /** @group Properties */
   val getResultSetHoldability: StatementIO[Holdability] =
-    FS.getResultSetHoldability.flatMap(Holdability.fromIntF[StatementIO])
+    IFS.getResultSetHoldability.flatMap(Holdability.fromIntF[StatementIO])
 
   /** @group Properties */
   val getResultSetType: StatementIO[ResultSetType] =
-    FS.getResultSetType.flatMap(ResultSetType.fromIntF[StatementIO])
+    IFS.getResultSetType.flatMap(ResultSetType.fromIntF[StatementIO])
 
   /** @group Results */
   val getUpdateCount: StatementIO[Int] =
-    FS.getUpdateCount
+    IFS.getUpdateCount
 
   /** @group Results */
   val getWarnings: StatementIO[SQLWarning] =
-    FS.getWarnings
+    IFS.getWarnings
 
   /** @group Properties */
   def setCursorName(name: String): StatementIO[Unit] =
-    FS.setCursorName(name)
+    IFS.setCursorName(name)
 
   /** @group Properties */
   def setEscapeProcessing(a: Boolean): StatementIO[Unit] =
-    FS.setEscapeProcessing(a)
+    IFS.setEscapeProcessing(a)
 
   /** @group Properties */
   def setFetchDirection(fd: FetchDirection): StatementIO[Unit] =
-    FS.setFetchDirection(fd.toInt)
+    IFS.setFetchDirection(fd.toInt)
 
   /** @group Properties */
   def setFetchSize(n: Int): StatementIO[Unit] =
-    FS.setFetchSize(n)
+    IFS.setFetchSize(n)
 
   /** @group Properties */
   def setMaxFieldSize(n: Int): StatementIO[Unit] =
-    FS.setMaxFieldSize(n)
+    IFS.setMaxFieldSize(n)
 
   /** @group Properties */
   def setMaxRows(n: Int): StatementIO[Unit] =
-    FS.setMaxRows(n)
+    IFS.setMaxRows(n)
 
   /** @group Properties */
   def setQueryTimeout(a: Int): StatementIO[Unit] =
-    FS.setQueryTimeout(a)
+    IFS.setQueryTimeout(a)
 
 }

--- a/modules/core/src/main/scala/doobie/syntax/connectionio.scala
+++ b/modules/core/src/main/scala/doobie/syntax/connectionio.scala
@@ -7,9 +7,10 @@ package doobie.syntax
 import cats.data.{EitherT, Kleisli, OptionT}
 import cats.effect.kernel.MonadCancelThrow
 import cats.syntax.functor._
-import doobie.{ ConnectionIO, HC }
+import doobie.ConnectionIO 
 import doobie.implicits._
 import doobie.util.transactor.Transactor
+import doobie.hi.{connection => IHC}
 
 class ConnectionIOOps[A](ma: ConnectionIO[A]) {
   def transact[M[_]: MonadCancelThrow](xa: Transactor[M]): M[A] = xa.trans.apply(ma)
@@ -18,14 +19,14 @@ class ConnectionIOOps[A](ma: ConnectionIO[A]) {
 class OptionTConnectionIOOps[A](ma: OptionT[ConnectionIO, A]) {
   def transact[M[_]: MonadCancelThrow](xa: Transactor[M]): OptionT[M, A] =
     OptionT(
-      xa.trans.apply(ma.orElseF(HC.rollback.as(None)).value)
+      xa.trans.apply(ma.orElseF(IHC.rollback.as(None)).value)
     )
 }
 
 class EitherTConnectionIOOps[E, A](ma: EitherT[ConnectionIO, E, A]) {
   def transact[M[_]: MonadCancelThrow](xa: Transactor[M]): EitherT[M, E, A] =
     EitherT(
-      xa.trans.apply(ma.leftSemiflatMap(HC.rollback.as(_)).value)
+      xa.trans.apply(ma.leftSemiflatMap(IHC.rollback.as(_)).value)
     )
 }
 

--- a/modules/core/src/main/scala/doobie/util/fragment.scala
+++ b/modules/core/src/main/scala/doobie/util/fragment.scala
@@ -11,6 +11,7 @@ import cats.syntax.all._
 import doobie._, doobie.implicits._
 import doobie.enumerated.Nullability._
 import doobie.util.pos.Pos
+import doobie.hi.{connection => IHC}
 import java.sql.{ PreparedStatement, ResultSet }
 import scala.Predef.{ augmentString, implicitly }
 
@@ -79,7 +80,7 @@ object fragment {
      * further handling delegated to the provided program.
      */
     def execWith[B](fa: PreparedStatementIO[B]): ConnectionIO[B] =
-      HC.prepareStatement(sql)(write.set(1, elems) *> fa)
+      IHC.prepareStatement(sql)(write.set(1, elems) *> fa)
 
     /** Concatenate this fragment with another, yielding a larger fragment. */
     def ++(fb: Fragment): Fragment =

--- a/modules/core/src/main/scala/doobie/util/read.scala
+++ b/modules/core/src/main/scala/doobie/util/read.scala
@@ -5,10 +5,13 @@
 package doobie.util
 
 import cats._
-import doobie.free.{ FRS, ResultSetIO }
+import doobie.free.{ ResultSetIO }
 import doobie.enumerated.Nullability._
 import java.sql.ResultSet
 import scala.annotation.implicitNotFound
+import doobie.free.{
+  resultset => IFRS 
+}
 
 @implicitNotFound("""
 Cannot find or construct a Read instance for type:
@@ -54,7 +57,7 @@ sealed abstract class Read[A](
     new Read(ff.gets ++ gets, (rs, n) => ff.unsafeGet(rs, n)(unsafeGet(rs, n + ff.length))) {}
 
   def get(n: Int): ResultSetIO[A] =
-    FRS.raw(unsafeGet(_, n))
+    IFRS.raw(unsafeGet(_, n))
 
 }
 

--- a/modules/core/src/main/scala/doobie/util/transactor.scala
+++ b/modules/core/src/main/scala/doobie/util/transactor.scala
@@ -11,6 +11,7 @@ import doobie.implicits._
 import doobie.util.lens._
 import doobie.util.log.LogHandler
 import doobie.util.yolo.Yolo
+import doobie.free.{connection => IFC}
 import cats.{Monad, ~>}
 import cats.data.Kleisli
 import cats.effect.kernel.{Async, MonadCancelThrow, Resource}
@@ -42,7 +43,7 @@ object transactor  {
     always: ConnectionIO[Unit]
   ) {
     val resource: Resource[ConnectionIO, Unit] = for {
-      _ <- Resource.make(doobie.FC.unit)(_ => always)
+      _ <- Resource.make(IFC.unit)(_ => always)
       _ <- Resource.makeCase(before) { case (_, exitCase) =>
         exitCase match {
           case ExitCase.Succeeded => after

--- a/modules/core/src/main/scala/doobie/util/write.scala
+++ b/modules/core/src/main/scala/doobie/util/write.scala
@@ -6,11 +6,15 @@ package doobie.util
 
 import cats.ContravariantSemigroupal
 import doobie.enumerated.Nullability._
-import doobie.free.{FPS, FRS, PreparedStatementIO, ResultSetIO}
+import doobie.free.{PreparedStatementIO, ResultSetIO}
 
 import java.sql.{PreparedStatement, ResultSet}
 import doobie.util.fragment.Fragment
 import doobie.util.fragment.Elem
+import doobie.free.{
+  preparedstatement => IFPS,
+  resultset => IFRS
+}
 
 import scala.annotation.implicitNotFound
 
@@ -52,10 +56,10 @@ sealed abstract class Write[A](
   lazy val length = puts.length
 
   def set(n: Int, a: A): PreparedStatementIO[Unit] =
-    FPS.raw(unsafeSet(_, n, a))
+    IFPS.raw(unsafeSet(_, n, a))
 
   def update(n: Int, a: A): ResultSetIO[Unit] =
-    FRS.raw(unsafeUpdate(_, n, a))
+    IFRS.raw(unsafeUpdate(_, n, a))
 
   def contramap[B](f: B => A): Write[B] =
     new Write[B](

--- a/modules/core/src/test/scala/doobie/util/TestTypes.scala
+++ b/modules/core/src/test/scala/doobie/util/TestTypes.scala
@@ -4,7 +4,7 @@
 
 package doobie.util
 
-import doobie.Meta
+import doobie.util.meta.Meta
 
 object TestTypes {
   case class LenStr1(n: Int, s: String)

--- a/modules/postgres/src/main/scala/doobie/postgres/free/aliases.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/free/aliases.scala
@@ -16,32 +16,32 @@ trait Types {
 }
 
 trait Modules {
-  lazy val PFCI  = copyin
-  lazy val PFCM  = copymanager
-  lazy val PFCO  = copyout
-  lazy val PFLO  = largeobject
-  lazy val PFLOM = largeobjectmanager
-  lazy val PFPC  = pgconnection
+  val PFCI  = copyin
+  val PFCM  = copymanager
+  val PFCO  = copyout
+  val PFLO  = largeobject
+  val PFLOM = largeobjectmanager
+  val PFPC  = pgconnection
 }
 
 trait Instances {
 
-  implicit lazy val WeakAsyncCopyInIO: WeakAsync[copyin.CopyInIO] =
+  implicit val WeakAsyncCopyInIO: WeakAsync[copyin.CopyInIO] =
     copyin.WeakAsyncCopyInIO
 
-  implicit lazy val WeakAsyncCopyManagerIO: WeakAsync[copymanager.CopyManagerIO] =
+  implicit val WeakAsyncCopyManagerIO: WeakAsync[copymanager.CopyManagerIO] =
     copymanager.WeakAsyncCopyManagerIO
 
-  implicit lazy val WeakAsyncCopyOutIO: WeakAsync[copyout.CopyOutIO] =
+  implicit val WeakAsyncCopyOutIO: WeakAsync[copyout.CopyOutIO] =
     copyout.WeakAsyncCopyOutIO
 
-  implicit lazy val WeakAsyncLargeObjectIO: WeakAsync[largeobject.LargeObjectIO] =
+  implicit val WeakAsyncLargeObjectIO: WeakAsync[largeobject.LargeObjectIO] =
     largeobject.WeakAsyncLargeObjectIO
 
-  implicit lazy val WeakAsyncLargeObjectManagerIO: WeakAsync[largeobjectmanager.LargeObjectManagerIO] =
+  implicit val WeakAsyncLargeObjectManagerIO: WeakAsync[largeobjectmanager.LargeObjectManagerIO] =
     largeobjectmanager.WeakAsyncLargeObjectManagerIO
 
-  implicit lazy val WeakAsyncPGConnectionIO: WeakAsync[pgconnection.PGConnectionIO] =
+  implicit val WeakAsyncPGConnectionIO: WeakAsync[pgconnection.PGConnectionIO] =
     pgconnection.WeakAsyncPGConnectionIO
 
 }

--- a/modules/postgres/src/main/scala/doobie/postgres/hi/aliases.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/hi/aliases.scala
@@ -5,9 +5,9 @@
 package doobie.postgres.hi
 
 trait Modules {
-  lazy val PHPC  = pgconnection
-  lazy val PHC   = connection
-  lazy val PHLO  = largeobject
-  lazy val PHLOM = largeobjectmanager
-  lazy val PHLOS = lostreaming
+  val PHPC  = pgconnection
+  val PHC   = connection
+  val PHLO  = largeobject
+  val PHLOM = largeobjectmanager
+  val PHLOS = lostreaming
 }

--- a/modules/postgres/src/main/scala/doobie/postgres/hi/largeobject.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/hi/largeobject.scala
@@ -7,6 +7,7 @@ package doobie.postgres.hi
 import cats.syntax.all._
 import doobie.util.io.IOActions
 import java.io.{File, InputStream, OutputStream}
+import doobie.postgres.free.{largeobject => IPFLO}
 
 
 object largeobject {
@@ -15,18 +16,18 @@ object largeobject {
   lazy val io = new IOActions[LargeObjectIO]
 
   def copyFromFile(blockSize: Int, file: File): LargeObjectIO[Unit] =
-    PFLO.getOutputStream.flatMap { os => io.copyFileToStream(blockSize, file, os) *> io.flush(os) }
+    IPFLO.getOutputStream.flatMap { os => io.copyFileToStream(blockSize, file, os) *> io.flush(os) }
 
   def copyToFile(blockSize: Int, file: File): LargeObjectIO[Unit] =
-    PFLO.getInputStream.flatMap { is => io.copyStreamToFile(blockSize, file, is) }
+    IPFLO.getInputStream.flatMap { is => io.copyStreamToFile(blockSize, file, is) }
 
   def copyFromStream(blockSize: Int, is: InputStream): LargeObjectIO[Unit] =
-    PFLO.getOutputStream.flatMap { os =>
+    IPFLO.getOutputStream.flatMap { os =>
       io.copyStream(new Array[Byte](blockSize))(is, os)
     }
 
   def copyToStream(blockSize: Int, os: OutputStream): LargeObjectIO[Unit] =
-    PFLO.getInputStream.flatMap { is =>
+    IPFLO.getInputStream.flatMap { is =>
       io.copyStream(new Array[Byte](blockSize))(is, os)
     }
 }

--- a/modules/postgres/src/main/scala/doobie/postgres/hi/largeobjectmanager.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/hi/largeobjectmanager.scala
@@ -7,41 +7,43 @@ package doobie.postgres.hi
 import cats.syntax.all._
 import doobie.postgres.implicits._
 import java.io.{ File, OutputStream, InputStream }
+import doobie.postgres.free.{largeobjectmanager => IPFLOM, largeobject => IPFLO}
+import doobie.postgres.hi.{largeobjectmanager => IPHLOM, largeobject => IPHLO}
 
 object largeobjectmanager {
 
   val createLO: LargeObjectManagerIO[Long] =
-    PFLOM.createLO
+    IPFLOM.createLO
 
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
   def createLO(a: Int): LargeObjectManagerIO[Long] =
-    PFLOM.createLO(a)
+    IPFLOM.createLO(a)
 
   def delete(a: Long): LargeObjectManagerIO[Unit] =
-    PFLOM.delete(a)
+    IPFLOM.delete(a)
 
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
   def open[A](a: Long, b: Int)(k: LargeObjectIO[A]): LargeObjectManagerIO[A] =
-    PFLOM.open(a, b) >>= (PFLOM.embed(_, k <* PFLO.close))
+    IPFLOM.open(a, b) >>= (IPFLOM.embed(_, k <* IPFLO.close))
 
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
   def open[A](a: Long)(k: LargeObjectIO[A]): LargeObjectManagerIO[A] =
-    PFLOM.open(a) >>= (PFLOM.embed(_, k <* PFLO.close))
+    IPFLOM.open(a) >>= (IPFLOM.embed(_, k <* IPFLO.close))
 
   def unlink(a: Long): LargeObjectManagerIO[Unit] =
-    PFLOM.unlink(a)
+    IPFLOM.unlink(a)
 
   def createLOFromFile(blockSize: Int, file: File): LargeObjectManagerIO[Long] =
-    createLO >>= { oid => open(oid)(PHLO.copyFromFile(blockSize, file)).as(oid) }
+    createLO >>= { oid => open(oid)(IPHLO.copyFromFile(blockSize, file)).as(oid) }
 
   def createFileFromLO(blockSize: Int, oid: Long, file: File): LargeObjectManagerIO[Unit] =
-    open(oid)(PHLO.copyToFile(blockSize, file))
+    open(oid)(IPHLO.copyToFile(blockSize, file))
 
   def createLOFromStream(blockSize: Int, is: InputStream): LargeObjectManagerIO[Long] =
-    PHLOM.createLO >>= { oid =>
-      PHLOM.open(oid)(PHLO.copyFromStream(blockSize, is)).as(oid)
+    IPHLOM.createLO >>= { oid =>
+      IPHLOM.open(oid)(IPHLO.copyFromStream(blockSize, is)).as(oid)
     }
 
   def createStreamFromLO(blockSize: Int, oid: Long, os: OutputStream): LargeObjectManagerIO[Unit] =
-    open(oid)(PHLO.copyToStream(blockSize, os))
+    open(oid)(IPHLO.copyToStream(blockSize, os))
 }

--- a/modules/postgres/src/main/scala/doobie/postgres/hi/lostreaming.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/hi/lostreaming.scala
@@ -7,6 +7,8 @@ package doobie.postgres.hi
 import cats.syntax.functor._
 import doobie.ConnectionIO
 import doobie.implicits._
+import doobie.postgres.free.{largeobjectmanager => IIPFLOM, largeobject => IPFLO}
+import doobie.postgres.hi.{connection => IPHC}
 import fs2.Stream
 import java.io.{InputStream, OutputStream}
 import org.postgresql.largeobject.LargeObject
@@ -25,17 +27,17 @@ object lostreaming {
       .flatMap(lo => fs2.io.readInputStream(getInputStream(lo), chunkSize))
 
   private val createLO: ConnectionIO[Long] =
-    PHC.pgGetLargeObjectAPI(PFLOM.createLO)
+    IPHC.pgGetLargeObjectAPI(IIPFLOM.createLO)
 
   private def openLO(oid: Long): ConnectionIO[LargeObject] =
-    PHC.pgGetLargeObjectAPI(PFLOM.open(oid))
+    IPHC.pgGetLargeObjectAPI(IIPFLOM.open(oid))
 
   private def closeLO(lo: LargeObject): ConnectionIO[Unit] =
-    PHC.pgGetLargeObjectAPI(PFLOM.embed(lo, PFLO.close))
+    IPHC.pgGetLargeObjectAPI(IIPFLOM.embed(lo, IPFLO.close))
 
   private def getOutputStream(lo: LargeObject): ConnectionIO[OutputStream] =
-    PHC.pgGetLargeObjectAPI(PFLOM.embed(lo, PFLO.getOutputStream))
+    IPHC.pgGetLargeObjectAPI(IIPFLOM.embed(lo, IPFLO.getOutputStream))
 
   private def getInputStream(lo: LargeObject): ConnectionIO[InputStream] =
-    PHC.pgGetLargeObjectAPI(PFLOM.embed(lo, PFLO.getInputStream))
+    IPHC.pgGetLargeObjectAPI(IIPFLOM.embed(lo, IPFLO.getInputStream))
 }

--- a/modules/postgres/src/main/scala/doobie/postgres/hi/pgconnection.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/hi/pgconnection.scala
@@ -5,28 +5,29 @@
 package doobie.postgres.hi
 
 import org.postgresql.PGNotification
+import doobie.postgres.free.{pgconnection => IPFPC}
 
 object pgconnection {
 
   val getBackendPID: PGConnectionIO[Int] =
-    PFPC.getBackendPID
+    IPFPC.getBackendPID
 
   def getCopyAPI[A](k: CopyManagerIO[A]): PGConnectionIO[A] =
-    PFPC.getCopyAPI.flatMap(s => PFPC.embed(s, k)) // N.B. no need to close()
+    IPFPC.getCopyAPI.flatMap(s => IPFPC.embed(s, k)) // N.B. no need to close()
 
   def getLargeObjectAPI[A](k: LargeObjectManagerIO[A]): PGConnectionIO[A] =
-    PFPC.getLargeObjectAPI.flatMap(s => PFPC.embed(s, k)) // N.B. no need to close()
+    IPFPC.getLargeObjectAPI.flatMap(s => IPFPC.embed(s, k)) // N.B. no need to close()
 
   val getNotifications: PGConnectionIO[List[PGNotification]] =
-    PFPC.getNotifications map {
+    IPFPC.getNotifications map {
       case null => Nil
       case ns   => ns.toList
     }
 
   val getPrepareThreshold: PGConnectionIO[Int] =
-    PFPC.getPrepareThreshold
+    IPFPC.getPrepareThreshold
 
   def setPrepareThreshold(threshold: Int): PGConnectionIO[Unit] =
-    PFPC.setPrepareThreshold(threshold)
+    IPFPC.setPrepareThreshold(threshold)
 
 }

--- a/modules/postgres/src/main/scala/doobie/postgres/rangeinstances.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/rangeinstances.scala
@@ -4,7 +4,7 @@
 
 package doobie.postgres
 
-import doobie.Meta
+import doobie.util.meta.Meta
 import doobie.postgres.types.Range
 import org.postgresql.util.PGobject
 


### PR DESCRIPTION
This would ocassionally cause deadlocks which is hard to debug. Fixes #1369.

Inside doobie itself we cannot use aliases like `doobie.free.FC` because it'll lead to cyclic dependencies during class loading. Therefore this PR switches all existing alias use to an import alias to e.g. `doobie.free.{connection => IFC}` (I stands for internal)