### PR TITLE
docs: annotate `Yolo` value with type

### DIFF
--- a/modules/docs/src/main/mdoc/docs/04-Selecting.md
+++ b/modules/docs/src/main/mdoc/docs/04-Selecting.md
@@ -97,7 +97,8 @@ For more information see the [fs2](https://github.com/functional-streams-for-sca
 The API we have seen so far is ok, but it's tiresome to keep saying `transact(xa)` and doing `foreach(println)` to see what the results look like. So **just for REPL exploration** there is a module of extra syntax provided on your `Transactor` that you can import.
 
 ```scala mdoc:silent
-val y = xa.yolo // a stable reference is required
+import doobie.util.yolo.Yolo
+val y: Yolo[IO] = xa.yolo // a stable reference is required
 import y._
 ```
 


### PR DESCRIPTION
Fixes some strange errors I get with Scala 3 when following the tutorial:

```scala
val yolo = xa.yolo
import yolo.*
```

```
[E] [E2] src/main/scala/Main.scala:34:8
[E]      yolo.Option does not take type parameters
[E]      L34:   gnp: Option[Double],
[E]                  ^^^^^^^^^^^^^^^
[E] [E1] src/main/scala/Main.scala:19:42
[E]      import yolo.* needs result type because its right-hand side attempts implicit search
[E]
[E]       Run with -explain-cyclic for more details.
[E]      L19: val xa = Transactor.fromDriverManager[IO](
[E]                                                    ^
[E] src/main/scala/Main.scala: L19 [E1], L34 [E2]
```

Adding a type annotation fixes this and (I think) should be backwards-compatible with Scala 2, so I figured I'd raise a PR for this.