### PR TITLE
Add otel4s-instrumentation module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,5 +197,5 @@ jobs:
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
-          modules-ignore: example_3 example_2.12 doobie_2.13 docs_2.13 bench_3 doobie-otel4s_2.13 doobie-otel4s_3 doobie-otel4s_2.13 doobie-otel4s_3 example_2.13 bench_2.13
+          modules-ignore: example_3 doobie-otel4s-instrumentation_2.13 doobie-otel4s-instrumentation_3 example_2.12 doobie_2.13 docs_2.13 bench_3 doobie-otel4s_2.13 doobie-otel4s_3 doobie-otel4s_2.13 doobie-otel4s_3 doobie-otel4s-instrumentation_2.13 doobie-otel4s-instrumentation_3 example_2.13 bench_2.13
           configs-ignore: test scala-tool scala-doc-tool test-internal

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -261,6 +261,22 @@ pull_request_rules:
       add:
       - otel4s
       remove: []
+- name: Label otel4s-instrumentation PRs
+  conditions:
+  - files~=^.sbt/matrix/otel4s-instrumentation/
+  actions:
+    label:
+      add:
+      - otel4s-instrumentation
+      remove: []
+- name: Label otel4s-instrumentation3 PRs
+  conditions:
+  - files~=^.sbt/matrix/otel4s-instrumentation3/
+  actions:
+    label:
+      add:
+      - otel4s-instrumentation3
+      remove: []
 - name: Label otel4s3 PRs
   conditions:
   - files~=^.sbt/matrix/otel4s3/

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ lazy val scalaCheckVersion = "1.15.4"
 lazy val scalatestVersion = "3.2.18"
 lazy val munitVersion = "1.2.3"
 lazy val otel4sVersion = "0.15.1"
+lazy val otelInstrumentationVersion = "2.25.0-alpha"
 lazy val shapelessVersion = "2.3.13"
 lazy val silencerVersion = "1.7.1"
 lazy val specs2Version = "4.23.0"
@@ -207,6 +208,7 @@ lazy val doobie = project.in(file("."))
       `postgres-circe`.projectRefs ++
       refined.projectRefs ++
       otel4s.projectRefs ++
+      `otel4s-instrumentation`.projectRefs ++
       scalatest.projectRefs ++
       munit.projectRefs ++
       specs2.projectRefs ++
@@ -622,6 +624,24 @@ lazy val otel4s = projectMatrix
       "org.typelevel" %% "otel4s-semconv" % otel4sVersion,
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-parser" % circeVersion,
+      "org.typelevel" %% "otel4s-oteljava-trace-testkit" % otel4sVersion % "test",
+      "com.h2database" % "h2" % h2Version % "test"
+    )
+  )
+  .jvmPlatform(scalaVersions = Seq(scala213Version, scala3Version))
+
+lazy val `otel4s-instrumentation` = projectMatrix
+  .in(file("modules/otel4s-instrumentation"))
+  .enablePlugins(AutomateHeaderPlugin, NoPublishPlugin)
+  .dependsOn(core)
+  .settings(doobieSettings)
+  .settings(
+    name := "doobie-otel4s-instrumentation",
+    description := "OpenTelemetry JDBC instrumentation support for doobie.",
+    crossScalaVersions := Seq(scala213Version, scala3Version),
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "otel4s-oteljava-trace" % otel4sVersion,
+      "io.opentelemetry.instrumentation" % "opentelemetry-jdbc" % otelInstrumentationVersion,
       "org.typelevel" %% "otel4s-oteljava-trace-testkit" % otel4sVersion % "test",
       "com.h2database" % "h2" % h2Version % "test"
     )

--- a/modules/otel4s-instrumentation/src/main/scala/doobie/otel4s/TracedJdbcInterpreter.scala
+++ b/modules/otel4s-instrumentation/src/main/scala/doobie/otel4s/TracedJdbcInterpreter.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2013-2020 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.otel4s
+
+import cats.data.Kleisli
+import cats.mtl.Ask
+import cats.syntax.flatMap.*
+import doobie.WeakAsync
+import doobie.free.KleisliInterpreter
+import doobie.util.log.LogHandler
+import org.typelevel.otel4s.oteljava.context.{AskContext, Context}
+
+private class TracedJdbcInterpreter[F[_]: WeakAsync: AskContext](
+    logHandler: LogHandler[F]
+) extends KleisliInterpreter(logHandler) {
+
+  override def primitive[J, A](f: J => A): Kleisli[F, J, A] = Kleisli { a =>
+    Ask[F, Context].ask.flatMap { ctx =>
+      // primitive JDBC methods throw exceptions and so do we when reading values
+      // so catch any non-fatal exceptions and lift them into the effect
+      try {
+        asyncM.blocking {
+          // make the current context active
+          val scope = ctx.underlying.makeCurrent()
+          try {
+            f(a)
+          } finally {
+            scope.close() // release the context
+          }
+        }
+      } catch {
+        case scala.util.control.NonFatal(e) => asyncM.raiseError(e)
+      }
+    }
+  }
+
+}
+
+object TracedJdbcInterpreter {
+
+  def apply[F[_]: WeakAsync: AskContext](logHandler: LogHandler[F]): KleisliInterpreter[F] =
+    new TracedJdbcInterpreter(logHandler)
+
+}

--- a/modules/otel4s-instrumentation/src/main/scala/doobie/otel4s/TracedJdbcTransactor.scala
+++ b/modules/otel4s-instrumentation/src/main/scala/doobie/otel4s/TracedJdbcTransactor.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2013-2020 Rob Norris and Contributors
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package doobie.otel4s
+
+import javax.sql.DataSource
+
+import doobie.util.log.LogHandler
+import doobie.{Transactor, WeakAsync}
+import io.opentelemetry.instrumentation.jdbc.datasource.JdbcTelemetry
+import org.typelevel.otel4s.oteljava.context.AskContext
+
+object TracedJdbcTransactor {
+
+  def dataSource[F[_]: WeakAsync: AskContext](
+      jdbcTelemetry: JdbcTelemetry,
+      transactor: Transactor.Aux[F, DataSource],
+      logHandler: Option[LogHandler[F]]
+  ): Transactor.Aux[F, DataSource] = {
+    val interpreter = new TracedJdbcInterpreter[F](logHandler.getOrElse(LogHandler.noop))
+    transactor.copy(
+      kernel0 = jdbcTelemetry.wrap(transactor.kernel),
+      interpret0 = interpreter.ConnectionInterpreter
+    )
+  }
+
+}


### PR DESCRIPTION
This module specifically targets the OpenTelemetry instrumentation module. However, it works **without** [IOLocal propagation](https://typelevel.org/cats-effect/docs/core/io-local#propagating-iolocals-as-threadlocals), which can incur a notable performance penalty.

Usage example: https://github.com/iRevive/otel4s-showcase/pull/6.

<img width="984" height="551" alt="image" src="https://github.com/user-attachments/assets/59baccb6-0fb2-493b-a56b-4d08cb4e6381" />

