### PR TITLE
fix query cancellation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         run: sbt +update
 
       - name: Start up Postgres
-        run: docker-compose up -d
+        run: docker compose up -d
 
       - name: Check Headers
         run: sbt '++ ${{ matrix.scala }}' headerCheckAll

--- a/build.sbt
+++ b/build.sbt
@@ -429,6 +429,7 @@ lazy val hikari = project
     libraryDependencies ++= Seq(
       // needs to be excluded, otherwise coursier may resolve slf4j-api 2 if > Java 11
       "com.zaxxer" % "HikariCP" % hikariVersion exclude ("org.slf4j", "slf4j-api"),
+      "org.postgresql" % "postgresql" % postgresVersion % "test",
       "com.h2database" % "h2" % h2Version % "test",
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.slf4j" % "slf4j-nop" % slf4jVersion % "test"

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ ThisBuild / tlSonatypeUseLegacyHost := false
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("11"))
 ThisBuild / githubWorkflowBuildPreamble ++= Seq(
   WorkflowStep.Run(
-    commands = List("docker-compose up -d"),
+    commands = List("docker compose up -d"),
     name = Some("Start up Postgres")
   ),
   WorkflowStep.Sbt(

--- a/modules/core/src/main/scala/doobie/util/transactor.scala
+++ b/modules/core/src/main/scala/doobie/util/transactor.scala
@@ -332,7 +332,8 @@ object transactor {
       )(implicit ev: Async[M]): Transactor.Aux[M, A] = {
         val connect =
           (dataSource: A) => Resource.fromAutoCloseable(ev.evalOn(ev.delay(dataSource.getConnection()), connectEC))
-        val interp = KleisliInterpreter[M](logHandler.getOrElse(LogHandler.noop), Primitive.Cancellable[M]().some).ConnectionInterpreter
+        val interp =
+          KleisliInterpreter[M](logHandler.getOrElse(LogHandler.noop), Primitive.Cancellable[M]().some).ConnectionInterpreter
         Transactor(dataSource, connect, interp, Strategy.default)
       }
     }
@@ -352,7 +353,8 @@ object transactor {
           async: Async[M]
       ): Transactor.Aux[M, Connection] = {
         val connect = (c: Connection) => Resource.pure[M, Connection](c)
-        val interp = KleisliInterpreter[M](logHandler.getOrElse(LogHandler.noop), Primitive.Cancellable[M]().some).ConnectionInterpreter
+        val interp =
+          KleisliInterpreter[M](logHandler.getOrElse(LogHandler.noop), Primitive.Cancellable[M]().some).ConnectionInterpreter
         Transactor(connection, connect, interp, Strategy.default)
       }
     }

--- a/modules/core/src/main/scala/doobie/util/transactor.scala
+++ b/modules/core/src/main/scala/doobie/util/transactor.scala
@@ -252,7 +252,7 @@ object transactor {
       val strategy = strategy0
     }
 
