### PR TITLE
Setup sbt-projectmatrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        scala: [2.12, 2.13, 3]
+        scala: [2.13]
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -53,46 +53,45 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
-        run: sbt +update
+        run: sbt update
 
       - name: Start up Postgres
         run: docker compose up -d
 
       - name: Check Headers
-        run: sbt '++ ${{ matrix.scala }}' headerCheckAll
+        run: sbt headerCheckAll
 
       - name: Check that workflows are up to date
         run: sbt githubWorkflowCheck
 
       - name: Check formatting
         if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-22.04'
-        run: sbt '++ ${{ matrix.scala }}' scalafmtCheckAll 'project /' scalafmtSbtCheck
+        run: sbt scalafmtCheckAll 'project /' scalafmtSbtCheck
 
       - name: Test
-        run: sbt '++ ${{ matrix.scala }}' freeGen2 test
+        run: sbt freeGen2 test
 
       - name: Check binary compatibility
         if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-22.04'
-        run: sbt '++ ${{ matrix.scala }}' mimaReportBinaryIssues
+        run: sbt mimaReportBinaryIssues
 
       - name: Generate API documentation
         if: matrix.java == 'temurin@11' && matrix.os == 'ubuntu-22.04'
-        run: sbt '++ ${{ matrix.scala }}' doc
+        run: sbt doc
 
       - name: Check there are no uncommitted changes in git (to catch generated files that weren't committed)
-        run: sbt '++ ${{ matrix.scala }}' checkGitNoUncommittedChanges
+        run: sbt checkGitNoUncommittedChanges
 
       - name: Check Doc Site (2.13 only)
-        if: matrix.scala == '2.13'
-        run: sbt '++ ${{ matrix.scala }}' docs/makeSite
+        run: sbt docs/makeSite
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p modules/weaver/target modules/scalatest/target modules/refined/target modules/postgres/target modules/log4cats/target modules/postgres-circe/target modules/h2/target modules/testutils/target modules/hikari/target modules/munit/target modules/h2-circe/target modules/mysql/target modules/core/target modules/specs2/target modules/free/target project/target
+        run: mkdir -p modules/weaver/target/jvm-2.13 modules/munit/target/jvm-2.12 modules/scalatest/target/jvm-2.13 modules/refined/target/jvm-2.13 modules/testutils/target/jvm-2.12 modules/hikari/target/jvm-3 modules/free/target/jvm-2.12 modules/refined/target/jvm-2.12 modules/specs2/target/jvm-2.12 modules/core/target/jvm-2.12 modules/postgres/target/jvm-2.13 modules/core/target/jvm-3 modules/testutils/target/jvm-3 modules/munit/target/jvm-3 modules/refined/target/jvm-3 modules/hikari/target/jvm-2.12 modules/log4cats/target/jvm-2.13 modules/postgres-circe/target/jvm-2.13 modules/scalatest/target/jvm-3 modules/weaver/target/jvm-3 modules/h2/target/jvm-2.13 modules/testutils/target/jvm-2.13 modules/h2-circe/target/jvm-3 modules/postgres/target/jvm-3 modules/hikari/target/jvm-2.13 modules/scalatest/target/jvm-2.12 modules/mysql/target/jvm-2.12 modules/weaver/target/jvm-2.12 modules/log4cats/target/jvm-2.12 modules/postgres-circe/target/jvm-3 modules/munit/target/jvm-2.13 modules/h2/target/jvm-2.12 modules/h2-circe/target/jvm-2.13 modules/mysql/target/jvm-2.13 modules/postgres-circe/target/jvm-2.12 modules/specs2/target/jvm-3 modules/core/target/jvm-2.13 modules/free/target/jvm-3 modules/mysql/target/jvm-3 modules/h2-circe/target/jvm-2.12 modules/log4cats/target/jvm-3 modules/postgres/target/jvm-2.12 modules/specs2/target/jvm-2.13 modules/h2/target/jvm-3 modules/free/target/jvm-2.13 project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar modules/weaver/target modules/scalatest/target modules/refined/target modules/postgres/target modules/log4cats/target modules/postgres-circe/target modules/h2/target modules/testutils/target modules/hikari/target modules/munit/target modules/h2-circe/target modules/mysql/target modules/core/target modules/specs2/target modules/free/target project/target
+        run: tar cf targets.tar modules/weaver/target/jvm-2.13 modules/munit/target/jvm-2.12 modules/scalatest/target/jvm-2.13 modules/refined/target/jvm-2.13 modules/testutils/target/jvm-2.12 modules/hikari/target/jvm-3 modules/free/target/jvm-2.12 modules/refined/target/jvm-2.12 modules/specs2/target/jvm-2.12 modules/core/target/jvm-2.12 modules/postgres/target/jvm-2.13 modules/core/target/jvm-3 modules/testutils/target/jvm-3 modules/munit/target/jvm-3 modules/refined/target/jvm-3 modules/hikari/target/jvm-2.12 modules/log4cats/target/jvm-2.13 modules/postgres-circe/target/jvm-2.13 modules/scalatest/target/jvm-3 modules/weaver/target/jvm-3 modules/h2/target/jvm-2.13 modules/testutils/target/jvm-2.13 modules/h2-circe/target/jvm-3 modules/postgres/target/jvm-3 modules/hikari/target/jvm-2.13 modules/scalatest/target/jvm-2.12 modules/mysql/target/jvm-2.12 modules/weaver/target/jvm-2.12 modules/log4cats/target/jvm-2.12 modules/postgres-circe/target/jvm-3 modules/munit/target/jvm-2.13 modules/h2/target/jvm-2.12 modules/h2-circe/target/jvm-2.13 modules/mysql/target/jvm-2.13 modules/postgres-circe/target/jvm-2.12 modules/specs2/target/jvm-3 modules/core/target/jvm-2.13 modules/free/target/jvm-3 modules/mysql/target/jvm-3 modules/h2-circe/target/jvm-2.12 modules/log4cats/target/jvm-3 modules/postgres/target/jvm-2.12 modules/specs2/target/jvm-2.13 modules/h2/target/jvm-3 modules/free/target/jvm-2.13 project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
@@ -130,17 +129,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
-        run: sbt +update
-
-      - name: Download target directories (2.12)
-        uses: actions/download-artifact@v6
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12
-
-      - name: Inflate target directories (2.12)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
+        run: sbt update
 
       - name: Download target directories (2.13)
         uses: actions/download-artifact@v6
@@ -148,16 +137,6 @@ jobs:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.13
 
       - name: Inflate target directories (2.13)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (3)
-        uses: actions/download-artifact@v6
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3
-
-      - name: Inflate target directories (3)
         run: |
           tar xf targets.tar
           rm targets.tar
@@ -214,10 +193,10 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
-        run: sbt +update
+        run: sbt update
 
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
-          modules-ignore: doobie_2.12 doobie_2.13 doobie_3 docs_2.12 docs_2.13 docs_3 doobie-otel4s_2.13 doobie-otel4s_3 example_2.12 example_2.13 example_3 bench_2.12 bench_2.13 bench_3
+          modules-ignore: example_3 example_2.12 doobie_2.13 docs_2.13 bench_3 doobie-otel4s_2.13 doobie-otel4s_3 doobie-otel4s_2.13 doobie-otel4s_3 example_2.13 bench_2.13
           configs-ignore: test scala-tool scala-doc-tool test-internal

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,30 +10,52 @@ pull_request_rules:
   conditions:
   - author=scala-steward
   - body~=labels:.*early-semver-patch
-  - status-success=Test (ubuntu-22.04, 2.12, temurin@11)
   - status-success=Test (ubuntu-22.04, 2.13, temurin@11)
-  - status-success=Test (ubuntu-22.04, 3, temurin@11)
   actions:
     merge: {}
 - name: Label bench PRs
   conditions:
-  - files~=^modules/bench/
+  - files~=^.sbt/matrix/bench/
   actions:
     label:
       add:
       - bench
       remove: []
+- name: Label bench3 PRs
+  conditions:
+  - files~=^.sbt/matrix/bench3/
+  actions:
+    label:
+      add:
+      - bench3
+      remove: []
 - name: Label core PRs
   conditions:
-  - files~=^modules/core/
+  - files~=^.sbt/matrix/core/
   actions:
     label:
       add:
       - core
       remove: []
+- name: Label core2_12 PRs
+  conditions:
+  - files~=^.sbt/matrix/core2_12/
+  actions:
+    label:
+      add:
+      - core2_12
+      remove: []
+- name: Label core3 PRs
+  conditions:
+  - files~=^.sbt/matrix/core3/
+  actions:
+    label:
+      add:
+      - core3
+      remove: []
 - name: Label docs PRs
   conditions:
-  - files~=^modules/docs/
+  - files~=^.sbt/matrix/docs/
   actions:
     label:
       add:
@@ -41,23 +63,55 @@ pull_request_rules:
       remove: []
 - name: Label example PRs
   conditions:
-  - files~=^modules/example/
+  - files~=^.sbt/matrix/example/
   actions:
     label:
       add:
       - example
       remove: []
+- name: Label example2_12 PRs
+  conditions:
+  - files~=^.sbt/matrix/example2_12/
+  actions:
+    label:
+      add:
+      - example2_12
+      remove: []
+- name: Label example3 PRs
+  conditions:
+  - files~=^.sbt/matrix/example3/
+  actions:
+    label:
+      add:
+      - example3
+      remove: []
 - name: Label free PRs
   conditions:
-  - files~=^modules/free/
+  - files~=^.sbt/matrix/free/
   actions:
     label:
       add:
       - free
       remove: []
+- name: Label free2_12 PRs
+  conditions:
+  - files~=^.sbt/matrix/free2_12/
+  actions:
+    label:
+      add:
+      - free2_12
+      remove: []
+- name: Label free3 PRs
+  conditions:
+  - files~=^.sbt/matrix/free3/
+  actions:
+    label:
+      add:
+      - free3
+      remove: []
 - name: Label h2 PRs
   conditions:
-  - files~=^modules/h2/
+  - files~=^.sbt/matrix/h2/
   actions:
     label:
       add:
@@ -65,55 +119,159 @@ pull_request_rules:
       remove: []
 - name: Label h2-circe PRs
   conditions:
-  - files~=^modules/h2-circe/
+  - files~=^.sbt/matrix/h2-circe/
   actions:
     label:
       add:
       - h2-circe
       remove: []
+- name: Label h2-circe2_12 PRs
+  conditions:
+  - files~=^.sbt/matrix/h2-circe2_12/
+  actions:
+    label:
+      add:
+      - h2-circe2_12
+      remove: []
+- name: Label h2-circe3 PRs
+  conditions:
+  - files~=^.sbt/matrix/h2-circe3/
+  actions:
+    label:
+      add:
+      - h2-circe3
+      remove: []
+- name: Label h22_12 PRs
+  conditions:
+  - files~=^.sbt/matrix/h22_12/
+  actions:
+    label:
+      add:
+      - h22_12
+      remove: []
+- name: Label h23 PRs
+  conditions:
+  - files~=^.sbt/matrix/h23/
+  actions:
+    label:
+      add:
+      - h23
+      remove: []
 - name: Label hikari PRs
   conditions:
-  - files~=^modules/hikari/
+  - files~=^.sbt/matrix/hikari/
   actions:
     label:
       add:
       - hikari
       remove: []
+- name: Label hikari2_12 PRs
+  conditions:
+  - files~=^.sbt/matrix/hikari2_12/
+  actions:
+    label:
+      add:
+      - hikari2_12
+      remove: []
+- name: Label hikari3 PRs
+  conditions:
+  - files~=^.sbt/matrix/hikari3/
+  actions:
+    label:
+      add:
+      - hikari3
+      remove: []
 - name: Label log4cats PRs
   conditions:
-  - files~=^modules/log4cats/
+  - files~=^.sbt/matrix/log4cats/
   actions:
     label:
       add:
       - log4cats
       remove: []
+- name: Label log4cats2_12 PRs
+  conditions:
+  - files~=^.sbt/matrix/log4cats2_12/
+  actions:
+    label:
+      add:
+      - log4cats2_12
+      remove: []
+- name: Label log4cats3 PRs
+  conditions:
+  - files~=^.sbt/matrix/log4cats3/
+  actions:
+    label:
+      add:
+      - log4cats3
+      remove: []
 - name: Label munit PRs
   conditions:
-  - files~=^modules/munit/
+  - files~=^.sbt/matrix/munit/
   actions:
     label:
       add:
       - munit
       remove: []
+- name: Label munit2_12 PRs
+  conditions:
+  - files~=^.sbt/matrix/munit2_12/
+  actions:
+    label:
+      add:
+      - munit2_12
+      remove: []
+- name: Label munit3 PRs
+  conditions:
+  - files~=^.sbt/matrix/munit3/
+  actions:
+    label:
+      add:
+      - munit3
+      remove: []
 - name: Label mysql PRs
   conditions:
-  - files~=^modules/mysql/
+  - files~=^.sbt/matrix/mysql/
   actions:
     label:
       add:
       - mysql
       remove: []
+- name: Label mysql2_12 PRs
+  conditions:
+  - files~=^.sbt/matrix/mysql2_12/
+  actions:
+    label:
+      add:
+      - mysql2_12
+      remove: []
+- name: Label mysql3 PRs
+  conditions:
+  - files~=^.sbt/matrix/mysql3/
+  actions:
+    label:
+      add:
+      - mysql3
+      remove: []
 - name: Label otel4s PRs
   conditions:
-  - files~=^modules/otel4s/
+  - files~=^.sbt/matrix/otel4s/
   actions:
     label:
       add:
       - otel4s
       remove: []
+- name: Label otel4s3 PRs
+  conditions:
+  - files~=^.sbt/matrix/otel4s3/
+  actions:
+    label:
+      add:
+      - otel4s3
+      remove: []
 - name: Label postgres PRs
   conditions:
-  - files~=^modules/postgres/
+  - files~=^.sbt/matrix/postgres/
   actions:
     label:
       add:
@@ -121,57 +279,167 @@ pull_request_rules:
       remove: []
 - name: Label postgres-circe PRs
   conditions:
-  - files~=^modules/postgres-circe/
+  - files~=^.sbt/matrix/postgres-circe/
   actions:
     label:
       add:
       - postgres-circe
       remove: []
+- name: Label postgres-circe2_12 PRs
+  conditions:
+  - files~=^.sbt/matrix/postgres-circe2_12/
+  actions:
+    label:
+      add:
+      - postgres-circe2_12
+      remove: []
+- name: Label postgres-circe3 PRs
+  conditions:
+  - files~=^.sbt/matrix/postgres-circe3/
+  actions:
+    label:
+      add:
+      - postgres-circe3
+      remove: []
+- name: Label postgres2_12 PRs
+  conditions:
+  - files~=^.sbt/matrix/postgres2_12/
+  actions:
+    label:
+      add:
+      - postgres2_12
+      remove: []
+- name: Label postgres3 PRs
+  conditions:
+  - files~=^.sbt/matrix/postgres3/
+  actions:
+    label:
+      add:
+      - postgres3
+      remove: []
 - name: Label refined PRs
   conditions:
-  - files~=^modules/refined/
+  - files~=^.sbt/matrix/refined/
   actions:
     label:
       add:
       - refined
       remove: []
+- name: Label refined2_12 PRs
+  conditions:
+  - files~=^.sbt/matrix/refined2_12/
+  actions:
+    label:
+      add:
+      - refined2_12
+      remove: []
+- name: Label refined3 PRs
+  conditions:
+  - files~=^.sbt/matrix/refined3/
+  actions:
+    label:
+      add:
+      - refined3
+      remove: []
 - name: Label scalatest PRs
   conditions:
-  - files~=^modules/scalatest/
+  - files~=^.sbt/matrix/scalatest/
   actions:
     label:
       add:
       - scalatest
       remove: []
+- name: Label scalatest2_12 PRs
+  conditions:
+  - files~=^.sbt/matrix/scalatest2_12/
+  actions:
+    label:
+      add:
+      - scalatest2_12
+      remove: []
+- name: Label scalatest3 PRs
+  conditions:
+  - files~=^.sbt/matrix/scalatest3/
+  actions:
+    label:
+      add:
+      - scalatest3
+      remove: []
 - name: Label specs2 PRs
   conditions:
-  - files~=^modules/specs2/
+  - files~=^.sbt/matrix/specs2/
   actions:
     label:
       add:
       - specs2
       remove: []
+- name: Label specs22_12 PRs
+  conditions:
+  - files~=^.sbt/matrix/specs22_12/
+  actions:
+    label:
+      add:
+      - specs22_12
+      remove: []
+- name: Label specs23 PRs
+  conditions:
+  - files~=^.sbt/matrix/specs23/
+  actions:
+    label:
+      add:
+      - specs23
+      remove: []
 - name: Label testutils PRs
   conditions:
-  - files~=^modules/testutils/
+  - files~=^.sbt/matrix/testutils/
   actions:
     label:
       add:
       - testutils
       remove: []
+- name: Label testutils2_12 PRs
+  conditions:
+  - files~=^.sbt/matrix/testutils2_12/
+  actions:
+    label:
+      add:
+      - testutils2_12
+      remove: []
+- name: Label testutils3 PRs
+  conditions:
+  - files~=^.sbt/matrix/testutils3/
+  actions:
+    label:
+      add:
+      - testutils3
+      remove: []
 - name: Label weaver PRs
   conditions:
-  - files~=^modules/weaver/
+  - files~=^.sbt/matrix/weaver/
   actions:
     label:
       add:
       - weaver
       remove: []
+- name: Label weaver2_12 PRs
+  conditions:
+  - files~=^.sbt/matrix/weaver2_12/
+  actions:
+    label:
+      add:
+      - weaver2_12
+      remove: []
+- name: Label weaver3 PRs
+  conditions:
+  - files~=^.sbt/matrix/weaver3/
+  actions:
+    label:
+      add:
+      - weaver3
+      remove: []
 - name: merge-when-ci-pass
   conditions:
-  - status-success=Test (ubuntu-22.04, 2.12, temurin@11)
   - status-success=Test (ubuntu-22.04, 2.13, temurin@11)
-  - status-success=Test (ubuntu-22.04, 3, temurin@11)
   - label=merge-on-build-success
   actions:
     merge: {}

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ lazy val specs2Version = "4.23.0"
 lazy val scala212Version = "2.12.21"
 lazy val scala213Version = "2.13.18"
 lazy val scala3Version = "3.3.7"
+lazy val allScalaVersions = List(scala212Version, scala213Version, scala3Version)
 // scala-steward:off
 lazy val slf4jVersion = "1.7.36"
 // scala-steward:on
@@ -38,7 +39,6 @@ ThisBuild / tlCiScalafmtCheck := true
 //ThisBuild / scalaVersion := scala212Version
 ThisBuild / scalaVersion := scala213Version
 // ThisBuild / scalaVersion := scala3Version
-ThisBuild / crossScalaVersions := Seq(scala212Version, scala213Version, scala3Version)
 ThisBuild / developers += tlGitHubDev("tpolecat", "Rob Norris")
 ThisBuild / tpolecatDefaultOptionsMode :=
   (if (sys.env.contains("CI")) CiMode else DevMode)
@@ -53,6 +53,7 @@ ThisBuild / githubWorkflowBuildPreamble ++= Seq(
     name = Some("Check Headers")
   )
 )
