### PR TITLE
Include withUniqueGeneratedKeys in logs

### DIFF
--- a/modules/core/src/test/scala/doobie/util/LogSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/LogSuite.scala
@@ -115,4 +115,16 @@ class LogSuite extends munit.FunSuite {
     ()
   }
 
+  test("[Update] withUniqueGeneratedKeys") {
+    val cio = for {
+        _  <- sql"create table if not exists foo (bar integer)".update.run
+        ins <- sql"insert into foo values (123)".updateWithLabel("test").withUniqueGeneratedKeys[Int]("bar")
+      } yield ins
+
+    eventForCIO(cio) match {
+      case Success(_, _, label, _, _) => assertEquals(label, "test")
+      case a => fail(s"no match: $a")
+    }
+  }
+
 }


### PR DESCRIPTION
A quick attempt at resolving the `withUniqueGeneratedKeys` aspect of https://github.com/tpolecat/doobie/issues/533 ( and https://github.com/tpolecat/doobie/issues/1888 )