-    def withLogHandler(logHandler: LogHandler[M])(implicit ev: WeakAsync[M]): Transactor.Aux[M, A] = copy(
+    def withLogHandler(logHandler: LogHandler[M])(implicit ev: Async[M]): Transactor.Aux[M, A] = copy(
       interpret0 =
         KleisliInterpreter[M](logHandler).ConnectionInterpreter
     )

--- a/modules/core/src/test/scala/doobie/util/QueryCancellationSuite.scala
+++ b/modules/core/src/test/scala/doobie/util/QueryCancellationSuite.scala
@@ -1,0 +1,51 @@
+// Copyright (c) 2013-2020 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.util
+
+import cats.effect.IO
+import doobie.Transactor
+import doobie.*
+import doobie.implicits.*
+import cats.syntax.all.*
+
+import scala.concurrent.duration.DurationInt
+
+class QueryCancellationSuite extends munit.FunSuite {
+  import cats.effect.unsafe.implicits.global
+
+  val xa = Transactor.fromDriverManager[IO](
+    driver = "org.h2.Driver",
+    url = "jdbc:h2:mem:queryspec;DB_CLOSE_DELAY=-1",
+    user = "sa",
+    password = "",
+    logHandler = None
+  )
+
+  test("Query cancel") {
+    val scenario = WeakAsync.liftIO[ConnectionIO].use { elevator =>
+      for {
+        _ <- sql"CREATE TABLE IF NOT EXISTS example_table ( id INT)".update.run.transact(xa)
+        _ <- sql"TRUNCATE TABLE example_table".update.run.transact(xa)
+        _ <- sql"INSERT INTO example_table (id) VALUES (1)".update.run.transact(xa)
+        _ <- {
+          sql"select * from example_table for update".query[Int].unique >> elevator.liftIO(IO.never)
+        }.transact(xa).start
+
+        insertWithLockFiber <- {
+          for {
+            _ <- IO.sleep(100.milli)
+            insertFiber <- sql"UPDATE example_table SET id = 2".update.run.transact(xa).start
+            _ <- IO.sleep(100.milli)
+            _ <- insertFiber.cancel
+          } yield ()
+        }.start
+
+        _ <- IO.race(insertWithLockFiber.join, IO.sleep(5.seconds) >> IO(fail("Cancellation is blocked")))
+        result <- sql"SELECT * FROM example_table".query[Int].to[List].transact(xa)
+      } yield assertEquals(result, List(1))
+    }
+    scenario.unsafeRunSync()
+  }
+}

--- a/modules/free/src/main/scala/doobie/free/Primitive.scala
+++ b/modules/free/src/main/scala/doobie/free/Primitive.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2013-2020 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.free
+
+import cats.data.Kleisli
+import cats.effect.Async
+import cats.effect.kernel.Outcome
+import doobie.WeakAsync
+
+sealed trait Primitive[M[_]] {
+  def primitive[J, A](f: J => A): Kleisli[M, J, A]
+}
+
+object Primitive {
+  case class Default[M[_]]()(implicit asyncM: WeakAsync[M]) extends Primitive[M] {
+
+    override def primitive[J, A](f: J => A): Kleisli[M, J, A] = Kleisli { a =>
+      // primitive JDBC methods throw exceptions and so do we when reading values
+      // so catch any non-fatal exceptions and lift them into the effect
+      try {
+        asyncM.blocking(f(a))
+      } catch {
+        case scala.util.control.NonFatal(e) => asyncM.raiseError(e)
+      }
+    }
+  }
+
+  case class Cancellable[M[_]]()(implicit asyncM: Async[M]) extends Primitive[M] {
+
+    override def primitive[J, A](f: J => A): Kleisli[M, J, A] = Kleisli { a =>
+      import cats.syntax.all._
+      import cats.effect.syntax.all._
+
+      asyncM.uncancelable { unmask =>
+        for {
+          jdbcBlockedFiber <- asyncM.blocking(f(a)).attempt.start
+          a <- unmask(jdbcBlockedFiber.join).flatMap(_.embedNever.rethrow)
+        } yield a
+      }
+    }
+  }
+}

--- a/modules/free/src/main/scala/doobie/free/Primitive.scala
+++ b/modules/free/src/main/scala/doobie/free/Primitive.scala
@@ -6,7 +6,6 @@ package doobie.free
 
 import cats.data.Kleisli
 import cats.effect.Async
-import cats.effect.kernel.Outcome
 import doobie.WeakAsync
 
 sealed trait Primitive[M[_]] {

--- a/modules/free/src/main/scala/doobie/free/kleisliinterpreter.scala
+++ b/modules/free/src/main/scala/doobie/free/kleisliinterpreter.scala
@@ -11,7 +11,6 @@ import cats.~>
 import cats.data.Kleisli
 import cats.effect.kernel.{Async, Outcome, Poll, Sync}
 import cats.free.Free
-import doobie.util.cancellation.CancellationForker
 import doobie.util.log.{LogEvent, LogHandler}
 
 import scala.concurrent.Future
@@ -102,6 +101,11 @@ class KleisliInterpreter[M[_]](logHandler: LogHandler[M])(implicit val asyncM: A
     // primitive JDBC methods throw exceptions and so do we when reading values
     // so catch any non-fatal exceptions and lift them into the effect
     import cats.syntax.all._
+//    try {
+//      asyncM.blocking(f(a))
+//    } catch {
+//      case scala.util.control.NonFatal(e) => asyncM.raiseError(e)
+//    }
     for {
       jdbcBlockedFiber <- asyncM.start(asyncM.blocking(f(a)).attempt)
       a <- jdbcBlockedFiber.join.flatMap {

--- a/modules/hikari/src/test/scala/doobie/HikariQueryCancellationSuite.scala
+++ b/modules/hikari/src/test/scala/doobie/HikariQueryCancellationSuite.scala
@@ -1,0 +1,56 @@
+// Copyright (c) 2013-2020 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie
+
+import cats.effect.*
+import cats.effect.unsafe.implicits.global
+import com.zaxxer.hikari.HikariConfig
+import doobie.hikari.HikariTransactor
+import doobie.implicits.*
+import doobie.util.transactor
+
+import scala.concurrent.duration.DurationInt
+
+class HikariQueryCancellationSuite extends munit.FunSuite {
+
+  // Typically you construct a transactor this way, using lifetime-managed thread pools.
+  val transactorRes: Resource[IO, Transactor[IO]] =
+    (for {
+      hikariConfig <- Resource.pure {
+        val config = new HikariConfig()
+        config.setDriverClassName("org.postgresql.Driver")
+        config.setJdbcUrl("jdbc:postgresql:world")
+        config.setUsername("postgres")
+        config.setPassword("password")
+        config.setMaximumPoolSize(2)
+        config
+      }
+      transactor <- HikariTransactor.fromHikariConfig[IO](hikariConfig)
+    } yield transactor)
+      .map(_.copy(strategy0 = transactor.Strategy.void))
+
+  test("Query cancel with Hikari") {
+    val insert = for {
+      _ <- sql"CREATE TABLE if not exists blah (i text)".update.run
+      _ <- sql"truncate table blah".update.run
+      _ <- sql"INSERT INTO blah values ('1')".update.run
+      _ <- sql"INSERT INTO blah select concat(2, pg_sleep(1))".update.run
+    } yield ()
+    val scenario = transactorRes.use { xa =>
+      for {
+        fiber <- insert.transact(xa).start
+        _ <- IO.sleep(200.millis) *> fiber.cancel
+        _ <- IO.sleep(3.second)
+        _ <- fiber.join.attempt
+        result <- sql"select * from blah order by i".query[String].to[List].transact(xa)
+      } yield {
+        assertEquals(result, List("1"))
+      }
+    }
+
+    scenario.unsafeRunSync()
+  }
+
+}

--- a/modules/hikari/src/test/scala/doobie/HikariQueryCancellationSuite.scala
+++ b/modules/hikari/src/test/scala/doobie/HikariQueryCancellationSuite.scala
@@ -21,9 +21,9 @@ class HikariQueryCancellationSuite extends munit.FunSuite {
       hikariConfig <- Resource.pure {
         val config = new HikariConfig()
         config.setDriverClassName("org.postgresql.Driver")
-        config.setJdbcUrl("jdbc:postgresql:world")
+        config.setJdbcUrl("jdbc:postgresql://localhost:5432/postgres")
         config.setUsername("postgres")
-        config.setPassword("password")
+        config.setPassword("mysecretpassword")
         config.setMaximumPoolSize(2)
         config
       }

--- a/modules/postgres/src/main/scala/doobie/postgres/free/kleisliinterpreter.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/free/kleisliinterpreter.scala
@@ -12,6 +12,7 @@ import cats.data.Kleisli
 import cats.effect.kernel.{ Poll, Sync }
 import cats.free.Free
 import doobie.WeakAsync
+import doobie.free.Primitive
 import doobie.util.log.{LogEvent, LogHandler}
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
@@ -44,12 +45,15 @@ import doobie.postgres.free.largeobjectmanager.{ LargeObjectManagerIO, LargeObje
 import doobie.postgres.free.pgconnection.{ PGConnectionIO, PGConnectionOp }
 
 object KleisliInterpreter {
-  def apply[M[_]: WeakAsync](logHandler: LogHandler[M]): KleisliInterpreter[M] =
-    new KleisliInterpreter[M](logHandler)
+  def apply[M[_]: WeakAsync](logHandler: LogHandler[M], customPrimitive: Option[Primitive[M]] = None): KleisliInterpreter[M] =
+    new KleisliInterpreter[M](logHandler, customPrimitive)
 }
 
 // Family of interpreters into Kleisli arrows for some monad M.
-class KleisliInterpreter[M[_]](logHandler: LogHandler[M])(implicit val asyncM: WeakAsync[M]) { outer =>
+class KleisliInterpreter[M[_]](logHandler: LogHandler[M], customPrimitive: Option[Primitive[M]] = None)(implicit val asyncM: WeakAsync[M]) { outer =>
+
+  private val _primitive = customPrimitive.getOrElse(Primitive.Default[M]())
+
 
   // The 6 interpreters, with definitions below. These can be overridden to customize behavior.
   lazy val CopyInInterpreter: CopyInOp ~> Kleisli[M, PGCopyIn, *] = new CopyInInterpreter { }
@@ -60,15 +64,8 @@ class KleisliInterpreter[M[_]](logHandler: LogHandler[M])(implicit val asyncM: W
   lazy val PGConnectionInterpreter: PGConnectionOp ~> Kleisli[M, PGConnection, *] = new PGConnectionInterpreter { }
 
   // Some methods are common to all interpreters and can be overridden to change behavior globally.
-  def primitive[J, A](f: J => A): Kleisli[M, J, A] = Kleisli { a =>
-    // primitive JDBC methods throw exceptions and so do we when reading values
-    // so catch any non-fatal exceptions and lift them into the effect
-    try {
-      asyncM.blocking(f(a))
-    } catch {
-      case scala.util.control.NonFatal(e) => asyncM.raiseError(e)
-    }
-  }
+  def primitive[J, A](f: J => A): Kleisli[M, J, A] = _primitive.primitive(f)
+
   def raw[J, A](f: J => A): Kleisli[M, J, A] = primitive(f)
   def raiseError[J, A](e: Throwable): Kleisli[M, J, A] = Kleisli(_ => asyncM.raiseError(e))
   def monotonic[J]: Kleisli[M, J, FiniteDuration] = Kleisli(_ => asyncM.monotonic)


### PR DESCRIPTION
After migrating Doobie to Cats Effect 3 (CE3), query cancellation no longer works as expected. When a query is canceled (using IO.cancel), the current fiber blocks, and PreparedStatement.close is not called immediately. This issue arises because in CE3, the cancellation of a fiber on a blocked thread does not trigger cancellation handlers right away, while PreparedStatement.close needs to be called in a cancellation handler.

Here is a code example that demonstrates this behavior. In CE2, the cancellation handler runs immediately, but in CE3, it only runs after the thread becomes unblocked:

```
import cats.effect.{Async, IO, IOApp}

object OnCancelTest extends IOApp.Simple {
  import scala.concurrent.duration._

  def goDB: IO[Unit] = IO(println("START goDB")).map(
    _ => Thread.sleep(10000)
  )
    .guarantee(
      IO(println("SEND CANCELLATION VIA JDBC"))
    )


  override def run: IO[Unit] =
    for {
      f <- goDB.start
      _ <- IO.sleep(1.second)
      _ <- f.cancel
      _ <- IO(println("CANCELLED goBD"))
    } yield ()
}
``` 
I also added unit test which reproduce that behaviour. 


Alternative more appropriate solution: https://github.com/tpolecat/doobie/pull/2079#issuecomment-2285146784