+ThisBuild / githubWorkflowBuildSbtStepPreamble := Seq.empty
 ThisBuild / githubWorkflowBuild := {
   val current = (ThisBuild / githubWorkflowBuild).value
   current.map {
@@ -74,10 +75,18 @@ ThisBuild / githubWorkflowBuildPostamble ++= Seq(
   ),
   WorkflowStep.Sbt(
     commands = List("docs/makeSite"),
-    name = Some(s"Check Doc Site (2.13 only)"),
-    cond = Some(s"matrix.scala == '2.13'")
+    name = Some(s"Check Doc Site (2.13 only)")
+    // cond = Some(s"matrix.scala == '2.13'")
   )
 )
+ThisBuild / githubWorkflowJobSetup ~= { steps =>
+  steps.map {
+    // change "sbt +update" to "sbt update" as the former doesn't work with sbt-projectmatrix
+    case s: WorkflowStep.Sbt if s.name == Some("sbt update") =>
+      s.withCommands(List("update"))
+    case s => s
+  }
+}
 
 ThisBuild / mergifyPrRules += MergifyPrRule(
   name = "merge-when-ci-pass",
@@ -186,28 +195,28 @@ lazy val doobie = project.in(file("."))
     }
   )
   .aggregate(
-    bench,
-    core,
-    docs,
-    example,
-    free,
-    h2,
-    `h2-circe`,
-    hikari,
-    mysql,
-    log4cats,
-    postgres,
-    `postgres-circe`,
-    refined,
-    otel4s,
-    scalatest,
-    munit,
-    specs2,
-    weaver,
-    testutils
+    bench.projectRefs ++
+      core.projectRefs ++
+      docs.projectRefs ++
+      example.projectRefs ++
+      free.projectRefs ++
+      h2.projectRefs ++
+      `h2-circe`.projectRefs ++
+      hikari.projectRefs ++
+      mysql.projectRefs ++
+      log4cats.projectRefs ++
+      postgres.projectRefs ++
+      `postgres-circe`.projectRefs ++
+      refined.projectRefs ++
+      otel4s.projectRefs ++
+      scalatest.projectRefs ++
+      munit.projectRefs ++
+      specs2.projectRefs ++
+      weaver.projectRefs ++
+      testutils.projectRefs: _*
   )
 
