### PR TITLE
Update build.sbt: keep Scala 2.13 and Scala 3 in otel4s module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,5 +219,5 @@ jobs:
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
-          modules-ignore: doobie_2.12 doobie_2.13 doobie_3 docs_2.12 docs_2.13 docs_3 example_2.12 example_2.13 example_3 bench_2.12 bench_2.13 bench_3
+          modules-ignore: doobie_2.12 doobie_2.13 doobie_3 docs_2.12 docs_2.13 docs_3 doobie-otel4s_2.13 doobie-otel4s_3 example_2.12 example_2.13 example_3 bench_2.12 bench_2.13 bench_3
           configs-ignore: test scala-tool scala-doc-tool test-internal

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -103,6 +103,14 @@ pull_request_rules:
       add:
       - mysql
       remove: []
+- name: Label otel4s PRs
+  conditions:
+  - files~=^modules/otel4s/
+  actions:
+    label:
+      add:
+      - otel4s
+      remove: []
 - name: Label postgres PRs
   conditions:
   - files~=^modules/postgres/

--- a/build.sbt
+++ b/build.sbt
@@ -592,6 +592,7 @@ lazy val otel4s = project
   .settings(
     name := "doobie-otel4s",
     description := "otel4s support for doobie.",
+    crossScalaVersions := Seq(scala213Version, scala3Version),
     libraryDependencies ++= Seq(
       "org.typelevel" %% "otel4s-core-trace" % otel4sVersion,
       "org.typelevel" %% "otel4s-semconv" % otel4sVersion,


### PR DESCRIPTION
That's a bit of an oversight from my side. I forgot that doobie supports Scala 2.12, while otel4s is available only for Scala 2.13 and 3.