### PR TITLE
Update stale dependency snippets, badges, and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-<img align="right" src="https://cdn.rawgit.com/typelevel/doobie/series/0.5.x/doobie_logo.svg" height="150px" style="padding-left: 20px"/>
+<img align="right" src="https://cdn.rawgit.com/typelevel/doobie/series/0.13.x/doobie_logo.svg" height="150px" style="padding-left: 20px"/>
 
 [![Discord](https://img.shields.io/discord/632277896739946517.svg?label=&logo=discord&logoColor=ffffff&color=404244&labelColor=6A7EC2)](https://discord.gg/7B4VfFTvsS)
-[![Join the chat at https://gitter.im/tpolecat/doobie](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/tpolecat/doobie?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Maven Central](https://img.shields.io/maven-central/v/org.tpolecat/doobie-core_2.12.svg)](https://central.sonatype.com/artifact/org.tpolecat/doobie-core_2.13)
-[![Javadocs](https://javadoc.io/badge/org.tpolecat/doobie-core_2.13.svg)](https://javadoc.io/doc/org.tpolecat/doobie-core_2.13)
+[![Maven Central](https://img.shields.io/maven-central/v/org.typelevel/doobie-core_2.13.svg)](https://central.sonatype.com/artifact/org.typelevel/doobie-core_2.13)
+[![Javadocs](https://javadoc.io/badge/org.typelevel/doobie-core_2.13.svg)](https://javadoc.io/doc/org.typelevel/doobie-core_2.13)
 
 **doobie** is a pure functional JDBC layer for Scala.
 

--- a/build.sbt
+++ b/build.sbt
@@ -597,6 +597,7 @@ lazy val docs = projectMatrix
   .enablePlugins(NoPublishPlugin)
   .enablePlugins(ParadoxPlugin)
   .enablePlugins(ParadoxSitePlugin)
+  .enablePlugins(SitePreviewPlugin)
   .enablePlugins(GhpagesPlugin)
   .enablePlugins(MdocPlugin)
   .settings(doobieSettings)

--- a/modules/docs/src/main/mdoc/docs/01-Introduction.md
+++ b/modules/docs/src/main/mdoc/docs/01-Introduction.md
@@ -14,11 +14,11 @@ This book is organized cookbook-style: we demonstrate a common task and then exp
 
 This library is designed for people who are interested in typed, pure functional programming. If you are not a [Cats](https://github.com/typelevel/cats) user or are not familiar with functional I/O and monadic effects, you may need to go slowly and may want to spend some time reading [Functional Programming in Scala](http://manning.com/bjarnason/), which introduces all of the ideas that you will find when exploring **doobie**.
 
-Having said this, if you find yourself confused or frustrated by this documentation or the **doobie** API, *please* ask a question on [Gitter](https://gitter.im/tpolecat/doobie), file an [issue](https://github.com/typelevel/doobie/issues) and ask for help. Both the library and the documentation are young and are changing quickly, and it is inevitable that some things will be unclear. Accordingly, **this book is updated continuously** to address problems and omissions.
+Having said this, if you find yourself confused or frustrated by this documentation or the **doobie** API, *please* ask a question on [Discord](https://discord.com/channels/632277896739946517/632727524434247691), file an [issue](https://github.com/typelevel/doobie/issues) and ask for help. Both the library and the documentation are young and are changing quickly, and it is inevitable that some things will be unclear. Accordingly, **this book is updated continuously** to address problems and omissions.
 
 ### The Setup
 
-This book is compiled as part of the build using the [tut](https://github.com/tpolecat/tut) tutorial generator, so the code examples are guaranteed to compile (and with luck should also work correctly). Each page stands on its own: if you copy and paste code samples starting from the top, it will work in your REPL as long as you have the proper setup, described here.
+This book is compiled as part of the build using the [mdoc](https://scalameta.org/mdoc/) documentation tool, so the code examples are guaranteed to compile (and with luck should also work correctly). Each page stands on its own: if you copy and paste code samples starting from the top, it will work in your REPL as long as you have the proper setup, described here.
 
 #### Sample Database Setup
 
@@ -70,9 +70,9 @@ scalaVersion := "$scalaVersion$" // Scala $scalaVersion$
 lazy val doobieVersion = "$version$"
 
 libraryDependencies ++= Seq(
-  "org.tpolecat" %% "doobie-core"     % doobieVersion,
-  "org.tpolecat" %% "doobie-postgres" % doobieVersion,
-  "org.tpolecat" %% "doobie-specs2"   % doobieVersion
+  "org.typelevel" %% "doobie-core"     % doobieVersion,
+  "org.typelevel" %% "doobie-postgres" % doobieVersion,
+  "org.typelevel" %% "doobie-specs2"   % doobieVersion
 )
 ```
 @@@
@@ -111,4 +111,4 @@ woozle(nel) // doesn't compile
 
 ### Feedback and Contributions
 
-Feedback on **doobie** or this book is genuinely welcome. Please feel free to file a [pull request](https://github.com/tpolecat/doobie) if you have a contribution, or file an [issue](https://github.com/typelevel/doobie/issues), or chat with us on [Gitter](https://gitter.im/tpolecat/doobie).
+Feedback on **doobie** or this book is genuinely welcome. Please feel free to file a [pull request](https://github.com/typelevel/doobie) if you have a contribution, or file an [issue](https://github.com/typelevel/doobie/issues), or chat with us on [Discord](https://discord.com/channels/632277896739946517/632727524434247691).

--- a/modules/docs/src/main/mdoc/docs/15-Extensions-PostgreSQL.md
+++ b/modules/docs/src/main/mdoc/docs/15-Extensions-PostgreSQL.md
@@ -4,7 +4,7 @@ In this chapter we discuss the extended support that **doobie** offers for users
 
 @@@ vars
 ```scala
-libraryDependencies += "org.tpolecat" %% "doobie-postgres" % "$version$"
+libraryDependencies += "org.typelevel" %% "doobie-postgres" % "$version$"
 ```
 @@@
 
@@ -18,7 +18,7 @@ There are extensions available for dealing with JSON by using Circe, if you like
 @@@ vars
 
 ```scala
-libraryDependencies += "org.tpolecat" %% "doobie-postgres-circe" % "$version$"
+libraryDependencies += "org.typelevel" %% "doobie-postgres-circe" % "$version$"
 ```
 
 @@@

--- a/modules/docs/src/main/mdoc/docs/16-Extensions-H2.md
+++ b/modules/docs/src/main/mdoc/docs/16-Extensions-H2.md
@@ -4,7 +4,7 @@ In this chapter we discuss the extended support that **doobie** offers for users
 
 @@@ vars
 ```scala
-libraryDependencies += "org.tpolecat" %% "doobie-h2" % "$version$"
+libraryDependencies += "org.typelevel" %% "doobie-h2" % "$version$"
 ```
 @@@
 
@@ -15,7 +15,7 @@ There are extensions available for dealing with JSON by using Circe, if you like
 @@@ vars
 
 ```scala
-libraryDependencies += "org.tpolecat" %% "doobie-h2-circe" % "$version$"
+libraryDependencies += "org.typelevel" %% "doobie-h2-circe" % "$version$"
 ```
 
 @@@

--- a/modules/docs/src/main/mdoc/docs/20-Otel4s-Tracing.md
+++ b/modules/docs/src/main/mdoc/docs/20-Otel4s-Tracing.md
@@ -8,7 +8,7 @@ through [otel4s](https://github.com/typelevel/otel4s).
 @@@ vars
 
 ```scala
-libraryDependencies += "org.tpolecat" %% "doobie-otel4s" % "$version$"
+libraryDependencies += "org.typelevel" %% "doobie-otel4s" % "$version$"
 ```
 
 @@@

--- a/modules/docs/src/main/mdoc/index.md
+++ b/modules/docs/src/main/mdoc/index.md
@@ -7,12 +7,11 @@
 
 # doobie
 
-<img align="right" src="https://cdn.rawgit.com/typelevel/doobie/series/0.5.x/doobie_logo.svg" height="150px" style="padding-left: 20px"/>
+<img align="right" src="https://cdn.rawgit.com/typelevel/doobie/series/0.13.x/doobie_logo.svg" height="150px" style="padding-left: 20px"/>
 
-[![Travis CI](https://travis-ci.org/tpolecat/doobie.svg?branch=series%2F0.5.x)](https://travis-ci.org/tpolecat/doobie)
-[![Join the chat at https://gitter.im/tpolecat/doobie](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/tpolecat/doobie?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Maven Central](https://img.shields.io/maven-central/v/org.tpolecat/doobie-core_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/org.tpolecat/doobie-core_2.12)
-[![Javadocs](https://javadoc.io/badge/org.tpolecat/doobie-core_2.12.svg)](https://javadoc.io/doc/org.tpolecat/doobie-core_2.12)
+[![Discord](https://img.shields.io/discord/632277896739946517.svg?label=&logo=discord&logoColor=ffffff&color=404244&labelColor=6A7EC2)](https://discord.gg/7B4VfFTvsS)
+[![Maven Central](https://img.shields.io/maven-central/v/org.typelevel/doobie-core_2.13.svg)](https://maven-badges.herokuapp.com/maven-central/org.typelevel/doobie-core_2.12)
+[![Javadocs](https://javadoc.io/badge/org.typelevel/doobie-core_2.12.svg)](https://javadoc.io/doc/org.typelevel/doobie-core_2.12)
 
 
 **doobie** is a pure functional JDBC layer for Scala and [**Cats**](http://typelevel.org/cats/). It is not an ORM, nor is it a relational algebra; it simply provides a functional way to construct programs (and higher-level libraries) that use JDBC. For common use cases **doobie** provides a minimal but expressive high-level API:
@@ -62,14 +61,14 @@ To use **doobie** you need to add the following to your `build.sbt`. If you're n
 libraryDependencies ++= Seq(
 
   // Start with this one
-  "org.tpolecat" %% "doobie-core"      % "$version$",
+  "org.typelevel" %% "doobie-core"      % "$version$",
 
   // And add any of these as needed
-  "org.tpolecat" %% "doobie-h2"        % "$version$",          // H2 driver $h2Version$ + type mappings.
-  "org.tpolecat" %% "doobie-hikari"    % "$version$",          // HikariCP transactor.
-  "org.tpolecat" %% "doobie-postgres"  % "$version$",          // Postgres driver $postgresVersion$ + type mappings.
-  "org.tpolecat" %% "doobie-specs2"    % "$version$" % "test", // Specs2 support for typechecking statements.
-  "org.tpolecat" %% "doobie-scalatest" % "$version$" % "test"  // ScalaTest support for typechecking statements.
+  "org.typelevel" %% "doobie-h2"        % "$version$",          // H2 driver $h2Version$ + type mappings.
+  "org.typelevel" %% "doobie-hikari"    % "$version$",          // HikariCP transactor.
+  "org.typelevel" %% "doobie-postgres"  % "$version$",          // Postgres driver $postgresVersion$ + type mappings.
+  "org.typelevel" %% "doobie-specs2"    % "$version$" % "test", // Specs2 support for typechecking statements.
+  "org.typelevel" %% "doobie-scalatest" % "$version$" % "test"  // ScalaTest support for typechecking statements.
 
 )
 ```
@@ -82,11 +81,11 @@ Note that **doobie** is pre-1.0 software and is still undergoing active developm
 ## Documentation and Support
 
 - Behold the sparkly [**documentation**](docs/01-Introduction.html) ← start here
-- The [**Scaladoc**](https://www.javadoc.io/doc/org.tpolecat/doobie-core_$scala.binary.version$) will be handy once you get your feet wet.
+- The [**Scaladoc**](https://www.javadoc.io/doc/org.typelevel/doobie-core_$scala.binary.version$) will be handy once you get your feet wet.
 - See [**releases**](https://github.com/typelevel/doobie/releases) for an overview of changes in this and previous versions.
-- The [**Gitter Channel**](https://gitter.im/tpolecat/doobie) is a great place to chat!
+- The [**Discord Channel**](https://discord.com/channels/632277896739946517/632727524434247691) is a great place to chat!
 - There is a [**Scala Exercises**](https://www.scala-exercises.org/) module, courtesy of our friends at 47 Degrees!
-- There is also the [**source**](https://github.com/tpolecat/doobie). Check out the examples too.
+- There is also the [**source**](https://github.com/typelevel/doobie). Check out the examples too.
 - If you have comments or run into trouble, please file an issue.
 
 ## Presentations, Blog Posts, etc.

--- a/modules/docs/src/main/mdoc/migration.md
+++ b/modules/docs/src/main/mdoc/migration.md
@@ -72,7 +72,7 @@ Please refer to the `examples` project for example usage, or ask questions on th
 
 ## Upgrading to 0.5.x from 0.4.x with Cats
 
-This guide covers the changes that are specific to **doobie**, but you will also need to deal with changes between cats 0.9 and cats 1.0 (the provided Scalafix rules may be helpful) and between fs2 0.9 and fs2 0.10. Please join the [gitter channel](https://gitter.im/tpolecat/doobie) if you run into trouble. We will update this document to reflect common issues as they arise.
+This guide covers the changes that are specific to **doobie**, but you will also need to deal with changes between cats 0.9 and cats 1.0 (the provided Scalafix rules may be helpful) and between fs2 0.9 and fs2 0.10.
 
 ### Artifacts
 


### PR DESCRIPTION
* Update group id in dependency snippets
* Replace Gitter links with the Typelevel Discord channel
* Drop dead Travis badge and update the others
* Enable site preview