-lazy val free = project
+lazy val free = projectMatrix
   .in(file("modules/free"))
   .enablePlugins(AutomateHeaderPlugin)
   .settings(doobieSettings)
@@ -252,8 +261,9 @@ lazy val free = project
       classOf[java.io.OutputStream]
     )
   )
+  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val core = project
+lazy val core = projectMatrix
   .in(file("modules/core"))
   .enablePlugins(AutomateHeaderPlugin)
   .dependsOn(free)
@@ -305,8 +315,9 @@ lazy val core = project
       Seq(outFile)
     }.taskValue
   )
+  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val log4cats = project
+lazy val log4cats = projectMatrix
   .in(file("modules/log4cats"))
   .enablePlugins(AutomateHeaderPlugin)
   .dependsOn(core)
@@ -316,8 +327,9 @@ lazy val log4cats = project
     description := "log4cats support for doobie.",
     libraryDependencies += "org.typelevel" %% "log4cats-core" % log4catsVersion
   )
+  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val example = project
+lazy val example = projectMatrix
   .in(file("modules/example"))
   .enablePlugins(NoPublishPlugin)
   .enablePlugins(AutomateHeaderPlugin)
@@ -328,8 +340,9 @@ lazy val example = project
       "co.fs2" %% "fs2-io" % fs2Version
     )
   )
+  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val mysql = project
+lazy val mysql = projectMatrix
   .in(file("modules/mysql"))
   .enablePlugins(AutomateHeaderPlugin)
   .dependsOn(core % "compile->compile;test->test")
@@ -340,8 +353,9 @@ lazy val mysql = project
       "com.mysql" % "mysql-connector-j" % mysqlVersion
     )
   )
+  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val postgres = project
+lazy val postgres = projectMatrix
   .in(file("modules/postgres"))
   .enablePlugins(AutomateHeaderPlugin)
   .dependsOn(core % "compile->compile;test->test")
@@ -397,8 +411,9 @@ lazy val postgres = project
       """,
     consoleQuick / initialCommands := ""
   )
+  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val `postgres-circe` = project
+lazy val `postgres-circe` = projectMatrix
   .in(file("modules/postgres-circe"))
   .enablePlugins(AutomateHeaderPlugin)
   .dependsOn(core, postgres)
@@ -411,8 +426,9 @@ lazy val `postgres-circe` = project
       "io.circe" %% "circe-parser" % circeVersion
     )
   )
+  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val h2 = project
+lazy val h2 = projectMatrix
   .in(file("modules/h2"))
   .enablePlugins(AutomateHeaderPlugin)
   .settings(doobieSettings)
@@ -422,8 +438,9 @@ lazy val h2 = project
     description := "H2 support for doobie.",
     libraryDependencies += "com.h2database" % "h2" % h2Version
   )
+  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val `h2-circe` = project
+lazy val `h2-circe` = projectMatrix
   .in(file("modules/h2-circe"))
   .enablePlugins(AutomateHeaderPlugin)
   .dependsOn(core, h2)
@@ -436,8 +453,9 @@ lazy val `h2-circe` = project
       "io.circe" %% "circe-parser" % circeVersion
     )
   )
+  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val hikari = project
+lazy val hikari = projectMatrix
   .in(file("modules/hikari"))
   .enablePlugins(AutomateHeaderPlugin)
   .dependsOn(core)
@@ -456,8 +474,9 @@ lazy val hikari = project
       "org.slf4j" % "slf4j-nop" % slf4jVersion % "test"
     )
   )
+  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val specs2 = project
+lazy val specs2 = projectMatrix
   .in(file("modules/specs2"))
   .enablePlugins(AutomateHeaderPlugin)
   .dependsOn(core, testutils % "test->test", h2 % "test")
@@ -467,8 +486,9 @@ lazy val specs2 = project
     description := "Specs2 support for doobie.",
     libraryDependencies += "org.specs2" %% "specs2-core" % specs2Version
   )
+  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val scalatest = project
+lazy val scalatest = projectMatrix
   .in(file("modules/scalatest"))
   .enablePlugins(AutomateHeaderPlugin)
   .dependsOn(core)
@@ -481,8 +501,9 @@ lazy val scalatest = project
       "com.h2database" % "h2" % h2Version % "test"
     )
   )
+  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val munit = project
+lazy val munit = projectMatrix
   .in(file("modules/munit"))
   .enablePlugins(AutomateHeaderPlugin)
   .dependsOn(core)
@@ -496,8 +517,9 @@ lazy val munit = project
       "com.h2database" % "h2" % h2Version % "test"
     )
   )
+  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val weaver = project
+lazy val weaver = projectMatrix
   .in(file("modules/weaver"))
   .enablePlugins(AutomateHeaderPlugin)
   .dependsOn(core)
@@ -511,16 +533,18 @@ lazy val weaver = project
       "com.h2database" % "h2" % h2Version % "test"
     )
   )
+  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val bench = project
+lazy val bench = projectMatrix
   .in(file("modules/bench"))
   .enablePlugins(NoPublishPlugin)
   .enablePlugins(AutomateHeaderPlugin)
   .enablePlugins(JmhPlugin)
   .dependsOn(core, postgres, hikari)
   .settings(doobieSettings)
+  .jvmPlatform(scalaVersions = Seq(scala213Version, scala3Version))
 
-lazy val docs = project
+lazy val docs = projectMatrix
   .in(file("modules/docs"))
   .dependsOn(core, postgres, specs2, munit, hikari, h2, scalatest, weaver)
   .enablePlugins(NoPublishPlugin)
@@ -547,7 +571,7 @@ lazy val docs = project
     version := version.value.takeWhile(_ != '+'), // strip off the +3-f22dca22+20191110-1520-SNAPSHOT business
     paradoxProperties ++= Map(
       "scala-versions" -> {
-        val crossVersions = (core / crossScalaVersions).value.flatMap(CrossVersion.partialVersion)
+        val crossVersions = allScalaVersions.flatMap(CrossVersion.partialVersion)
         val scala2Versions = crossVersions.filter(_._1 == 2).map(_._2).mkString("2.", "/", "") // 2.12/13
         val scala3 = crossVersions.find(_._1 == 3).map(_ => "3") // 3
         List(Some(scala2Versions), scala3).flatten.filter(_.nonEmpty).mkString(" and ") // 2.12/13 and 3
@@ -563,14 +587,15 @@ lazy val docs = project
       "scalaVersion" -> scalaVersion.value,
       "canonical.base_url" -> "https://github.com/typelevel/doobie/"
     ),
-    mdocIn := baseDirectory.value / "src" / "main" / "mdoc",
+    mdocIn := (ThisBuild / baseDirectory).value / "modules" / "docs" / "src" / "main" / "mdoc",
     ghpagesRepository := (ThisBuild / baseDirectory).value / "doc_worktree",
     mdocExtraArguments ++= Seq("--no-link-hygiene"),
     Compile / paradox / sourceDirectory := mdocOut.value,
     makeSite := makeSite.dependsOn(mdoc.toTask("")).value
   )
+  .jvmPlatform(scalaVersions = Seq(scala213Version))
 
-lazy val refined = project
+lazy val refined = projectMatrix
   .in(file("modules/refined"))
   .enablePlugins(AutomateHeaderPlugin)
   .dependsOn(core)
@@ -583,8 +608,9 @@ lazy val refined = project
       "com.h2database" % "h2" % h2Version % "test"
     )
   )
+  .jvmPlatform(scalaVersions = allScalaVersions)
 
-lazy val otel4s = project
+lazy val otel4s = projectMatrix
   .in(file("modules/otel4s"))
   .enablePlugins(AutomateHeaderPlugin, NoPublishPlugin)
   .dependsOn(core)
@@ -602,12 +628,14 @@ lazy val otel4s = project
       "com.h2database" % "h2" % h2Version % "test"
     )
   )
+  .jvmPlatform(scalaVersions = Seq(scala213Version, scala3Version))
 
-lazy val testutils = project
+lazy val testutils = projectMatrix
   .in(file("modules/testutils"))
   .enablePlugins(AutomateHeaderPlugin)
   .settings(doobieSettings)
   .settings(publish / skip := true)
+  .jvmPlatform(scalaVersions = allScalaVersions)
 
 lazy val checkGitNoUncommittedChanges =
   taskKey[Unit]("Check git working tree is clean (no uncommitted changes) due to generated code not being committed")

--- a/modules/free/src/main/scala/doobie/free/blob.scala
+++ b/modules/free/src/main/scala/doobie/free/blob.scala
@@ -188,6 +188,7 @@ object blob { module =>
   def cancelable[A](fa: BlobIO[A], fin: BlobIO[Unit]) = FF.liftF[BlobOp, A](Cancelable(fa, fin))
   def performLogging(event: LogEvent) = FF.liftF[BlobOp, Unit](PerformLogging(event))
 
+
   // Smart constructors for Blob-specific operations.
   val free: BlobIO[Unit] = FF.liftF(Free)
   val getBinaryStream: BlobIO[InputStream] = FF.liftF(GetBinaryStream)

--- a/modules/free/src/main/scala/doobie/free/callablestatement.scala
+++ b/modules/free/src/main/scala/doobie/free/callablestatement.scala
@@ -1097,6 +1097,7 @@ object callablestatement { module =>
   def cancelable[A](fa: CallableStatementIO[A], fin: CallableStatementIO[Unit]) = FF.liftF[CallableStatementOp, A](Cancelable(fa, fin))
   def performLogging(event: LogEvent) = FF.liftF[CallableStatementOp, Unit](PerformLogging(event))
 
+
   // Smart constructors for CallableStatement-specific operations.
   val addBatch: CallableStatementIO[Unit] = FF.liftF(AddBatch)
   def addBatch(a: String): CallableStatementIO[Unit] = FF.liftF(AddBatch1(a))

--- a/modules/free/src/main/scala/doobie/free/clob.scala
+++ b/modules/free/src/main/scala/doobie/free/clob.scala
@@ -199,6 +199,7 @@ object clob { module =>
   def cancelable[A](fa: ClobIO[A], fin: ClobIO[Unit]) = FF.liftF[ClobOp, A](Cancelable(fa, fin))
   def performLogging(event: LogEvent) = FF.liftF[ClobOp, Unit](PerformLogging(event))
 
+
   // Smart constructors for Clob-specific operations.
   val free: ClobIO[Unit] = FF.liftF(Free)
   val getAsciiStream: ClobIO[InputStream] = FF.liftF(GetAsciiStream)

--- a/modules/free/src/main/scala/doobie/free/connection.scala
+++ b/modules/free/src/main/scala/doobie/free/connection.scala
@@ -399,6 +399,7 @@ object connection { module =>
   def cancelable[A](fa: ConnectionIO[A], fin: ConnectionIO[Unit]) = FF.liftF[ConnectionOp, A](Cancelable(fa, fin))
   def performLogging(event: LogEvent) = FF.liftF[ConnectionOp, Unit](PerformLogging(event))
 
+
   // Smart constructors for Connection-specific operations.
   def abort(a: Executor): ConnectionIO[Unit] = FF.liftF(Abort(a))
   val beginRequest: ConnectionIO[Unit] = FF.liftF(BeginRequest)

--- a/modules/free/src/main/scala/doobie/free/databasemetadata.scala
+++ b/modules/free/src/main/scala/doobie/free/databasemetadata.scala
@@ -863,6 +863,7 @@ object databasemetadata { module =>
   def cancelable[A](fa: DatabaseMetaDataIO[A], fin: DatabaseMetaDataIO[Unit]) = FF.liftF[DatabaseMetaDataOp, A](Cancelable(fa, fin))
   def performLogging(event: LogEvent) = FF.liftF[DatabaseMetaDataOp, Unit](PerformLogging(event))
 
+
   // Smart constructors for DatabaseMetaData-specific operations.
   val allProceduresAreCallable: DatabaseMetaDataIO[Boolean] = FF.liftF(AllProceduresAreCallable)
   val allTablesAreSelectable: DatabaseMetaDataIO[Boolean] = FF.liftF(AllTablesAreSelectable)

--- a/modules/free/src/main/scala/doobie/free/driver.scala
+++ b/modules/free/src/main/scala/doobie/free/driver.scala
@@ -175,6 +175,7 @@ object driver { module =>
   def cancelable[A](fa: DriverIO[A], fin: DriverIO[Unit]) = FF.liftF[DriverOp, A](Cancelable(fa, fin))
   def performLogging(event: LogEvent) = FF.liftF[DriverOp, Unit](PerformLogging(event))
 
+
   // Smart constructors for Driver-specific operations.
   def acceptsURL(a: String): DriverIO[Boolean] = FF.liftF(AcceptsURL(a))
   def connect(a: String, b: Properties): DriverIO[Connection] = FF.liftF(Connect(a, b))

--- a/modules/free/src/main/scala/doobie/free/kleisliinterpreter.scala
+++ b/modules/free/src/main/scala/doobie/free/kleisliinterpreter.scala
@@ -899,7 +899,6 @@ class KleisliInterpreter[M[_]](logHandler: LogHandler[M])(implicit val asyncM: W
 
     override def performLogging(event: LogEvent): Kleisli[M, PreparedStatement, Unit] = Kleisli(_ => logHandler.run(event))
     override def trace[A](event: TraceEvent, fa: PreparedStatementIO[A]): Kleisli[M, PreparedStatement, A] = outer.trace(event, this)(fa)
-
     // for operations using PreparedStatementIO we must call ourself recursively
     override def handleErrorWith[A](fa: PreparedStatementIO[A])(f: Throwable => PreparedStatementIO[A]): Kleisli[M, PreparedStatement, A] = outer.handleErrorWith(this)(fa)(f)
     override def forceR[A, B](fa: PreparedStatementIO[A])(fb: PreparedStatementIO[B]): Kleisli[M, PreparedStatement, B] = outer.forceR(this)(fa)(fb)

--- a/modules/free/src/main/scala/doobie/free/nclob.scala
+++ b/modules/free/src/main/scala/doobie/free/nclob.scala
@@ -200,6 +200,7 @@ object nclob { module =>
   def cancelable[A](fa: NClobIO[A], fin: NClobIO[Unit]) = FF.liftF[NClobOp, A](Cancelable(fa, fin))
   def performLogging(event: LogEvent) = FF.liftF[NClobOp, Unit](PerformLogging(event))
 
+
   // Smart constructors for NClob-specific operations.
   val free: NClobIO[Unit] = FF.liftF(Free)
   val getAsciiStream: NClobIO[InputStream] = FF.liftF(GetAsciiStream)

--- a/modules/free/src/main/scala/doobie/free/preparedstatement.scala
+++ b/modules/free/src/main/scala/doobie/free/preparedstatement.scala
@@ -10,11 +10,10 @@ import cats.{~>, Applicative, Semigroup, Monoid}
 import cats.effect.kernel.{ CancelScope, Poll, Sync }
 import cats.free.{ Free as FF } // alias because some algebras have an op called Free
 import doobie.util.log.LogEvent
-import doobie.util.trace.TraceEvent
 import doobie.WeakAsync
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
-
+import doobie.util.trace.TraceEvent
 import java.io.InputStream
 import java.io.Reader
 import java.lang.Class
@@ -84,7 +83,6 @@ object preparedstatement { module =>
       def cancelable[A](fa: PreparedStatementIO[A], fin: PreparedStatementIO[Unit]): F[A]
       def performLogging(event: LogEvent): F[Unit]
       def trace[A](event: TraceEvent, fa: PreparedStatementIO[A]): F[A]
-
       // PreparedStatement
       def addBatch: F[Unit]
       def addBatch(a: String): F[Unit]
@@ -254,7 +252,6 @@ object preparedstatement { module =>
     case class Trace[A](event: TraceEvent, fa: PreparedStatementIO[A]) extends PreparedStatementOp[A] {
       def visit[F[_]](v: Visitor[F]) = v.trace(event, fa)
     }
-
     // PreparedStatement-specific operations.
     case object AddBatch extends PreparedStatementOp[Unit] {
       def visit[F[_]](v: Visitor[F]) = v.addBatch

--- a/modules/free/src/main/scala/doobie/free/ref.scala
+++ b/modules/free/src/main/scala/doobie/free/ref.scala
@@ -159,6 +159,7 @@ object ref { module =>
   def cancelable[A](fa: RefIO[A], fin: RefIO[Unit]) = FF.liftF[RefOp, A](Cancelable(fa, fin))
   def performLogging(event: LogEvent) = FF.liftF[RefOp, Unit](PerformLogging(event))
 
+
   // Smart constructors for Ref-specific operations.
   val getBaseTypeName: RefIO[String] = FF.liftF(GetBaseTypeName)
   val getObject: RefIO[AnyRef] = FF.liftF(GetObject)

--- a/modules/free/src/main/scala/doobie/free/resultset.scala
+++ b/modules/free/src/main/scala/doobie/free/resultset.scala
@@ -927,6 +927,7 @@ object resultset { module =>
   def cancelable[A](fa: ResultSetIO[A], fin: ResultSetIO[Unit]) = FF.liftF[ResultSetOp, A](Cancelable(fa, fin))
   def performLogging(event: LogEvent) = FF.liftF[ResultSetOp, Unit](PerformLogging(event))
 
+
   // Smart constructors for ResultSet-specific operations.
   def absolute(a: Int): ResultSetIO[Boolean] = FF.liftF(Absolute(a))
   val afterLast: ResultSetIO[Unit] = FF.liftF(AfterLast)

--- a/modules/free/src/main/scala/doobie/free/sqldata.scala
+++ b/modules/free/src/main/scala/doobie/free/sqldata.scala
@@ -157,6 +157,7 @@ object sqldata { module =>
   def cancelable[A](fa: SQLDataIO[A], fin: SQLDataIO[Unit]) = FF.liftF[SQLDataOp, A](Cancelable(fa, fin))
   def performLogging(event: LogEvent) = FF.liftF[SQLDataOp, Unit](PerformLogging(event))
 
+
   // Smart constructors for SQLData-specific operations.
   val getSQLTypeName: SQLDataIO[String] = FF.liftF(GetSQLTypeName)
   def readSQL(a: SQLInput, b: String): SQLDataIO[Unit] = FF.liftF(ReadSQL(a, b))

--- a/modules/free/src/main/scala/doobie/free/sqlinput.scala
+++ b/modules/free/src/main/scala/doobie/free/sqlinput.scala
@@ -270,6 +270,7 @@ object sqlinput { module =>
   def cancelable[A](fa: SQLInputIO[A], fin: SQLInputIO[Unit]) = FF.liftF[SQLInputOp, A](Cancelable(fa, fin))
   def performLogging(event: LogEvent) = FF.liftF[SQLInputOp, Unit](PerformLogging(event))
 
+
   // Smart constructors for SQLInput-specific operations.
   val readArray: SQLInputIO[SqlArray] = FF.liftF(ReadArray)
   val readAsciiStream: SQLInputIO[InputStream] = FF.liftF(ReadAsciiStream)

--- a/modules/free/src/main/scala/doobie/free/sqloutput.scala
+++ b/modules/free/src/main/scala/doobie/free/sqloutput.scala
@@ -272,6 +272,7 @@ object sqloutput { module =>
   def cancelable[A](fa: SQLOutputIO[A], fin: SQLOutputIO[Unit]) = FF.liftF[SQLOutputOp, A](Cancelable(fa, fin))
   def performLogging(event: LogEvent) = FF.liftF[SQLOutputOp, Unit](PerformLogging(event))
 
+
   // Smart constructors for SQLOutput-specific operations.
   def writeArray(a: SqlArray): SQLOutputIO[Unit] = FF.liftF(WriteArray(a))
   def writeAsciiStream(a: InputStream): SQLOutputIO[Unit] = FF.liftF(WriteAsciiStream(a))

--- a/modules/free/src/main/scala/doobie/free/statement.scala
+++ b/modules/free/src/main/scala/doobie/free/statement.scala
@@ -371,6 +371,7 @@ object statement { module =>
   def cancelable[A](fa: StatementIO[A], fin: StatementIO[Unit]) = FF.liftF[StatementOp, A](Cancelable(fa, fin))
   def performLogging(event: LogEvent) = FF.liftF[StatementOp, Unit](PerformLogging(event))
 
+
   // Smart constructors for Statement-specific operations.
   def addBatch(a: String): StatementIO[Unit] = FF.liftF(AddBatch(a))
   val cancel: StatementIO[Unit] = FF.liftF(Cancel)

--- a/modules/otel4s/src/test/scala/doobie/otel4s/TracedTransactorSuite.scala
+++ b/modules/otel4s/src/test/scala/doobie/otel4s/TracedTransactorSuite.scala
@@ -135,8 +135,10 @@ class TracedTransactorSuite extends munit.CatsEffectSuite {
 
     for {
       tx <- testkit.tracedTransactor(config)
-      _ <- sql"select 1".query[Int].unique.transact(tx)
-      _ <- sql"select 2".query[Int].unique.transact(tx)
+      _ <- (for {
+        _ <- sql"select 1".query[Int].unique
+        _ <- sql"select 2".query[Int].unique
+      } yield ()).transact(tx)
       _ <- testkit.finishedSpans.assertEquals(expected)
     } yield ()
   }

--- a/modules/postgres/src/main/scala/doobie/postgres/free/copyin.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/free/copyin.scala
@@ -183,6 +183,7 @@ object copyin { module =>
   def cancelable[A](fa: CopyInIO[A], fin: CopyInIO[Unit]) = FF.liftF[CopyInOp, A](Cancelable(fa, fin))
   def performLogging(event: LogEvent) = FF.liftF[CopyInOp, Unit](PerformLogging(event))
 
+
   // Smart constructors for CopyIn-specific operations.
   val cancelCopy: CopyInIO[Unit] = FF.liftF(CancelCopy)
   val endCopy: CopyInIO[Long] = FF.liftF(EndCopy)

--- a/modules/postgres/src/main/scala/doobie/postgres/free/copymanager.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/free/copymanager.scala
@@ -191,6 +191,7 @@ object copymanager { module =>
   def cancelable[A](fa: CopyManagerIO[A], fin: CopyManagerIO[Unit]) = FF.liftF[CopyManagerOp, A](Cancelable(fa, fin))
   def performLogging(event: LogEvent) = FF.liftF[CopyManagerOp, Unit](PerformLogging(event))
 
+
   // Smart constructors for CopyManager-specific operations.
   def copyDual(a: String): CopyManagerIO[PGCopyDual] = FF.liftF(CopyDual(a))
   def copyIn(a: String): CopyManagerIO[PGCopyIn] = FF.liftF(CopyIn(a))

--- a/modules/postgres/src/main/scala/doobie/postgres/free/copyout.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/free/copyout.scala
@@ -174,6 +174,7 @@ object copyout { module =>
   def cancelable[A](fa: CopyOutIO[A], fin: CopyOutIO[Unit]) = FF.liftF[CopyOutOp, A](Cancelable(fa, fin))
   def performLogging(event: LogEvent) = FF.liftF[CopyOutOp, Unit](PerformLogging(event))
 
+
   // Smart constructors for CopyOut-specific operations.
   val cancelCopy: CopyOutIO[Unit] = FF.liftF(CancelCopy)
   val getFieldCount: CopyOutIO[Int] = FF.liftF(GetFieldCount)

--- a/modules/postgres/src/main/scala/doobie/postgres/free/largeobject.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/free/largeobject.scala
@@ -229,6 +229,7 @@ object largeobject { module =>
   def cancelable[A](fa: LargeObjectIO[A], fin: LargeObjectIO[Unit]) = FF.liftF[LargeObjectOp, A](Cancelable(fa, fin))
   def performLogging(event: LogEvent) = FF.liftF[LargeObjectOp, Unit](PerformLogging(event))
 
+
   // Smart constructors for LargeObject-specific operations.
   val close: LargeObjectIO[Unit] = FF.liftF(Close)
   val copy: LargeObjectIO[LargeObject] = FF.liftF(Copy)

--- a/modules/postgres/src/main/scala/doobie/postgres/free/largeobjectmanager.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/free/largeobjectmanager.scala
@@ -183,6 +183,7 @@ object largeobjectmanager { module =>
   def cancelable[A](fa: LargeObjectManagerIO[A], fin: LargeObjectManagerIO[Unit]) = FF.liftF[LargeObjectManagerOp, A](Cancelable(fa, fin))
   def performLogging(event: LogEvent) = FF.liftF[LargeObjectManagerOp, Unit](PerformLogging(event))
 
+
   // Smart constructors for LargeObjectManager-specific operations.
   val createLO: LargeObjectManagerIO[Long] = FF.liftF(CreateLO)
   def createLO(a: Int): LargeObjectManagerIO[Long] = FF.liftF(CreateLO1(a))

--- a/modules/postgres/src/main/scala/doobie/postgres/free/pgconnection.scala
+++ b/modules/postgres/src/main/scala/doobie/postgres/free/pgconnection.scala
@@ -256,6 +256,7 @@ object pgconnection { module =>
   def cancelable[A](fa: PGConnectionIO[A], fin: PGConnectionIO[Unit]) = FF.liftF[PGConnectionOp, A](Cancelable(fa, fin))
   def performLogging(event: LogEvent) = FF.liftF[PGConnectionOp, Unit](PerformLogging(event))
 
+
   // Smart constructors for PGConnection-specific operations.
   def addDataType(a: String, b: Class[? <: org.postgresql.util.PGobject]): PGConnectionIO[Unit] = FF.liftF(AddDataType(a, b))
   def alterUserPassword(a: String, b: Array[Char], c: String): PGConnectionIO[Unit] = FF.liftF(AlterUserPassword(a, b, c))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,6 +11,7 @@ addSbtPlugin("com.github.sbt" % "sbt-header" % "5.11.0")
 addSbtPlugin("org.typelevel" % "sbt-tpolecat" % "0.5.2")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.8.2")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.5")
+addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.11.0")
 addDependencyTreePlugin
 
 // Setting semanticdbVersion explicitly as the version is defaulting to 4.12.3


### PR DESCRIPTION
Update FreeGen2 code generation for otel4s new `trace` methods

sbt-projectmatrix is needed because otel4s module only builds for 2.13/3, which won't
work in vanilla sbt cross building when we cross build against 2.12 too.

Also:
small test adjustment in TracedTransactorSuite
